### PR TITLE
BC-296 - Disabling assessment outcome for non-escaped cases

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/WebConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/WebConfig.java
@@ -1,0 +1,19 @@
+package uk.gov.justice.laa.amend.claim.config;
+
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import uk.gov.justice.laa.amend.claim.interceptors.ClaimInterceptor;
+
+@Configuration
+@AllArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new ClaimInterceptor())
+            .addPathPatterns("/submissions/*/claims/*/*")
+            .excludePathPatterns("/submissions/*/claims/*/assessments/*");
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeController.java
@@ -31,19 +31,14 @@ public class AssessmentOutcomeController {
         @PathVariable(value = "submissionId") String submissionId,
         @PathVariable(value = "claimId") String claimId
     ) {
-        AssessmentOutcomeForm form = new AssessmentOutcomeForm();
-
-        // Load values from Claim if it exists
         ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
 
-        if (claim != null) {
-            // Load assessment outcome
-            form.setAssessmentOutcome(claim.getAssessmentOutcome());
+        AssessmentOutcomeForm form = new AssessmentOutcomeForm();
+        form.setAssessmentOutcome(claim.getAssessmentOutcome());
 
-            // Load VAT liability from vatClaimed
-            if (claim.getVatClaimed() != null && claim.getVatClaimed().getAmended() != null) {
-                form.setLiabilityForVat((Boolean) claim.getVatClaimed().getAmended());
-            }
+        // Load VAT liability from vatClaimed
+        if (claim.getVatClaimed() != null && claim.getVatClaimed().getAmended() != null) {
+            form.setLiabilityForVat((Boolean) claim.getVatClaimed().getAmended());
         }
 
         return renderView(model, form, submissionId, claimId);
@@ -66,23 +61,21 @@ public class AssessmentOutcomeController {
 
         ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
 
-        if (claim != null) {
-            OutcomeType newOutcome = form.getAssessmentOutcome();
+        OutcomeType newOutcome = form.getAssessmentOutcome();
 
-            // Apply business logic based on outcome change
-            assessmentService.applyAssessmentOutcome(claim, newOutcome);
+        // Apply business logic based on outcome change
+        assessmentService.applyAssessmentOutcome(claim, newOutcome);
 
-            // Set the assessment outcome
-            claim.setAssessmentOutcome(newOutcome);
+        // Set the assessment outcome
+        claim.setAssessmentOutcome(newOutcome);
 
-            // Update VAT liability in vatClaimed
-            if (claim.getVatClaimed() != null) {
-                claim.getVatClaimed().setAmended(form.getLiabilityForVat());
-            }
-
-            // Save updated Claim back to session
-            session.setAttribute(claimId, claim);
+        // Update VAT liability in vatClaimed
+        if (claim.getVatClaimed() != null) {
+            claim.getVatClaimed().setAmended(form.getLiabilityForVat());
         }
+
+        // Save updated Claim back to session
+        session.setAttribute(claimId, claim);
 
         return String.format("redirect:/submissions/%s/claims/%s/review", submissionId, claimId);
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeController.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -26,12 +27,12 @@ public class AssessmentOutcomeController {
 
     @GetMapping("/assessment-outcome")
     public String setAssessmentOutcome(
-        HttpSession session,
+        HttpServletRequest request,
         Model model,
         @PathVariable(value = "submissionId") String submissionId,
         @PathVariable(value = "claimId") String claimId
     ) {
-        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+        ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
 
         AssessmentOutcomeForm form = new AssessmentOutcomeForm();
         form.setAssessmentOutcome(claim.getAssessmentOutcome());
@@ -52,6 +53,7 @@ public class AssessmentOutcomeController {
         BindingResult bindingResult,
         HttpSession session,
         Model model,
+        HttpServletRequest request,
         HttpServletResponse response
     ) {
         if (bindingResult.hasErrors()) {
@@ -59,7 +61,7 @@ public class AssessmentOutcomeController {
             return renderView(model, form, submissionId, claimId);
         }
 
-        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+        ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
 
         OutcomeType newOutcome = form.getAssessmentOutcome();
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsController.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -27,12 +28,14 @@ import static uk.gov.justice.laa.amend.claim.utils.CurrencyUtils.setScale;
 public class ChangeAllowedTotalsController {
 
     @GetMapping()
-    public String loadPage(@PathVariable String claimId,
-                           @PathVariable String submissionId,
-                           Model model,
-                           HttpSession session) {
+    public String loadPage(
+        @PathVariable String claimId,
+        @PathVariable String submissionId,
+        Model model,
+        HttpServletRequest request
+    ) {
 
-        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+        ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
         AllowedTotalForm allowedTotalForm = new AllowedTotalForm();
 
         ClaimField allowedTotalVatField = claim.getAllowedTotalVat();
@@ -60,6 +63,7 @@ public class ChangeAllowedTotalsController {
         BindingResult bindingResult,
         HttpSession session,
         Model model,
+        HttpServletRequest request,
         HttpServletResponse response
     ) {
         if (bindingResult.hasErrors()) {
@@ -67,7 +71,7 @@ public class ChangeAllowedTotalsController {
             return renderView(model, allowedTotalForm, submissionId, claimId);
         }
 
-        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+        ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
 
         ClaimField allowedTotalVatField = claim.getAllowedTotalVat();
         ClaimField allowedTotalInclVatField = claim.getAllowedTotalInclVat();

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsController.java
@@ -21,7 +21,6 @@ import java.math.BigDecimal;
 
 import static uk.gov.justice.laa.amend.claim.utils.CurrencyUtils.setScale;
 
-
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/submissions/{submissionId}/claims/{claimId}/allowed-totals")
@@ -34,23 +33,20 @@ public class ChangeAllowedTotalsController {
                            HttpSession session) {
 
         ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
-        model.addAttribute("redirectUrl", getRedirectUrl(submissionId, claimId));
         AllowedTotalForm allowedTotalForm = new AllowedTotalForm();
 
-        if (claim != null) {
-            ClaimField allowedTotalVatField = claim.getAllowedTotalVat();
-            ClaimField allowedTotalInclVatField = claim.getAllowedTotalInclVat();
+        ClaimField allowedTotalVatField = claim.getAllowedTotalVat();
+        ClaimField allowedTotalInclVatField = claim.getAllowedTotalInclVat();
 
-            BigDecimal allowedTotalVat = allowedTotalVatField != null ? (BigDecimal) allowedTotalVatField.getAmended() : null;
-            BigDecimal allowedTotalInclVat = allowedTotalInclVatField != null ? (BigDecimal) allowedTotalInclVatField.getAmended() : null;
+        BigDecimal allowedTotalVat = allowedTotalVatField != null ? (BigDecimal) allowedTotalVatField.getAmended() : null;
+        BigDecimal allowedTotalInclVat = allowedTotalInclVatField != null ? (BigDecimal) allowedTotalInclVatField.getAmended() : null;
 
-            if (allowedTotalVat != null) {
-                allowedTotalForm.setAllowedTotalVat(setScale(allowedTotalVat).toString());
-            }
+        if (allowedTotalVat != null) {
+            allowedTotalForm.setAllowedTotalVat(setScale(allowedTotalVat).toString());
+        }
 
-            if (allowedTotalInclVat != null) {
-                allowedTotalForm.setAllowedTotalInclVat(setScale(allowedTotalInclVat).toString());
-            }
+        if (allowedTotalInclVat != null) {
+            allowedTotalForm.setAllowedTotalInclVat(setScale(allowedTotalInclVat).toString());
         }
 
         return renderView(model, allowedTotalForm, submissionId, claimId);
@@ -58,13 +54,13 @@ public class ChangeAllowedTotalsController {
 
     @PostMapping()
     public String setTotals(
-            @PathVariable(value = "submissionId") String submissionId,
-            @PathVariable(value = "claimId") String claimId,
-            @Valid @ModelAttribute("allowedTotalForm") AllowedTotalForm allowedTotalForm,
-            BindingResult bindingResult,
-            HttpSession session,
-            Model model,
-            HttpServletResponse response
+        @PathVariable(value = "submissionId") String submissionId,
+        @PathVariable(value = "claimId") String claimId,
+        @Valid @ModelAttribute("allowedTotalForm") AllowedTotalForm allowedTotalForm,
+        BindingResult bindingResult,
+        HttpSession session,
+        Model model,
+        HttpServletResponse response
     ) {
         if (bindingResult.hasErrors()) {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
@@ -73,23 +69,20 @@ public class ChangeAllowedTotalsController {
 
         ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
 
+        ClaimField allowedTotalVatField = claim.getAllowedTotalVat();
+        ClaimField allowedTotalInclVatField = claim.getAllowedTotalInclVat();
 
-        if (claim != null) {
-            ClaimField allowedTotalVatField = claim.getAllowedTotalVat();
-            ClaimField allowedTotalInclVatField = claim.getAllowedTotalInclVat();
+        BigDecimal allowedTotalInclVat = setScale(allowedTotalForm.getAllowedTotalInclVat());
+        BigDecimal allowedTotalVat = setScale(allowedTotalForm.getAllowedTotalVat());
 
-            BigDecimal allowedTotalInclVat = setScale(allowedTotalForm.getAllowedTotalInclVat());
-            BigDecimal allowedTotalVat = setScale(allowedTotalForm.getAllowedTotalVat());
+        allowedTotalInclVatField.setAmended(allowedTotalInclVat);
+        allowedTotalVatField.setAmended(allowedTotalVat);
 
-            allowedTotalInclVatField.setAmended(allowedTotalInclVat);
-            allowedTotalVatField.setAmended(allowedTotalVat);
+        allowedTotalVatField.setStatus(AmendStatus.AMENDABLE);
+        allowedTotalInclVatField.setStatus(AmendStatus.AMENDABLE);
 
-            allowedTotalVatField.setStatus(AmendStatus.AMENDABLE);
-            allowedTotalInclVatField.setStatus(AmendStatus.AMENDABLE);
-
-            // Save updated Claim back to session
-            session.setAttribute(claimId, claim);
-        }
+        // Save updated Claim back to session
+        session.setAttribute(claimId, claim);
 
         return String.format("redirect:/submissions/%s/claims/%s/review", submissionId, claimId);
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueController.java
@@ -39,7 +39,6 @@ public class ChangeMonetaryValueController {
         HttpServletResponse response
     ) throws IOException {
         try {
-            // TODO - if retrieval from session returns null, redirect to session expired?
             ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
             ClaimField claimField = cost.getAccessor().get(claim);
             BigDecimal value = claimField != null ? (BigDecimal) claimField.getAmended() : null;
@@ -68,7 +67,6 @@ public class ChangeMonetaryValueController {
         BindingResult bindingResult
     ) throws IOException {
         try {
-            // TODO - if retrieval from session returns null, redirect to session expired?
             ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
 
             if (bindingResult.hasErrors()) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueController.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
@@ -31,15 +32,15 @@ public class ChangeMonetaryValueController {
 
     @GetMapping("{cost}")
     public String getMonetaryValue(
-        HttpSession session,
         Model model,
         @PathVariable(value = "submissionId") String submissionId,
         @PathVariable(value = "claimId") String claimId,
         @PathVariable(value = "cost") Cost cost,
+        HttpServletRequest request,
         HttpServletResponse response
     ) throws IOException {
         try {
-            ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+            ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
             ClaimField claimField = cost.getAccessor().get(claim);
             BigDecimal value = claimField != null ? (BigDecimal) claimField.getAmended() : null;
 
@@ -62,12 +63,13 @@ public class ChangeMonetaryValueController {
         @PathVariable(value = "submissionId") String submissionId,
         @PathVariable(value = "claimId") String claimId,
         @PathVariable(value = "cost") Cost cost,
+        HttpServletRequest request,
         HttpServletResponse response,
         @Valid @ModelAttribute("form") MonetaryValueForm form,
         BindingResult bindingResult
     ) throws IOException {
         try {
-            ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+            ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
 
             if (bindingResult.hasErrors()) {
                 response.setStatus(HttpServletResponse.SC_BAD_REQUEST);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewController.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
@@ -31,11 +32,6 @@ public class ClaimReviewController {
         @PathVariable(value = "claimId") String claimId
     ) {
         ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
-
-        if (claim == null) {
-            return String.format("redirect:/submissions/%s/claims/%s", submissionId, claimId);
-        }
-
         return renderView(model, claim, submissionId, claimId);
     }
 
@@ -53,6 +49,7 @@ public class ClaimReviewController {
 
     @PostMapping("/submissions/{submissionId}/claims/{claimId}/review")
     public String submit(
+        HttpServletRequest request,
         HttpSession session,
         Model model,
         @AuthenticationPrincipal OidcUser oidcUser,

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewController.java
@@ -26,12 +26,12 @@ public class ClaimReviewController {
 
     @GetMapping("/submissions/{submissionId}/claims/{claimId}/review")
     public String onPageLoad(
-        HttpSession session,
+        HttpServletRequest request,
         Model model,
         @PathVariable(value = "submissionId") String submissionId,
         @PathVariable(value = "claimId") String claimId
     ) {
-        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+        ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
         return renderView(model, claim, submissionId, claimId);
     }
 
@@ -57,7 +57,7 @@ public class ClaimReviewController {
         @PathVariable(value = "claimId") String claimId,
         HttpServletResponse response
     ) {
-        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+        ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
         ClaimDetailsView<? extends ClaimDetails> viewModel = claim.toViewModel();
         if (viewModel.getErrors().isEmpty()) {
             String userId = oidcUser.getClaim("oid");

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryController.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
 
@@ -15,7 +16,6 @@ import uk.gov.justice.laa.amend.claim.service.ClaimService;
 public class ClaimSummaryController {
 
     private final ClaimService claimService;
-
 
     @GetMapping("/submissions/{submissionId}/claims/{claimId}")
     public String onPageLoad(
@@ -30,5 +30,13 @@ public class ClaimSummaryController {
         model.addAttribute("submissionId", submissionId);
         model.addAttribute("claim", claimDetails.toViewModel());
         return "claim-summary";
+    }
+
+    @PostMapping("/submissions/{submissionId}/claims/{claimId}")
+    public String onSubmit(
+        @PathVariable(value = "submissionId") String submissionId,
+        @PathVariable(value = "claimId") String claimId
+    ) {
+        return String.format("redirect:/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
@@ -41,6 +41,8 @@ public class ClaimInterceptor implements HandlerInterceptor {
             return error(response, request, "Claim is not an escape case");
         }
 
+        request.setAttribute(claimId, claim);
+
         return true;
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
@@ -1,0 +1,45 @@
+package uk.gov.justice.laa.amend.claim.interceptors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+
+import java.util.Map;
+
+@Component
+public class ClaimInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(
+        HttpServletRequest request,
+        HttpServletResponse response,
+        Object handler
+    ) throws Exception {
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, String.format("%s: session not found", request.getRequestURI()));
+            return false;
+        }
+
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String claimId = pathVariables.get("claimId");
+        if (claimId == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, String.format("%s: claim ID path variable not found", request.getRequestURI()));
+            return false;
+        }
+
+        ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);
+
+        // TODO - see if claim is not escaped
+        if (claim == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND, String.format("%s: claim not found", request.getRequestURI()));
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
@@ -22,15 +22,18 @@ public class ClaimInterceptor implements HandlerInterceptor {
         HttpServletResponse response,
         Object handler
     ) throws Exception {
-        HttpSession session = request.getSession(false);
-        if (session == null) {
-            return error(response, request, "Session not found");
+        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+        String submissionId = pathVariables.get("submissionId");
+        String claimId = pathVariables.get("claimId");
+        if (submissionId == null || claimId == null) {
+            return error(response, request, "Expected path variables not found");
         }
 
-        Map<String, String> pathVariables = (Map<String, String>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-        String claimId = pathVariables.get("claimId");
-        if (claimId == null) {
-            return error(response, request, "Claim ID path variable not found");
+        HttpSession session = request.getSession(false);
+        if (session == null) {
+            String redirectUrl = String.format("/submissions/%s/claims/%s", submissionId, claimId);
+            response.sendRedirect(redirectUrl);
+            return false;
         }
 
         ClaimDetails claim = (ClaimDetails) session.getAttribute(claimId);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptor.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.amend.claim.interceptors;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.HandlerMapping;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.util.Map;
 
 @Component
+@Slf4j
 public class ClaimInterceptor implements HandlerInterceptor {
 
     @Override
@@ -43,7 +45,8 @@ public class ClaimInterceptor implements HandlerInterceptor {
     }
 
     private boolean error(HttpServletResponse response, HttpServletRequest request, String message) throws IOException {
-        response.sendError(HttpServletResponse.SC_NOT_FOUND, String.format("%s: %s", request.getRequestURI(), message));
+        log.warn("{}: {}", request.getRequestURI(), message);
+        response.sendError(HttpServletResponse.SC_NOT_FOUND);
         return false;
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapper.java
@@ -45,7 +45,7 @@ public interface AssessmentMapper {
 
     @InheritConfiguration(name = "mapClaimToAssessment")
     @Mapping(target = "netCostOfCounselAmount", expression = "java(mapNetCostOfCounselAmount(claim))")
-    @Mapping(target = "detentionTravelAndWaitingCostsAmount", expression = "java(mapDetentionTravelAndWaitingCostsAmount(claim))") // TODO
+    @Mapping(target = "detentionTravelAndWaitingCostsAmount", expression = "java(mapDetentionTravelAndWaitingCostsAmount(claim))")
     @Mapping(target = "boltOnAdjournedHearingFee", expression = "java(mapBoltOnAdjournedHearingFee(claim))")
     @Mapping(target = "jrFormFillingAmount", expression = "java(mapJrFormFillingAmount(claim))")
     @Mapping(target = "boltOnCmrhOralFee", expression = "java(mapBoltOnCmrhOralFee(claim))")
@@ -91,7 +91,7 @@ public interface AssessmentMapper {
     CrimeClaimDetails mapToCrimeClaim(AssessmentGet assessmentGet, @MappingTarget CrimeClaimDetails claimDetails);
 
     default ClaimDetails mapAssessmentToClaimDetails(AssessmentGet assessmentGet, @MappingTarget ClaimDetails claimDetails) {
-        if (assessmentGet == null || claimDetails == null || claimDetails.getAreaOfLaw() == null) {
+        if (assessmentGet == null || claimDetails == null) {
             throw new IllegalArgumentException("AssessmentGet and ClaimDetails must be non-null");
         }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapper.java
@@ -43,6 +43,7 @@ public interface ClaimMapper {
     @Mapping(target = "submittedDate", ignore = true)
     // Ignored
     @Mapping(target = "assessmentOutcome", ignore = true)
+    @Mapping(target = "lastAssessment", ignore = true)
     ClaimDetails mapToCommonDetails(ClaimResponse claimResponse, @Context SubmissionResponse submissionResponse);
 
     @Mapping(target = "submissionId", source = "submissionId")

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimDetails.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimDetails.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import uk.gov.justice.laa.amend.claim.forms.AllowedTotalForm;
 import uk.gov.justice.laa.amend.claim.mappers.AssessmentMapper;
 import uk.gov.justice.laa.amend.claim.viewmodels.ClaimDetailsView;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;

--- a/src/main/resources/templates/allowed-totals.html
+++ b/src/main/resources/templates/allowed-totals.html
@@ -17,7 +17,7 @@
                         <div class="govuk-grid-column-two-thirds">
 
 
-                            <form th:action="@{/submissions/{submissionId}/claims/{claimID}/allowed-totals(submissionId=${submissionId}, claimID=${claimId})}"
+                            <form th:action="@{/submissions/{submissionId}/claims/{claimId}/allowed-totals(submissionId=${submissionId}, claimId=${claimId})}"
                                   th:object="${allowedTotalForm}"
                                   method="post">
 

--- a/src/main/resources/templates/assessment-outcome.html
+++ b/src/main/resources/templates/assessment-outcome.html
@@ -9,7 +9,7 @@
     )}">
     <body>
         <main class="govuk-main-wrapper" id="main-content">
-            <form th:action="@{/submissions/{submissionId}/claims/{claimID}/assessment-outcome(submissionId=${submissionId}, claimID=${claimId})}"
+            <form th:action="@{/submissions/{submissionId}/claims/{claimId}/assessment-outcome(submissionId=${submissionId}, claimId=${claimId})}"
                   th:object="${assessmentOutcomeForm}"
                   method="post">
 

--- a/src/main/resources/templates/claim-summary.html
+++ b/src/main/resources/templates/claim-summary.html
@@ -15,49 +15,61 @@
                         <h1 class="govuk-heading-l">
                             <span th:text="#{claimSummary.mainHeading}"></span>
                         </h1>
-                        <div class="govuk-summary-card" th:if="${claim != null}">
-                            <div class="govuk-summary-card__title-wrapper">
-                                <h2 class="govuk-summary-card__title" th:text="#{claimSummary.summary}"></h2>
-                            </div>
-                            <div class="govuk-summary-card__content">
-                                <dl class="govuk-summary-list">
-                                    <div class="govuk-summary-list__row" th:each="entry : ${claim.summaryRows}">
-                                        <dt class="govuk-summary-list__key" th:text="#{${'claimSummary.rows.' + entry.key}}"></dt>
-                                        <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.value)}"></dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </div>
 
-                        <div class="govuk-summary-card" th:if="${claim != null}">
-                            <div class="govuk-summary-card__title-wrapper">
-                                <h2 class="govuk-summary-card__title" th:text="#{claimSummary.values}"></h2>
+                        <th:block th:if="${claim != null}">
+                            <div class="govuk-summary-card">
+                                <div class="govuk-summary-card__title-wrapper">
+                                    <h2 class="govuk-summary-card__title" th:text="#{claimSummary.summary}"></h2>
+                                </div>
+                                <div class="govuk-summary-card__content">
+                                    <dl class="govuk-summary-list">
+                                        <div class="govuk-summary-list__row" th:each="entry : ${claim.summaryRows}">
+                                            <dt class="govuk-summary-list__key" th:text="#{${'claimSummary.rows.' + entry.key}}"></dt>
+                                            <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.value)}"></dd>
+                                        </div>
+                                    </dl>
+                                </div>
                             </div>
-                            <div class="govuk-summary-card__content">
-                                <dl class="govuk-summary-list">
-                                    <div class="govuk-summary-list__row">
-                                        <dt class="govuk-summary-list__key" th:text="#{claimSummary.item}"></dt>
-                                        <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.calculated}"></dd>
-                                        <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.submitted}"></dd>
-                                    </div>
-                                    <div class="govuk-summary-list__row" th:each="row : ${claim.tableRows}" th:if="${@ThymeleafUtils.displayClaimField(row)}">
-                                        <dt class="govuk-summary-list__key govuk-!-font-weight-bold" th:text="#{${row.label}}"></dt>
-                                        <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated)}"></dd>
-                                        <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted)}"></dd>
-                                    </div>
-                                </dl>
-                            </div>
-                        </div>
 
-                        <div class="govuk-button-group">
-                            <a th:href="@{/submissions/{submissionId}/claims/{claimID}/assessment-outcome(submissionId=${submissionId}, claimID=${claimId})}"
-                               th:text="#{claimSummary.assessmentButton}" class="govuk-button">
-                            </a>
-                            <a th:href="@{/}"
-                               role="button" draggable="false" class="govuk-button govuk-button--secondary"
-                               th:text="#{claimSummary.backToSearch}" data-module="govuk-button">
-                            </a>
-                        </div>
+                            <div class="govuk-summary-card">
+                                <div class="govuk-summary-card__title-wrapper">
+                                    <h2 class="govuk-summary-card__title" th:text="#{claimSummary.values}"></h2>
+                                </div>
+                                <div class="govuk-summary-card__content">
+                                    <dl class="govuk-summary-list">
+                                        <div class="govuk-summary-list__row">
+                                            <dt class="govuk-summary-list__key" th:text="#{claimSummary.item}"></dt>
+                                            <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.calculated}"></dd>
+                                            <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.submitted}"></dd>
+                                        </div>
+                                        <div class="govuk-summary-list__row" th:each="row : ${claim.tableRows}" th:if="${@ThymeleafUtils.displayClaimField(row)}">
+                                            <dt class="govuk-summary-list__key govuk-!-font-weight-bold" th:text="#{${row.label}}"></dt>
+                                            <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated)}"></dd>
+                                            <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted)}"></dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </div>
+
+                            <form th:action="@{/submissions/{submissionId}/claims/{claimId}(submissionId=${submissionId}, claimId=${claimId})}" method="post">
+                                <div class="govuk-button-group">
+                                    <th:block th:with="disabled=${!(claim.claim.escaped ?: false)}">
+                                        <button type="submit"
+                                                class="govuk-button"
+                                                data-module="govuk-button"
+                                                th:text="#{claimSummary.assessmentButton}"
+                                                th:disabled="${disabled}"
+                                                th:attr="aria-disabled=${disabled}">
+                                        </button>
+                                    </th:block>
+
+                                    <a th:href="@{/}"
+                                       role="button" draggable="false" class="govuk-button govuk-button--secondary"
+                                       th:text="#{claimSummary.backToSearch}" data-module="govuk-button">
+                                    </a>
+                                </div>
+                            </form>
+                        </th:block>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/confirmation.html
+++ b/src/main/resources/templates/confirmation.html
@@ -29,7 +29,7 @@
                                id="go-to-search">
                             </a>
 
-                            <a th:href="@{/submissions/{submissionId}/claims/{claimID}(submissionId=${submissionId}, claimID=${claimId})}"
+                            <a th:href="@{/submissions/{submissionId}/claims/{claimId}(submissionId=${submissionId}, claimId=${claimId})}"
                                th:text="#{confirmation.view}"
                                role="button"
                                class="govuk-button govuk-button--secondary"

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -10,6 +11,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
+import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 
 import java.util.UUID;
@@ -17,7 +19,10 @@ import java.util.UUID;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
 @ActiveProfiles("local")
 @WebMvcTest(AssessmentOutcomeController.class)
@@ -30,12 +35,20 @@ public class AssessmentOutcomeControllerTest {
     @MockitoBean
     private AssessmentService assessmentService;
 
+    private UUID submissionId;
+    private UUID claimId;
+    private MockHttpSession session;
+
+    @BeforeEach
+    void setup() {
+        submissionId = UUID.randomUUID();
+        claimId = UUID.randomUUID();
+        session = new MockHttpSession();
+        session.setAttribute(claimId.toString(), new CivilClaimDetails());
+    }
+
     @Test
     public void testGetAssessmentOutcome_ReturnsView() throws Exception {
-        String submissionId = UUID.randomUUID().toString();
-        String claimId = UUID.randomUUID().toString();
-
-        MockHttpSession session = new MockHttpSession();
         String path = String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId);
 
         mockMvc.perform(
@@ -48,10 +61,6 @@ public class AssessmentOutcomeControllerTest {
 
     @Test
     public void testOnSubmitReturnsBadRequestWithViewForInvalidForm() throws Exception {
-        String submissionId = UUID.randomUUID().toString();
-        String claimId = UUID.randomUUID().toString();
-
-        MockHttpSession session = new MockHttpSession();
         String path = String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId);
 
         mockMvc.perform(
@@ -66,10 +75,6 @@ public class AssessmentOutcomeControllerTest {
 
     @Test
     public void testOnSubmitRedirects() throws Exception {
-        String submissionId = UUID.randomUUID().toString();
-        String claimId = UUID.randomUUID().toString();
-
-        MockHttpSession session = new MockHttpSession();
         String path = String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId);
 
         String redirectUrl = String.format("/submissions/%s/claims/%s/review", submissionId, claimId);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
-import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 
 import java.util.UUID;
@@ -44,7 +44,7 @@ public class AssessmentOutcomeControllerTest {
         submissionId = UUID.randomUUID();
         claimId = UUID.randomUUID();
         session = new MockHttpSession();
-        session.setAttribute(claimId.toString(), new CivilClaimDetails());
+        session.setAttribute(claimId.toString(), MockClaimsFunctions.createMockCivilClaim());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsControllerTest.java
@@ -8,27 +8,21 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
-import uk.gov.justice.laa.amend.claim.forms.AllowedTotalForm;
 import uk.gov.justice.laa.amend.claim.models.AmendStatus;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
-import uk.gov.justice.laa.amend.claim.models.Claim;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
-import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 
 import java.math.BigDecimal;
-import java.util.UUID;
 
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -62,7 +56,9 @@ class ChangeAllowedTotalsControllerTest {
 
     @Test
     void testGetReturnsView_CivilClaim() throws Exception {
-        session.setAttribute(claimId, new CivilClaimDetails());
+        civilClaim.setAllowedTotalVat(null);
+        civilClaim.setAllowedTotalInclVat(null);
+        session.setAttribute(claimId, civilClaim);
 
         mockMvc.perform(get(buildPath())
                 .session(session))
@@ -74,7 +70,9 @@ class ChangeAllowedTotalsControllerTest {
 
     @Test
     void testGetReturnsView_CrimeClaim() throws Exception {
-        session.setAttribute(claimId, new CrimeClaimDetails());
+        crimeClaim.setAllowedTotalVat(null);
+        crimeClaim.setAllowedTotalInclVat(null);
+        session.setAttribute(claimId, crimeClaim);
 
         mockMvc.perform(get(buildPath())
                 .session(session))
@@ -86,8 +84,8 @@ class ChangeAllowedTotalsControllerTest {
 
     @Test
     void testGetReturnsViewWhenQuestionAlreadyAnswered_CivilClaim() throws Exception {
-        civilClaim.setAllowedTotalInclVat(MockClaimsFunctions.createClaimFieldWithStatus(AmendStatus.AMENDABLE));
-        civilClaim.setAllowedTotalVat(MockClaimsFunctions.createClaimFieldWithStatus(AmendStatus.AMENDABLE));
+        civilClaim.setAllowedTotalInclVat(MockClaimsFunctions.createClaimField(AmendStatus.AMENDABLE));
+        civilClaim.setAllowedTotalVat(MockClaimsFunctions.createClaimField(AmendStatus.AMENDABLE));
 
         session.setAttribute(claimId, civilClaim);
 
@@ -101,8 +99,8 @@ class ChangeAllowedTotalsControllerTest {
 
     @Test
     void testGetReturnsViewWhenQuestionAlreadyAnswered_CrimeClaim() throws Exception {
-        crimeClaim.setAllowedTotalInclVat(MockClaimsFunctions.createClaimFieldWithStatus(AmendStatus.AMENDABLE));
-        crimeClaim.setAllowedTotalVat(MockClaimsFunctions.createClaimFieldWithStatus(AmendStatus.AMENDABLE));
+        crimeClaim.setAllowedTotalInclVat(MockClaimsFunctions.createClaimField(AmendStatus.AMENDABLE));
+        crimeClaim.setAllowedTotalVat(MockClaimsFunctions.createClaimField(AmendStatus.AMENDABLE));
 
         session.setAttribute(claimId, crimeClaim);
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.models.*;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
@@ -158,9 +159,9 @@ class ChangeMonetaryValueControllerTest {
         Class<?> targetClass = cost.getAccessor().type();
         Claim claim;
         if (CivilClaimDetails.class.equals(targetClass)) {
-            claim = new CivilClaimDetails();
+            claim = MockClaimsFunctions.createMockCivilClaim();
         } else {
-            claim = new CrimeClaimDetails();
+            claim = MockClaimsFunctions.createMockCrimeClaim();
         }
         ClaimField claimField = new ClaimField();
         claimField.setKey("");

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueControllerTest.java
@@ -54,7 +54,7 @@ class ChangeMonetaryValueControllerTest {
     @ParameterizedTest
     @MethodSource("validCosts")
     void testGetReturnsView(Cost cost) throws Exception {
-        Claim claim = CreateClaimFor(cost);
+        Claim claim = createClaimFor(cost);
         session.setAttribute(claimId, claim);
 
         mockMvc.perform(get(buildPath(cost.getPath())).session(session))
@@ -67,7 +67,7 @@ class ChangeMonetaryValueControllerTest {
     @ParameterizedTest
     @MethodSource("validCosts")
     void testGetReturnsViewWhenQuestionAlreadyAnswered(Cost cost) throws Exception {
-        Claim claim = CreateClaimFor(cost);
+        Claim claim = createClaimFor(cost);
         ClaimField claimField = cost.getAccessor().get(claim);
         Assertions.assertNotNull(claimField);
         claimField.setAmended(BigDecimal.valueOf(100));
@@ -83,7 +83,7 @@ class ChangeMonetaryValueControllerTest {
     @ParameterizedTest
     @MethodSource("validCosts")
     void testPostSavesValueAndRedirects(Cost cost) throws Exception {
-        Claim claim = CreateClaimFor(cost);
+        Claim claim = createClaimFor(cost);
         ClaimField claimField = cost.getAccessor().get(claim);
         Assertions.assertNotNull(claimField);
         session.setAttribute(claimId, claim);
@@ -105,6 +105,9 @@ class ChangeMonetaryValueControllerTest {
     @ParameterizedTest
     @MethodSource("validCosts")
     void testPostReturnsBadRequestForInvalidValue(Cost cost) throws Exception {
+        Claim claim = createClaimFor(cost);
+        session.setAttribute(claimId, claim);
+
         mockMvc.perform(post(buildPath(cost.getPath()))
                 .session(session)
                 .with(csrf())
@@ -151,7 +154,7 @@ class ChangeMonetaryValueControllerTest {
             .andExpect(status().isNotFound());
     }
 
-    private Claim CreateClaimFor(Cost cost) {
+    private Claim createClaimFor(Cost cost) {
         Class<?> targetClass = cost.getAccessor().type();
         Claim claim;
         if (CivilClaimDetails.class.equals(targetClass)) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewControllerTest.java
@@ -15,11 +15,10 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.models.AmendStatus;
-import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.Claim;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
-import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateAssessment201Response;
 
@@ -56,7 +55,7 @@ public class ClaimReviewControllerTest {
         submissionId = UUID.randomUUID();
         claimId = UUID.randomUUID();
         session = new MockHttpSession();
-        claim = new CivilClaimDetails();
+        claim = MockClaimsFunctions.createMockCivilClaim();
         claim.setSubmissionId(submissionId.toString());
         claim.setClaimId(claimId.toString());
         session.setAttribute(claimId.toString(), claim);
@@ -156,11 +155,11 @@ public class ClaimReviewControllerTest {
         String claimId1 = UUID.randomUUID().toString();
         String claimId2 = UUID.randomUUID().toString();
 
-        Claim claim1 = new CivilClaimDetails();
+        Claim claim1 = MockClaimsFunctions.createMockCivilClaim();
         claim1.setSubmissionId(submissionId.toString());
         claim1.setClaimId(claimId1);
 
-        Claim claim2 = new CrimeClaimDetails();
+        Claim claim2 = MockClaimsFunctions.createMockCrimeClaim();
         claim2.setSubmissionId(submissionId.toString());
         claim2.setClaimId(claimId2);
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
@@ -17,11 +17,11 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.anyInt;
 import static org.mockito.Mockito.anyString;
-import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ClaimInterceptorTest {
@@ -57,7 +57,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("Session not found"));
+        verify(response).sendError(eq(404));
     }
 
     @Test
@@ -71,7 +71,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("Claim ID path variable not found"));
+        verify(response).sendError(eq(404));
     }
 
     @Test
@@ -86,7 +86,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("Claim not found"));
+        verify(response).sendError(eq(404));
     }
 
     @Test
@@ -101,7 +101,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("Claim is not an escape case"));
+        verify(response).sendError(eq(404));
     }
 
     @Test
@@ -116,7 +116,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("Claim is not an escape case"));
+        verify(response).sendError(eq(404));
     }
 
     @Test
@@ -131,7 +131,7 @@ class ClaimInterceptorTest {
 
         assertTrue(interceptor.preHandle(request, response, handler));
 
-        verify(response, never()).sendError(anyInt(), anyString());
+        verifyNoInteractions(response);
     }
 
     @Test
@@ -146,6 +146,6 @@ class ClaimInterceptorTest {
 
         assertTrue(interceptor.preHandle(request, response, handler));
 
-        verify(response, never()).sendError(anyInt(), anyString());
+        verifyNoInteractions(response);
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
@@ -57,7 +57,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("session not found"));
+        verify(response).sendError(eq(404), contains("Session not found"));
     }
 
     @Test
@@ -71,7 +71,7 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("claim ID path variable not found"));
+        verify(response).sendError(eq(404), contains("Claim ID path variable not found"));
     }
 
     @Test
@@ -86,13 +86,44 @@ class ClaimInterceptorTest {
 
         assertFalse(interceptor.preHandle(request, response, handler));
 
-        verify(response).sendError(eq(404), contains("claim not found"));
+        verify(response).sendError(eq(404), contains("Claim not found"));
     }
 
     @Test
-    void preHandle_shouldReturnTrue_whenCivilClaimFound() throws Exception {
+    void preHandle_shouldReturn404_whenEscapedFlagIsNull() throws Exception {
         Map<String, String> vars = Map.of("claimId", claimId.toString());
         ClaimDetails claim = new CivilClaimDetails();
+        claim.setEscaped(null);
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(session.getAttribute(claimId.toString())).thenReturn(claim);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+
+        verify(response).sendError(eq(404), contains("Claim is not an escape case"));
+    }
+
+    @Test
+    void preHandle_shouldReturn404_whenEscapedFlagIsFalse() throws Exception {
+        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        ClaimDetails claim = new CivilClaimDetails();
+        claim.setEscaped(false);
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(session.getAttribute(claimId.toString())).thenReturn(claim);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+
+        verify(response).sendError(eq(404), contains("Claim is not an escape case"));
+    }
+
+    @Test
+    void preHandle_shouldReturnTrue_whenEscapedCivilClaimFound() throws Exception {
+        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        ClaimDetails claim = new CivilClaimDetails();
+        claim.setEscaped(true);
 
         when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
@@ -104,9 +135,10 @@ class ClaimInterceptorTest {
     }
 
     @Test
-    void preHandle_shouldReturnTrue_whenCrimeClaimFound() throws Exception {
+    void preHandle_shouldReturnTrue_whenEscapedCrimeClaimFound() throws Exception {
         Map<String, String> vars = Map.of("claimId", claimId.toString());
         ClaimDetails claim = new CivilClaimDetails();
+        claim.setEscaped(true);
 
         when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
@@ -9,17 +9,13 @@ import org.springframework.web.servlet.HandlerMapping;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.anyInt;
-import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -49,10 +45,13 @@ class ClaimInterceptorTest {
     }
 
     @Test
-    void preHandle_shouldReturn404_whenSessionMissing() throws Exception {
+    void preHandle_shouldReturn404_whenSubmissionIdMissing() throws Exception {
         String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
+        Map<String, String> vars = Map.of(
+            "claimId", claimId.toString()
+        );
 
-        when(request.getSession(false)).thenReturn(null);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
         when(request.getRequestURI()).thenReturn(uri);
 
         assertFalse(interceptor.preHandle(request, response, handler));
@@ -63,9 +62,10 @@ class ClaimInterceptorTest {
     @Test
     void preHandle_shouldReturn404_whenClaimIdMissing() throws Exception {
         String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
-        Map<String, String> vars = new HashMap<>();
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString()
+        );
 
-        when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
         when(request.getRequestURI()).thenReturn(uri);
 
@@ -75,12 +75,32 @@ class ClaimInterceptorTest {
     }
 
     @Test
+    void preHandle_shouldReturn404_whenSessionMissing() throws Exception {
+        String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString(),
+            "claimId", claimId.toString()
+        );
+
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getSession(false)).thenReturn(null);
+        when(request.getRequestURI()).thenReturn(uri);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+
+        verify(response).sendRedirect(eq(String.format("/submissions/%s/claims/%s", submissionId, claimId)));
+    }
+
+    @Test
     void preHandle_shouldReturn404_whenClaimNotFoundInSession() throws Exception {
         String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
-        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString(),
+            "claimId", claimId.toString()
+        );
 
-        when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getSession(false)).thenReturn(session);
         when(request.getRequestURI()).thenReturn(uri);
         when(session.getAttribute(claimId.toString())).thenReturn(null);
 
@@ -91,12 +111,15 @@ class ClaimInterceptorTest {
 
     @Test
     void preHandle_shouldReturn404_whenEscapedFlagIsNull() throws Exception {
-        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString(),
+            "claimId", claimId.toString()
+        );
         ClaimDetails claim = new CivilClaimDetails();
         claim.setEscaped(null);
 
-        when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getSession(false)).thenReturn(session);
         when(session.getAttribute(claimId.toString())).thenReturn(claim);
 
         assertFalse(interceptor.preHandle(request, response, handler));
@@ -106,12 +129,15 @@ class ClaimInterceptorTest {
 
     @Test
     void preHandle_shouldReturn404_whenEscapedFlagIsFalse() throws Exception {
-        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString(),
+            "claimId", claimId.toString()
+        );
         ClaimDetails claim = new CivilClaimDetails();
         claim.setEscaped(false);
 
-        when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getSession(false)).thenReturn(session);
         when(session.getAttribute(claimId.toString())).thenReturn(claim);
 
         assertFalse(interceptor.preHandle(request, response, handler));
@@ -121,12 +147,15 @@ class ClaimInterceptorTest {
 
     @Test
     void preHandle_shouldReturnTrue_whenEscapedCivilClaimFound() throws Exception {
-        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString(),
+            "claimId", claimId.toString()
+        );
         ClaimDetails claim = new CivilClaimDetails();
         claim.setEscaped(true);
 
-        when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getSession(false)).thenReturn(session);
         when(session.getAttribute(claimId.toString())).thenReturn(claim);
 
         assertTrue(interceptor.preHandle(request, response, handler));
@@ -136,12 +165,15 @@ class ClaimInterceptorTest {
 
     @Test
     void preHandle_shouldReturnTrue_whenEscapedCrimeClaimFound() throws Exception {
-        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        Map<String, String> vars = Map.of(
+            "submissionId", submissionId.toString(),
+            "claimId", claimId.toString()
+        );
         ClaimDetails claim = new CivilClaimDetails();
         claim.setEscaped(true);
 
-        when(request.getSession(false)).thenReturn(session);
         when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getSession(false)).thenReturn(session);
         when(session.getAttribute(claimId.toString())).thenReturn(claim);
 
         assertTrue(interceptor.preHandle(request, response, handler));

--- a/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/interceptors/ClaimInterceptorTest.java
@@ -1,0 +1,119 @@
+package uk.gov.justice.laa.amend.claim.interceptors;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.HandlerMapping;
+import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyInt;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ClaimInterceptorTest {
+
+    private ClaimInterceptor interceptor;
+
+    private HttpServletRequest request;
+    private HttpServletResponse response;
+    private HttpSession session;
+
+    private Object handler;
+
+    private UUID submissionId;
+    private UUID claimId;
+
+    @BeforeEach
+    void setup() {
+        interceptor = new ClaimInterceptor();
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        session = mock(HttpSession.class);
+        handler = new Object();
+        submissionId = UUID.randomUUID();
+        claimId = UUID.randomUUID();
+    }
+
+    @Test
+    void preHandle_shouldReturn404_whenSessionMissing() throws Exception {
+        String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
+
+        when(request.getSession(false)).thenReturn(null);
+        when(request.getRequestURI()).thenReturn(uri);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+
+        verify(response).sendError(eq(404), contains("session not found"));
+    }
+
+    @Test
+    void preHandle_shouldReturn404_whenClaimIdMissing() throws Exception {
+        String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
+        Map<String, String> vars = new HashMap<>();
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getRequestURI()).thenReturn(uri);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+
+        verify(response).sendError(eq(404), contains("claim ID path variable not found"));
+    }
+
+    @Test
+    void preHandle_shouldReturn404_whenClaimNotFoundInSession() throws Exception {
+        String uri = String.format("/submission/%s/claims/%s", submissionId, claimId);
+        Map<String, String> vars = Map.of("claimId", claimId.toString());
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(request.getRequestURI()).thenReturn(uri);
+        when(session.getAttribute(claimId.toString())).thenReturn(null);
+
+        assertFalse(interceptor.preHandle(request, response, handler));
+
+        verify(response).sendError(eq(404), contains("claim not found"));
+    }
+
+    @Test
+    void preHandle_shouldReturnTrue_whenCivilClaimFound() throws Exception {
+        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        ClaimDetails claim = new CivilClaimDetails();
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(session.getAttribute(claimId.toString())).thenReturn(claim);
+
+        assertTrue(interceptor.preHandle(request, response, handler));
+
+        verify(response, never()).sendError(anyInt(), anyString());
+    }
+
+    @Test
+    void preHandle_shouldReturnTrue_whenCrimeClaimFound() throws Exception {
+        Map<String, String> vars = Map.of("claimId", claimId.toString());
+        ClaimDetails claim = new CivilClaimDetails();
+
+        when(request.getSession(false)).thenReturn(session);
+        when(request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE)).thenReturn(vars);
+        when(session.getAttribute(claimId.toString())).thenReturn(claim);
+
+        assertTrue(interceptor.preHandle(request, response, handler));
+
+        verify(response, never()).sendError(anyInt(), anyString());
+    }
+}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/resources/MockClaimsFunctions.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/resources/MockClaimsFunctions.java
@@ -12,24 +12,16 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class MockClaimsFunctions {
 
-    public static CivilClaimDetails createBaseMockCivilClaim(){
-        CivilClaimDetails claim = new CivilClaimDetails();
-        claim.setClaimId("test-civil-claim-123");
-        claim.setSubmissionId("test-submission-456");
-
-        return claim;
-    }
-
     public static CivilClaimDetails createMockCivilClaim(){
         CivilClaimDetails claim = new CivilClaimDetails();
         claim.setClaimId("test-civil-claim-123");
         claim.setSubmissionId("test-submission-456");
+        claim.setEscaped(true);
 
         claim.setFixedFee(createClaimField());
         claim.setNetProfitCost(createClaimField());
         claim.setNetDisbursementAmount(createClaimField());
         claim.setDisbursementVatAmount(createClaimField());
-        claim.setVatClaimed(createClaimField());
         claim.setTotalAmount(createClaimField());
         claim.setCounselsCost(createClaimField());
         claim.setDetentionTravelWaitingCosts(createClaimField());
@@ -39,76 +31,60 @@ public class MockClaimsFunctions {
         claim.setCmrhOral(createClaimField());
         claim.setHoInterview(createClaimField());
         claim.setSubstantiveHearing(createClaimField());
-        claim.setVatClaimed(createClaimField());
+        claim.setVatClaimed(createBooleanClaimField());
 
-        claim.setAllowedTotalInclVat(createClaimFieldWithStatus(AmendStatus.NEEDS_AMENDING));
-        claim.setAllowedTotalVat(createClaimFieldWithStatus(AmendStatus.NEEDS_AMENDING));
+        claim.setAllowedTotalInclVat(createClaimField());
+        claim.setAllowedTotalVat(createClaimField());
 
         return claim;
     }
 
-    public static void assertCivilAllowedTotalsAreCorrect(CivilClaimDetails claim){
-        assertEquals(BigDecimal.valueOf(100), claim.getAllowedTotalInclVat().getSubmitted());
-        assertEquals(BigDecimal.valueOf(200), claim.getAllowedTotalInclVat().getCalculated());
-        assertNull(claim.getAllowedTotalInclVat().getAmended());
-        assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
-
-        assertEquals(BigDecimal.valueOf(100), claim.getAllowedTotalVat().getSubmitted());
-        assertEquals(BigDecimal.valueOf(200), claim.getAllowedTotalVat().getCalculated());
-        assertNull(claim.getAllowedTotalVat().getAmended());
-        assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
-    }
-
-    public static void assertCrimeAllowedTotalsAreCorrect(CrimeClaimDetails claim){
-        assertEquals(BigDecimal.valueOf(100), claim.getAllowedTotalInclVat().getSubmitted());
-        assertEquals(BigDecimal.valueOf(200), claim.getAllowedTotalInclVat().getCalculated());
-        assertNull(claim.getAllowedTotalInclVat().getAmended());
-        assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
-
-        assertEquals(BigDecimal.valueOf(100), claim.getAllowedTotalVat().getSubmitted());
-        assertEquals(BigDecimal.valueOf(200), claim.getAllowedTotalVat().getCalculated());
-        assertNull(claim.getAllowedTotalVat().getAmended());
-        assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
-    }
-
-     public static CrimeClaimDetails createMockCrimeClaim() {
+    public static CrimeClaimDetails createMockCrimeClaim() {
         CrimeClaimDetails claim = new CrimeClaimDetails();
         claim.setClaimId("test-crime-claim-123");
         claim.setSubmissionId("test-submission-456");
+        claim.setEscaped(true);
+
         claim.setNetProfitCost(createClaimField());
         claim.setTravelCosts(createClaimField());
         claim.setWaitingCosts(createClaimField());
-        claim.setVatClaimed(createClaimField());
         claim.setFixedFee(createClaimField());
         claim.setNetDisbursementAmount(createClaimField());
         claim.setDisbursementVatAmount(createClaimField());
+        claim.setVatClaimed(createBooleanClaimField());
 
-        claim.setAllowedTotalInclVat(createClaimFieldWithStatus(AmendStatus.NEEDS_AMENDING));
-        claim.setAllowedTotalVat(createClaimFieldWithStatus(AmendStatus.NEEDS_AMENDING));
+        claim.setAllowedTotalInclVat(createClaimField());
+        claim.setAllowedTotalVat(createClaimField());
 
         return claim;
     }
 
-    public static ClaimField createClaimFieldWithStatus(AmendStatus status) {
+    public static ClaimField createClaimField(AmendStatus status) {
         return new ClaimField(
-                "foo",
-                BigDecimal.valueOf(100),
-                BigDecimal.valueOf(200),
-                BigDecimal.valueOf(300),
-                null,
-                status
-
+            "foo",
+            BigDecimal.valueOf(100),
+            BigDecimal.valueOf(200),
+            BigDecimal.valueOf(300),
+            null,
+            status
         );
     }
 
-
-     public static ClaimField createClaimField() {
+    public static ClaimField createClaimField() {
         return new ClaimField(
-                "foo",
-                BigDecimal.valueOf(100),
-                BigDecimal.valueOf(200),
-                BigDecimal.valueOf(300)
+            "foo",
+            BigDecimal.valueOf(100),
+            BigDecimal.valueOf(200),
+            BigDecimal.valueOf(300)
         );
     }
 
+    public static ClaimField createBooleanClaimField() {
+        return new ClaimField(
+            "foo",
+            true,
+            false,
+            true
+        );
+    }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/AssessmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/AssessmentServiceTest.java
@@ -57,7 +57,6 @@ class AssessmentServiceTest {
             assertEquals(BigDecimal.ZERO, claim.getNetProfitCost().getAmended());
             assertEquals(BigDecimal.ZERO, claim.getNetDisbursementAmount().getAmended());
             assertEquals(BigDecimal.ZERO, claim.getDisbursementVatAmount().getAmended());
-            assertEquals(BigDecimal.valueOf(300), claim.getVatClaimed().getAmended()); // VAT unchanged (calculated)
         }
 
         @Test
@@ -313,7 +312,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getTravelCosts().getSubmitted(), claim.getTravelCosts().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getTravelCosts().getStatus());
 
-            MockClaimsFunctions.assertCrimeAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -361,7 +364,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getCounselsCost().getSubmitted(), claim.getCounselsCost().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getCounselsCost().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -382,7 +389,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getNetDisbursementAmount().getCalculated(), claim.getNetDisbursementAmount().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getNetDisbursementAmount().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -403,7 +414,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getNetDisbursementAmount().getCalculated(), claim.getNetDisbursementAmount().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getNetDisbursementAmount().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -419,7 +434,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getNetDisbursementAmount().getCalculated(), claim.getNetDisbursementAmount().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getNetDisbursementAmount().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -434,7 +453,11 @@ class AssessmentServiceTest {
             // Then: Amended value should remain unchanged
             assertEquals(BigDecimal.valueOf(200), claim.getNetDisbursementAmount().getAmended());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
     }
 
@@ -467,7 +490,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getWaitingCosts().getSubmitted(), claim.getWaitingCosts().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getWaitingCosts().getStatus());
 
-            MockClaimsFunctions.assertCrimeAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -515,7 +542,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getCounselsCost().getSubmitted(), claim.getCounselsCost().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getCounselsCost().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -536,7 +567,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getNetDisbursementAmount().getSubmitted(), claim.getNetDisbursementAmount().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getNetDisbursementAmount().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -557,7 +592,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getNetDisbursementAmount().getSubmitted(), claim.getNetDisbursementAmount().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getNetDisbursementAmount().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
 
         @Test
@@ -573,7 +612,11 @@ class AssessmentServiceTest {
             assertEquals(claim.getNetDisbursementAmount().getSubmitted(), claim.getNetDisbursementAmount().getAmended());
             assertEquals(AmendStatus.AMENDABLE, claim.getNetDisbursementAmount().getStatus());
 
-            MockClaimsFunctions.assertCivilAllowedTotalsAreCorrect(claim);
+            assertNull(claim.getAllowedTotalInclVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalInclVat().getStatus());
+
+            assertNull(claim.getAllowedTotalVat().getAmended());
+            assertEquals(AmendStatus.NEEDS_AMENDING, claim.getAllowedTotalVat().getStatus());
         }
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ChangeAllowedTotalViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ChangeAllowedTotalViewTest.java
@@ -9,16 +9,11 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.controllers.ChangeAllowedTotalsController;
-import uk.gov.justice.laa.amend.claim.controllers.ChangeMonetaryValueController;
-import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
-import uk.gov.justice.laa.amend.claim.models.Claim;
 
 @ActiveProfiles("local")
 @WebMvcTest(ChangeAllowedTotalsController.class)
 @Import(LocalSecurityConfig.class)
 class ChangeAllowedTotalViewTest extends ViewTestBase {
-
-    private String claimId = "claimId";
 
     ChangeAllowedTotalViewTest() {
         super("/submissions/submissionId/claims/claimId/allowed-totals");
@@ -26,8 +21,6 @@ class ChangeAllowedTotalViewTest extends ViewTestBase {
 
     @Test
     void testPage() throws Exception {
-        Claim claim = new CivilClaimDetails();
-        session.setAttribute(claimId, claim);
         Document doc = renderDocument();
 
         assertPageHasTitle(doc, "Assess total allowed value");

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ChangeMonetaryValueViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ChangeMonetaryValueViewTest.java
@@ -9,15 +9,11 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.controllers.ChangeMonetaryValueController;
-import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
-import uk.gov.justice.laa.amend.claim.models.Claim;
 
 @ActiveProfiles("local")
 @WebMvcTest(ChangeMonetaryValueController.class)
 @Import(LocalSecurityConfig.class)
 class ChangeMonetaryValueViewTest extends ViewTestBase {
-
-    private String claimId = "claimId";
 
     ChangeMonetaryValueViewTest() {
         super("/submissions/submissionId/claims/claimId/profit-costs");
@@ -25,8 +21,6 @@ class ChangeMonetaryValueViewTest extends ViewTestBase {
 
     @Test
     void testPage() throws Exception {
-        Claim claim = new CivilClaimDetails();
-        session.setAttribute(claimId, claim);
         Document doc = renderDocument();
 
         assertPageHasTitle(doc, "Assess profit costs");

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ClaimSummaryViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ClaimSummaryViewTest.java
@@ -17,6 +17,7 @@ import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
@@ -155,6 +156,17 @@ class ClaimSummaryViewTest extends ViewTestBase {
         assertPageHasValuesRow(doc, "Total", claim.getTotalAmount());
         assertPageHasValuesRow(doc, "Travel costs", claim.getTravelCosts());
         assertPageHasValuesRow(doc, "Waiting costs", claim.getWaitingCosts());
+    }
+
+    @Test
+    void testNonEscapedClaimPage() throws Exception {
+        claim.setEscaped(false);
+
+        when(claimService.getClaimDetails(anyString(), anyString())).thenReturn(claim);
+
+        Document doc = renderDocument();
+
+        assertPageHasPrimaryButtonDisabled(doc, "Add assessment outcome");
     }
 
     private static void createClaimSummary(ClaimDetails claim) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ReviewAndAmendViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ReviewAndAmendViewTest.java
@@ -46,7 +46,8 @@ class ReviewAndAmendViewTest extends ViewTestBase {
     void testPageWithSubmissionError() throws Exception {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
-        WebClientResponseException exception = WebClientResponseException.create(500, "Something went wrong", null, null, null);
+        WebClientResponseException exception = WebClientResponseException
+            .create(500, "Something went wrong", null, null, null);
 
         when(assessmentService.submitAssessment(any(), any()))
             .thenThrow(exception);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ReviewAndAmendViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ReviewAndAmendViewTest.java
@@ -8,14 +8,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.controllers.ClaimReviewController;
 import uk.gov.justice.laa.amend.claim.models.AmendStatus;
-import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
-import uk.gov.justice.laa.amend.claim.models.Claim;
-import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 
@@ -30,16 +26,12 @@ class ReviewAndAmendViewTest extends ViewTestBase {
     @MockitoBean
     private AssessmentService assessmentService;
 
-    private final String claimId = "claimId";
-
     ReviewAndAmendViewTest() {
         super("/submissions/submissionId/claims/claimId/review");
     }
 
     @Test
     void testPage() throws Exception {
-        Claim claim = new CivilClaimDetails();
-        session.setAttribute(claimId, claim);
         Document doc = renderDocument();
 
         assertPageHasTitle(doc, "Review and amend");
@@ -52,9 +44,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
 
     @Test
     void testPageWithSubmissionError() throws Exception {
-        Claim claim = new CivilClaimDetails();
-        session.setAttribute(claimId, claim);
-
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
         WebClientResponseException exception = WebClientResponseException.create(500, "Something went wrong", null, null, null);
@@ -69,19 +58,14 @@ class ReviewAndAmendViewTest extends ViewTestBase {
 
     @Test
     void testPageWithValidationError() throws Exception {
-        ClaimDetails claim = new CivilClaimDetails();
         ClaimField claimField = new ClaimField();
         claimField.setKey("profitCosts");
         claimField.setStatus(AmendStatus.NEEDS_AMENDING);
         claim.setNetProfitCost(claimField);
-        session.setAttribute(claimId, claim);
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
 
         Document doc = renderDocumentWithErrors(params);
-
-        System.out.println("***");
-        System.out.println(doc.html());
 
         assertPageHasTitle(doc, "Review and amend");
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
@@ -5,6 +5,7 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpSession;
@@ -12,6 +13,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.util.MultiValueMap;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
+import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 
 import java.util.Arrays;
@@ -28,9 +31,18 @@ public abstract class ViewTestBase {
   @Autowired
   public MockMvc mockMvc;
 
+  @BeforeEach
+  public void setup() {
+    session = new MockHttpSession();
+    claim = new CivilClaimDetails();
+  }
+
   protected String mapping;
 
-  protected MockHttpSession session = new MockHttpSession();
+  protected MockHttpSession session;
+  protected ClaimDetails claim;
+
+  protected final String claimId = "claimId";
 
   protected ViewTestBase(String mapping) {
     this.mapping = mapping;
@@ -41,6 +53,7 @@ public abstract class ViewTestBase {
   }
 
   protected Document renderDocument(Map<String, Object> variables) throws Exception {
+    session.setAttribute("claimId", claim);
     MockHttpServletRequestBuilder requestBuilder = get(mapping).session(session);
 
     for (Map.Entry<String, Object> entry : variables.entrySet()) {
@@ -57,6 +70,7 @@ public abstract class ViewTestBase {
   }
 
   protected Document renderDocumentWithErrors(MultiValueMap<String, String> params) throws Exception {
+    session.setAttribute("claimId", claim);
     MockHttpServletRequestBuilder requestBuilder = post(mapping).session(session);
 
     String html = mockMvc.perform(requestBuilder.params(params))

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
@@ -103,6 +103,14 @@ public abstract class ViewTestBase {
     Assertions.assertEquals(expectedText, elements.getFirst().text());
   }
 
+  protected void assertPageHasPrimaryButtonDisabled(Document doc, String expectedText) {
+    Elements elements = doc.getElementsByClass("govuk-button");
+    Assertions.assertFalse(elements.isEmpty());
+    Element button = elements.getFirst();
+    Assertions.assertEquals(expectedText, button.text());
+    Assertions.assertTrue(button.hasAttr("disabled"));
+  }
+
   protected void assertPageHasSecondaryButton(Document doc, String expectedText) {
     Elements elements = doc.getElementsByClass("govuk-button--secondary");
     Assertions.assertFalse(elements.isEmpty());

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
@@ -13,9 +13,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.util.MultiValueMap;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
-import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +34,7 @@ public abstract class ViewTestBase {
   @BeforeEach
   public void setup() {
     session = new MockHttpSession();
-    claim = new CivilClaimDetails();
+    claim = MockClaimsFunctions.createMockCivilClaim();
   }
 
   protected String mapping;


### PR DESCRIPTION
## BC-296

[Link to story](https://dsdmoj.atlassian.net/browse/BC-296)

- Using a HandlerInterceptor to:
  - check the session has a claim for the given claim ID
  - check the claim is escaped
- Disabling assessment outcome for non-escaped cases

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

