### PR TITLE
Bugfix/bc 265 hide fields when no value

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperHelper.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.amend.claim.mappers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.Named;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
@@ -41,7 +40,7 @@ public class ClaimMapperHelper {
     public ClaimField mapFixedFee(ClaimResponse claimResponse) {
         var calculated = claimResponse.getFeeCalculationResponse() != null
                 ? claimResponse.getFeeCalculationResponse().getFixedFeeAmount() : null;
-        return new ClaimField(FIXED_FEE, "NA", calculated, null, null);
+        return new ClaimField(FIXED_FEE, "NA", calculated, null);
     }
 
     @Named("mapNetProfitCost")

--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperHelper.java
@@ -40,7 +40,7 @@ public class ClaimMapperHelper {
     public ClaimField mapFixedFee(ClaimResponse claimResponse) {
         var calculated = claimResponse.getFeeCalculationResponse() != null
                 ? claimResponse.getFeeCalculationResponse().getFixedFeeAmount() : null;
-        return new ClaimField(FIXED_FEE, "NA", calculated, null);
+        return new ClaimField(FIXED_FEE, null, calculated, null);
     }
 
     @Named("mapNetProfitCost")

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
@@ -28,11 +28,8 @@ public class ClaimField implements Serializable {
     }
 
     public ClaimField(String label, Object submitted, Object calculated, Object amended) {
-        this.label = label;
-        this.submitted = submitted;
-        this.calculated = calculated;
+        this(label, submitted, calculated);
         this.amended = amended;
-        this.cost = null;
     }
 
     public ClaimField(String label, Object submitted, Object calculated, Cost cost) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
@@ -106,9 +106,12 @@ public class ThymeleafUtils {
 
     /**
      * Determines whether a claim field should be displayed, it used only in summary page.
-     * A field is displayed if:
-     *  - It has a non-empty submitted value, OR
-     *  - Its label is not in the list of hidden fields.
+     * A field displayed:
+     * - if field has a non empty submitted value.
+     *
+     * A field is not displayed if:
+     *  - It has a empty submitted value, and
+     *  - Its label is in the list of hidden fields.
      *
      * @param claimField the claim field to check
      * @return true if the field should be displayed, false otherwise

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
@@ -3,27 +3,32 @@ package uk.gov.justice.laa.amend.claim.utils;
 import lombok.AllArgsConstructor;
 import org.springframework.context.MessageSource;
 import org.springframework.context.i18n.LocaleContextHolder;
-import org.thymeleaf.expression.Messages;
 import org.thymeleaf.spring6.util.DetailedError;
 import uk.gov.justice.laa.amend.claim.forms.errors.AssessmentOutcomeFormError;
 import uk.gov.justice.laa.amend.claim.forms.errors.MonetaryValueFormError;
 import uk.gov.justice.laa.amend.claim.forms.errors.SearchFormError;
+import uk.gov.justice.laa.amend.claim.models.ClaimField;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.DEFAULT_DATE_FORMAT;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.ADJOURNED_FEE;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_ORAL;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_TELEPHONE;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.HO_INTERVIEW;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.JR_FORM_FILLING;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.SUBSTANTIVE_HEARING;
 
 @AllArgsConstructor
 public class ThymeleafUtils {
 
     private final MessageSource messageSource;
+
+    private static final List<String> hiddenFields = List.of(CMRH_TELEPHONE, CMRH_ORAL, JR_FORM_FILLING, ADJOURNED_FEE, HO_INTERVIEW, SUBSTANTIVE_HEARING);
 
     public List<SearchFormError> toSearchFormErrors(List<DetailedError> errors) {
         return errors
@@ -87,5 +92,18 @@ public class ThymeleafUtils {
     private String getMessage(String key, Object... args) {
         Locale locale = LocaleContextHolder.getLocale();
         return messageSource.getMessage(key, args, locale);
+    }
+
+    private boolean isEmptyValue(Object value) {
+        return switch (value) {
+            case null -> true;
+            case BigDecimal bigDecimal -> BigDecimal.ZERO.compareTo(bigDecimal) == 0;
+            case Integer i -> i == 0;
+            default -> false;
+        };
+    }
+
+    public boolean displayClaimField(ClaimField claimField) {
+        return !isEmptyValue(claimField.getSubmitted()) || !hiddenFields.contains(claimField.getLabel());
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
@@ -103,7 +103,20 @@ public class ThymeleafUtils {
         };
     }
 
+
+    /**
+     * Determines whether a claim field should be displayed, it used only in summary page.
+     * A field is displayed if:
+     *  - It has a non-empty submitted value, OR
+     *  - Its label is not in the list of hidden fields.
+     *
+     * @param claimField the claim field to check
+     * @return true if the field should be displayed, false otherwise
+     */
     public boolean displayClaimField(ClaimField claimField) {
-        return !isEmptyValue(claimField.getSubmitted()) || !hiddenFields.contains(claimField.getLabel());
+        if (!isEmptyValue(claimField.getSubmitted())) {
+            return true;
+        }
+        return !hiddenFields.contains(claimField.getLabel());
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -8,7 +8,7 @@ service.cancel=Cancel
 service.yes=Yes
 service.no=No
 service.navigation.search=Search
-service.noData=No data
+service.noData=NA
 
 pagination.page=page
 pagination.page.previous=Previous
@@ -108,7 +108,7 @@ claimSummary.rows.adjournedHearingFee=Adjourned hearing fee
 claimSummary.rows.cmrhTelephone=CMRH telephone
 claimSummary.rows.cmrhOral=CMRH oral
 claimSummary.rows.homeOffice=Home office interview
-claimSummary.rows.substantiveHearing= Substantive hearing
+claimSummary.rows.substantiveHearing=Substantive hearing
 claimSummary.rows.vat=VAT
 claimSummary.rows.total=Total
 claimSummary.rows.waiting=Waiting costs

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -8,7 +8,7 @@ service.cancel=Cancel
 service.yes=Yes
 service.no=No
 service.navigation.search=Search
-service.noData=NA
+service.noData=Not applicable
 
 pagination.page=page
 pagination.page.previous=Previous

--- a/src/main/resources/templates/claim-summary.html
+++ b/src/main/resources/templates/claim-summary.html
@@ -40,7 +40,7 @@
                                         <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.calculated}"></dd>
                                         <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.submitted}"></dd>
                                     </div>
-                                    <div class="govuk-summary-list__row" th:each="row : ${claim.tableRows}">
+                                    <div class="govuk-summary-list__row" th:each="row : ${claim.tableRows}" th:if="${@ThymeleafUtils.displayClaimField(row)}">
                                         <dt class="govuk-summary-list__key govuk-!-font-weight-bold" th:text="#{${row.label}}"></dt>
                                         <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated)}"></dd>
                                         <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted)}"></dd>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperTest.java
