### PR TITLE
BC-292: Making month and year labels not bold.

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -21,7 +21,7 @@
                     <div id="search-hint" class="govuk-hint" th:text="#{index.hint}"></div>
 
                     <div class="search-panel">
-                        <div th:replace="partials/text-input :: textInput('providerAccountNumber', 'provider-account-number', 'index.providerAccountNumber', 'govuk-!-width-one-half', 'text', true)"></div>
+                        <div th:replace="partials/text-input :: textInput('providerAccountNumber', 'provider-account-number', 'index.providerAccountNumber', 'govuk-!-width-one-half', 'text', true, 'govuk-label--s')"></div>
 
                         <div class="govuk-form-group" th:classappend="${#fields.hasErrors('submissionDateMonth') || #fields.hasErrors('submissionDateYear') ? 'govuk-form-group--error' : ''}">
                             <fieldset class="govuk-fieldset" role="group" aria-describedby="submission-date-hint">
@@ -38,18 +38,18 @@
                                 </p>
                                 <div class="govuk-date-input">
                                     <div class="govuk-date-input__item">
-                                        <div th:replace="partials/text-input :: textInput('submissionDateMonth', 'submission-date-month', 'index.submissionDate.month', 'govuk-input--width-2', 'numeric', false)"></div>
+                                        <div th:replace="partials/text-input :: textInput('submissionDateMonth', 'submission-date-month', 'index.submissionDate.month', 'govuk-input--width-2', 'numeric', false, 'govuk-date-input__label')"></div>
                                     </div>
                                     <div class="govuk-date-input__item">
-                                        <div th:replace="partials/text-input :: textInput('submissionDateYear', 'submission-date-year', 'index.submissionDate.year', 'govuk-input--width-4', 'numeric', false)"></div>
+                                        <div th:replace="partials/text-input :: textInput('submissionDateYear', 'submission-date-year', 'index.submissionDate.year', 'govuk-input--width-4', 'numeric', false, 'govuk-date-input__label')"></div>
                                     </div>
                                 </div>
                             </fieldset>
                         </div>
 
-                        <div th:replace="partials/text-input :: textInput('uniqueFileNumber', 'unique-file-number', 'index.uniqueFileNumber', 'govuk-!-width-one-half', 'text', true)"></div>
+                        <div th:replace="partials/text-input :: textInput('uniqueFileNumber', 'unique-file-number', 'index.uniqueFileNumber', 'govuk-!-width-one-half', 'text', true, 'govuk-label--s')"></div>
 
-                        <div th:replace="partials/text-input :: textInput('caseReferenceNumber', 'case-reference-number', 'index.caseReferenceNumber', 'govuk-!-width-one-half', 'text', true)"></div>
+                        <div th:replace="partials/text-input :: textInput('caseReferenceNumber', 'case-reference-number', 'index.caseReferenceNumber', 'govuk-!-width-one-half', 'text', true, 'govuk-label--s')"></div>
 
                         <div class="govuk-button-group">
                             <button type="submit" class="govuk-button" data-module="govuk-button" th:text="#{index.search}"></button>

--- a/src/main/resources/templates/partials/text-input.html
+++ b/src/main/resources/templates/partials/text-input.html
@@ -1,6 +1,6 @@
-<th:block th:fragment="textInput(name, id, messageKey, inputWidth, inputMode, showErrorMessage)">
+<th:block th:fragment="textInput(name, id, messageKey, inputWidth, inputMode, showErrorMessage, labelClass)">
     <div class="govuk-form-group" th:classappend="${#fields.hasErrors(name) ? 'govuk-form-group--error' : ''}">
-        <label class="govuk-label govuk-label--s" th:for="${id}" th:text="#{${messageKey}}"></label>
+        <label th:class="'govuk-label ' + ${labelClass}" th:for="${id}" th:text="#{${messageKey}}"></label>
         <th:block th:if="${showErrorMessage}">
             <p th:if="${#fields.hasErrors(name)}" class="govuk-error-message" th:errors="*{__${name}__}">
                 <span class="govuk-visually-hidden" th:text="#{form.error}"></span>


### PR DESCRIPTION
## BC-292

[Link to story](https://dsdmoj.atlassian.net/browse/BC-XXX)

Making month and year labels not bold.

<img width="3840" height="2378" alt="screencapture-localhost-8080-2025-11-27-11_18_00" src="https://github.com/user-attachments/assets/3f5f054d-c3f1-4c11-aa30-f2a4b2c6cdbb" />

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

