### PR TITLE
BC-293: Design changes to assessment outcome page.

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -61,8 +61,8 @@ error.generic.message=Error processing claim
 error.code=Error code: {0}
 back.to.home=Back to home
 
-assessmentOutcome.mainHeading=Assessment Outcome
-assessmentOutcome.title=Assessment Outcome
+assessmentOutcome.mainHeading=Assessment outcome
+assessmentOutcome.title=Assessment outcome
 assessmentOutcome.vatLiabilitySubHeading=Is this claim liable for VAT?
 assessmentOutcome.vatLiabilityHint=Applies to fixed fees, profit costs, and counsel's costs.
 assessmentOutcome.paidInFull=Paid in full

--- a/src/main/resources/templates/assessment-outcome.html
+++ b/src/main/resources/templates/assessment-outcome.html
@@ -5,7 +5,7 @@
         title=#{assessmentOutcome.title},
         mainContent=~{::#main-content},
         pageCategory=${null},
-        showBackLink=${false}
+        showBackLink=${true}
     )}">
     <body>
         <main class="govuk-main-wrapper" id="main-content">
@@ -15,80 +15,80 @@
 
                 <th:block th:replace="~{partials/error-summary :: error-summary(${@ThymeleafUtils.toAssessmentOutcomeErrors(#fields.detailedErrors())})}"></th:block>
 
-                <div class="govuk-form-group">
                 <fieldset class="govuk-fieldset">
                     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
-                        <h1 class="govuk-heading-xl">
+                        <h1 class="govuk-fieldset__heading">
                             <span th:text="#{assessmentOutcome.mainHeading}"></span>
                         </h1>
                     </legend>
 
-                <div class="govuk-radios" data-module="govuk-radios"
-                     th:classappend="${#fields.hasErrors('assessmentOutcome')} ? 'govuk-form-group--error'">
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset">
+                            <div class="govuk-radios" data-module="govuk-radios"
+                                 th:classappend="${#fields.hasErrors('assessmentOutcome')} ? 'govuk-form-group--error'">
 
-                    <p class="govuk-error-message"
-                       th:if="${#fields.hasErrors('assessmentOutcome')}"
-                       th:errors="*{assessmentOutcome}"></p>
+                                <p class="govuk-error-message"
+                                   th:if="${#fields.hasErrors('assessmentOutcome')}"
+                                   th:errors="*{assessmentOutcome}"></p>
 
-                    <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="assessment-outcome" name="assessmentOutcome" type="radio" value="reduced-to-fixed-fee-assessed"
-                               th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'reduced-to-fixed-fee-assessed'}">
-                        <label class="govuk-label govuk-radios__label" for="assessment-outcome" th:text="#{assessmentOutcome.reducedAssessed}">
-                        </label>
-                    </div>
-                    <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="assessment-outcome-2" name="assessmentOutcome" type="radio" value="reduced-still-escaped"
-                               th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'reduced-still-escaped'}">
-                        <label class="govuk-label govuk-radios__label" for="assessment-outcome-2" th:text="#{assessmentOutcome.reducedStillEscaped}">
-                        </label>
-                    </div>
-                    <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="assessment-outcome-3" name="assessmentOutcome" type="radio" value="nilled"
-                               th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'nilled'}">
-                        <label class="govuk-label govuk-radios__label" for="assessment-outcome-3" th:text="#{assessmentOutcome.nilled}">
-                        </label>
-                    </div>
-                    <div class="govuk-radios__item">
-                        <input class="govuk-radios__input" id="assessment-outcome-4" name="assessmentOutcome" type="radio" value="paid-in-full"
-                               th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'paid-in-full'}">
-                        <label class="govuk-label govuk-radios__label" for="assessment-outcome-4" th:text="#{assessmentOutcome.paidInFull}">
-                        </label>
-                    </div>
-                </div>
-                </fieldset>
-                </div>
-
-                <div class="govuk-form-group">
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-                            <h2 class="govuk-label govuk-label--m">
-                                <span th:text="#{assessmentOutcome.vatLiabilitySubHeading}"></span>
-                            </h2>
-                        </legend>
-                        <div id="liabilityForVat-hint" class="govuk-hint" th:text="#{assessmentOutcome.vatLiabilityHint}"></div>
-                        <div th:classappend="${#fields.hasErrors('liabilityForVat')} ? 'govuk-form-group--error'">
-                        <p class="govuk-error-message"
-                           th:if="${#fields.hasErrors('liabilityForVat')}"
-                           th:errors="*{liabilityForVat}"></p>
-
-                        <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios"
-                             >
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="liability-for-vat" name="liabilityForVat" type="radio" value="yes"
-                                       th:checked="${assessmentOutcomeForm.liabilityForVat != null && assessmentOutcomeForm.liabilityForVat}">
-                                <label class="govuk-label govuk-radios__label" for="liability-for-vat" th:text="#{service.yes}">
-                                </label>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="assessment-outcome" name="assessmentOutcome" type="radio" value="reduced-to-fixed-fee-assessed"
+                                           th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'reduced-to-fixed-fee-assessed'}">
+                                    <label class="govuk-label govuk-radios__label" for="assessment-outcome" th:text="#{assessmentOutcome.reducedAssessed}">
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="assessment-outcome-2" name="assessmentOutcome" type="radio" value="reduced-still-escaped"
+                                           th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'reduced-still-escaped'}">
+                                    <label class="govuk-label govuk-radios__label" for="assessment-outcome-2" th:text="#{assessmentOutcome.reducedStillEscaped}">
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="assessment-outcome-3" name="assessmentOutcome" type="radio" value="nilled"
+                                           th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'nilled'}">
+                                    <label class="govuk-label govuk-radios__label" for="assessment-outcome-3" th:text="#{assessmentOutcome.nilled}">
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="assessment-outcome-4" name="assessmentOutcome" type="radio" value="paid-in-full"
+                                           th:checked="${assessmentOutcomeForm.assessmentOutcome != null && assessmentOutcomeForm.assessmentOutcome.formValue == 'paid-in-full'}">
+                                    <label class="govuk-label govuk-radios__label" for="assessment-outcome-4" th:text="#{assessmentOutcome.paidInFull}">
+                                    </label>
+                                </div>
                             </div>