@@ -66,7 +66,7 @@ class ClaimMapperTest {
 
         ClaimField claimField = claim.getFixedFee();
         assertEquals(AmendClaimConstants.Label.FIXED_FEE, claimField.getLabel());
-        assertEquals("NA", claimField.getSubmitted());
+        assertEquals(null, claimField.getSubmitted());
         assertEquals(BigDecimal.valueOf(120), claimField.getCalculated());
         assertNull(claimField.getAmended());
         assertNull(claimField.getCost());

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/AssessmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/AssessmentServiceTest.java
@@ -38,7 +38,7 @@ class AssessmentServiceTest {
     void testApplyNilledOutcome_SetsAllMonetaryFieldsToZero() {
         // Given: A claim with non-zero values
         CivilClaimDetails claim = createTestCivilClaim();
-        claim.setFixedFee(new ClaimField("Fixed Fee", "NA", new BigDecimal("100.00"), new BigDecimal("100.00")));
+        claim.setFixedFee(new ClaimField("Fixed Fee", null, new BigDecimal("100.00"), new BigDecimal("100.00")));
         claim.setNetProfitCost(new ClaimField("Profit Cost", new BigDecimal("500.00"), new BigDecimal("450.00"), new BigDecimal("450.00")));
         claim.setNetDisbursementAmount(new ClaimField("Disbursement", new BigDecimal("200.00"), new BigDecimal("180.00"), new BigDecimal("180.00")));
         claim.setDisbursementVatAmount(new ClaimField("Disbursement VAT", new BigDecimal("40.00"), new BigDecimal("36.00"), new BigDecimal("36.00")));

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
@@ -230,4 +230,8 @@ public abstract class ViewTestBase {
     Elements elements = doc.getElementsByClass("govuk-panel");
     Assertions.assertFalse(elements.isEmpty());
   }
+
+  protected boolean pageHasLabel(Document doc, String label) {
+    return !doc.select("dl.govuk-summary-list dt.govuk-summary-list__key:containsOwn(" + label + ")").isEmpty();
+  }
 }


### PR DESCRIPTION
## What is this PR?

[Link to story](https://dsdmoj.atlassian.net/browse/BC-265)

Replaced "No data" to "NA"
Conditional display of fields for civil case on summary page

<img width="566" height="858" alt="image" src="https://github.com/user-attachments/assets/19518bcd-c0ae-4842-8a8d-30a451f8ed8a" />



## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

