### PR TITLE
BC-291: Making sign out link bold

### DIFF
--- a/src/main/resources/static/css/styles.css
+++ b/src/main/resources/static/css/styles.css
@@ -38,3 +38,7 @@
 .govuk-summary-highlight-lastrow .govuk-summary-list__row:last-child {
     border-bottom: 1px solid #0B0C0C;
 }
+
+.moj-header__navigation-item-bold {
+    font-weight: bold;
+}

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -48,7 +48,7 @@
                                 <span sec:authentication="principal.attributes['preferred_username']"></span>
                             </li>
 
-                            <li class="moj-header__navigation-item">
+                            <li class="moj-header__navigation-item moj-header__navigation-item-bold">
                                 <a class="moj-header__navigation-link" th:href="@{/logout}" th:text="#{service.signOut}"></a>
                             </li>
                         </ul>


### PR DESCRIPTION
## BC-291

[Link to story](https://dsdmoj.atlassian.net/browse/BC-291)

Making sign out link bold

<img width="3840" height="2378" alt="screencapture-localhost-8080-2025-11-27-11_01_06" src="https://github.com/user-attachments/assets/97a2af78-84ca-4afe-bbcc-8181ac61e8b0" />

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