-                            <div class="govuk-radios__item">
-                                <input class="govuk-radios__input" id="liability-for-vat-2" name="liabilityForVat" type="radio" value="no"
-                                       th:checked="${assessmentOutcomeForm.liabilityForVat != null && !assessmentOutcomeForm.liabilityForVat}">
-                                <label class="govuk-label govuk-radios__label" for="liability-for-vat-2" th:text="#{service.no}">
-                                </label>
+                        </fieldset>
+                    </div>
+
+                    <div class="govuk-form-group">
+                        <fieldset class="govuk-fieldset" aria-describedby="liabilityForVat-hint">
+                            <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                                <h2 class="govuk-label govuk-label--m">
+                                    <span th:text="#{assessmentOutcome.vatLiabilitySubHeading}"></span>
+                                </h2>
+                            </legend>
+                            <div id="liabilityForVat-hint" class="govuk-hint" th:text="#{assessmentOutcome.vatLiabilityHint}"></div>
+                            <div th:classappend="${#fields.hasErrors('liabilityForVat')} ? 'govuk-form-group--error'">
+                            <p class="govuk-error-message"
+                               th:if="${#fields.hasErrors('liabilityForVat')}"
+                               th:errors="*{liabilityForVat}"></p>
+
+                            <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios">
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="liability-for-vat" name="liabilityForVat" type="radio" value="yes"
+                                           th:checked="${assessmentOutcomeForm.liabilityForVat != null && assessmentOutcomeForm.liabilityForVat}">
+                                    <label class="govuk-label govuk-radios__label" for="liability-for-vat" th:text="#{service.yes}">
+                                    </label>
+                                </div>
+                                <div class="govuk-radios__item">
+                                    <input class="govuk-radios__input" id="liability-for-vat-2" name="liabilityForVat" type="radio" value="no"
+                                           th:checked="${assessmentOutcomeForm.liabilityForVat != null && !assessmentOutcomeForm.liabilityForVat}">
+                                    <label class="govuk-label govuk-radios__label" for="liability-for-vat-2" th:text="#{service.no}">
+                                    </label>
+                                </div>
                             </div>
-                        </div>
-                        </div>
-                    </fieldset>
-                </div>
+                            </div>
+                        </fieldset>
+                    </div>
 
                     <div class="govuk-button-group">
                         <button class="govuk-button" type="submit" th:text="#{assessmentOutcome.continue}"></button>
@@ -97,6 +97,7 @@
                            data-module="govuk-button"
                            th:text="#{assessmentOutcome.cancel}"></a>
                     </div>
+                </fieldset>
             </form>
         </main>
     </body>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/AssessmentOutcomeViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/AssessmentOutcomeViewTest.java
@@ -29,15 +29,15 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
     void testPage() throws Exception {
         Document doc = renderDocument();
 
-        assertPageHasTitle(doc, "Assessment Outcome");
+        assertPageHasTitle(doc, "Assessment outcome");
 
-        assertPageHasHeading(doc, "Assessment Outcome");
+        assertPageHasHeading(doc, "Assessment outcome");
         assertPageHasPrimaryButton(doc, "Continue");
         assertPageHasSecondaryButton(doc, "Cancel");
         assertPageHasNoActiveServiceNavigationItems(doc);
         assertPageHasRadioButtons(doc);
         assertPageHasInlineRadioButtons(doc);
-
+        assertPageHasBackLink(doc);
     }
 
     @Test
@@ -48,9 +48,9 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
 
         Document doc = renderDocumentWithErrors(params);
 
-        assertPageHasTitle(doc, "Assessment Outcome");
+        assertPageHasTitle(doc, "Assessment outcome");
 
-        assertPageHasHeading(doc, "Assessment Outcome");
+        assertPageHasHeading(doc, "Assessment outcome");
         assertPageHasPrimaryButton(doc, "Continue");
         assertPageHasSecondaryButton(doc, "Cancel");
         assertPageHasNoActiveServiceNavigationItems(doc);


### PR DESCRIPTION
## BC-293

[Link to story](https://dsdmoj.atlassian.net/browse/BC-293)

Design changes to assessment outcome page.

1. Remove capital O on H1
2. The padding between the H1 and the radio looks too big
3. This page is missing a back link

<img width="3840" height="2296" alt="screencapture-localhost-8080-submissions-019a9cfa-c361-7d81-99b2-540884bae6eb-claims-019a9cfa-ce3d-7ee9-bb77-ec86c966ae44-assessment-outcome-2025-11-27-11_38_11" src="https://github.com/user-attachments/assets/41ff7019-0f6f-4e9d-b08a-19d20441e59e" />

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

