### PR TITLE
BC-340: Ensuring columns are not sortable when feature flag is disabled.

### DIFF
--- a/src/integrationTest/resources/application.yml
+++ b/src/integrationTest/resources/application.yml
@@ -21,4 +21,5 @@ spring:
 claims-api:
   url: http://localhost:8089
   access-token: ""
-
+search:
+  sort-enabled: true

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/Sort.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/Sort.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 
 import java.util.regex.Matcher;
@@ -11,6 +12,7 @@ import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.DEFAU
 
 @Data
 @AllArgsConstructor
+@Builder
 public class Sort {
     private String field;
     private SortDirection direction;
@@ -20,8 +22,10 @@ public class Sort {
         return direction.getValue() != null ? String.format("%s,%s", field, direction.getValue()) : null;
     }
 
-    public Sort() {
-        applyDefaults();
+    public static Sort defaults() {
+        Sort sort = Sort.builder().build();
+        sort.applyDefaults();
+        return sort;
     }
 
     public Sort(String str) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/Sorts.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/Sorts.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -7,11 +9,19 @@ import java.util.Map;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Sorts {
     private Map<String, SortDirection> value;
+    private boolean enabled;
 
     public Sorts(Sort sort) {
         this.value = Map.of(sort.getField(), sort.getDirection());
+        this.enabled = true;
+    }
+
+    public static Sorts disabled() {
+        return Sorts.builder().enabled(false).build();
     }
 
     public SortDirection getDirection(String field) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/ClaimService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/ClaimService.java
@@ -4,14 +4,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
-import uk.gov.justice.laa.amend.claim.client.config.SearchProperties;
 import uk.gov.justice.laa.amend.claim.exceptions.ClaimNotFoundException;
 import uk.gov.justice.laa.amend.claim.mappers.ClaimMapper;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.Sort;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResultSet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionResponse;
 
+import java.util.Objects;
 import java.util.Optional;
 
 @Service
@@ -20,7 +21,6 @@ import java.util.Optional;
 public class ClaimService {
 
     private final ClaimsApiClient claimsApiClient;
-    private final SearchProperties searchProperties;
     private final ClaimMapper claimMapper;
 
 
@@ -31,7 +31,7 @@ public class ClaimService {
         Optional<String> submissionPeriod,
         int page,
         int size,
-        String sort
+        Sort sort
     ) {
         try {
             return claimsApiClient.searchClaims(
@@ -41,7 +41,7 @@ public class ClaimService {
                 submissionPeriod.orElse(null),
                 page - 1,
                 size,
-                searchProperties.isSortEnabled() ? sort : null
+                Objects.toString(sort, null)
             ).block();
         } catch (Exception e) {
             log.error("Error searching claims", e);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/RedirectUrlUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/RedirectUrlUtils.java
@@ -5,6 +5,8 @@ import uk.gov.justice.laa.amend.claim.forms.SearchForm;
 import uk.gov.justice.laa.amend.claim.models.Sort;
 import uk.gov.justice.laa.amend.claim.models.SortDirection;
 
+import java.util.Objects;
+
 import static org.springframework.util.StringUtils.hasText;
 
 public class RedirectUrlUtils {
@@ -19,7 +21,7 @@ public class RedirectUrlUtils {
         addQueryParam(builder, "caseReferenceNumber", form.getCaseReferenceNumber());
 
         addQueryParam(builder, "page", String.valueOf(page));
-        addQueryParam(builder, "sort", sort.toString());
+        addQueryParam(builder, "sort", Objects.toString(sort, null));
 
         return builder.build().toUriString();
     }
@@ -30,10 +32,6 @@ public class RedirectUrlUtils {
 
     public static String getRedirectUrl(SearchForm form, Sort sort) {
         return getRedirectUrl(form, 1, sort);
-    }
-
-    public static String getRedirectUrl(SearchForm form) {
-        return getRedirectUrl(form, new Sort());
     }
 
     private static void addQueryParam(UriComponentsBuilder builder, String key, String value) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,7 +30,7 @@ claims-api:
   url: ${CLAIMS_API}
   access-token: ${CLAIMS_TOKEN}
 search:
-  sort-enabled: false
+  sort-enabled: true
 
 logging:
   level:

--- a/src/main/resources/templates/partials/sortable-header.html
+++ b/src/main/resources/templates/partials/sortable-header.html
@@ -1,8 +1,13 @@
-<th:block th:fragment="sortableHeader(form,sorts,field,messageKey)" th:with="direction=${sorts.getDirection(field)}">
-    <th scope="col" class="govuk-table__header" th:aria-sort="${direction.aria}">
-        <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-link--sort" th:href="${@RedirectUrlUtils.getRedirectUrl(form, field, direction.toggle())}">
-            <span th:text="#{${messageKey}}"></span>
-            <th:block th:replace="~{partials/sort-arrow :: sortArrow(${direction})}"></th:block>
-        </a>
-    </th>
+<th:block th:fragment="sortableHeader(form,sorts,field,messageKey)">
+    <th:block th:if="${sorts.enabled}" th:with="direction=${sorts.getDirection(field)}">
+        <th scope="col" class="govuk-table__header" th:aria-sort="${direction.aria}">
+            <a class="govuk-link govuk-link--no-visited-state govuk-link--no-underline govuk-link--sort" th:href="${@RedirectUrlUtils.getRedirectUrl(form, field, direction.toggle())}">
+                <span th:text="#{${messageKey}}"></span>
+                <th:block th:replace="~{partials/sort-arrow :: sortArrow(${direction})}"></th:block>
+            </a>
+        </th>
+    </th:block>
+    <th:block th:unless="${sorts.enabled}">
+        <th scope="col" class="govuk-table__header" th:text="#{${messageKey}}"></th>
+    </th:block>
 </th:block>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/HomePageControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/HomePageControllerTest.java
@@ -7,14 +7,21 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.amend.claim.client.config.SearchProperties;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.mappers.ClaimMapper;
 import uk.gov.justice.laa.amend.claim.mappers.ClaimResultMapper;
+import uk.gov.justice.laa.amend.claim.models.SortDirection;
+import uk.gov.justice.laa.amend.claim.models.Sorts;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
 
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -37,15 +44,60 @@ public class HomePageControllerTest {
     @MockitoBean
     private ClaimMapper claimMapper;
 
+    @MockitoBean
+    private SearchProperties searchProperties;
+
     @Test
     public void testOnPageLoadReturnsView() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(true);
+
+        Sorts expectedSorts = Sorts
+            .builder()
+            .value(Map.of("uniqueFileNumber", SortDirection.ASCENDING))
+            .enabled(true)
+            .build();
+
         mockMvc.perform(get("/"))
                 .andExpect(status().isOk())
-                .andExpect(view().name("index"));
+                .andExpect(view().name("index"))
+                .andExpect(model().attribute("sorts", equalTo(expectedSorts)));
+    }
+
+    @Test
+    public void testOnPageLoadReturnsViewWithDefinedSort() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(true);
+
+        Sorts expectedSorts = Sorts
+            .builder()
+            .value(Map.of("caseReferenceNumber", SortDirection.DESCENDING))
+            .enabled(true)
+            .build();
+
+        mockMvc.perform(get("/?sort=caseReferenceNumber,desc"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("index"))
+            .andExpect(model().attribute("sorts", equalTo(expectedSorts)));
+    }
+
+    @Test
+    public void testOnPageLoadReturnsViewWithSortingDisabled() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(false);
+
+        Sorts expectedSorts = Sorts
+            .builder()
+            .enabled(false)
+            .build();
+
+        mockMvc.perform(get("/"))
+            .andExpect(status().isOk())
+            .andExpect(view().name("index"))
+            .andExpect(model().attribute("sorts", equalTo(expectedSorts)));
     }
 
     @Test
     public void testOnPageLoadWithParamsReturnsView() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(true);
+
         mockMvc.perform(get("/")
                 .param("providerAccountNumber", "12345")
                 .param("submissionDateMonth", "3")
@@ -64,6 +116,8 @@ public class HomePageControllerTest {
 
     @Test
     public void testOnSubmitReturnsBadRequestWithViewForInvalidForm() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(true);
+
         mockMvc.perform(post("/")
                 .with(csrf())
                 .param("providerAccountNumber", "")
@@ -75,6 +129,8 @@ public class HomePageControllerTest {
 
     @Test
     public void testOnSubmitReturnsViewForValidFormWithOneField() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(true);
+
         mockMvc.perform(post("/")
                 .with(csrf())
                 .param("providerAccountNumber", "12345")
@@ -85,6 +141,8 @@ public class HomePageControllerTest {
 
     @Test
     public void testOnSubmitReturnsViewForValidFormWithAllFields() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(true);
+
         mockMvc.perform(post("/")
                 .with(csrf())
                 .param("providerAccountNumber", "12345")
@@ -95,5 +153,17 @@ public class HomePageControllerTest {
             )
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl("/?providerAccountNumber=12345&submissionDateMonth=3&submissionDateYear=2007&uniqueFileNumber=456&caseReferenceNumber=789&page=1&sort=uniqueFileNumber,asc"));;
+    }
+
+    @Test
+    public void testOnSubmitReturnsViewForValidFormWithSortingDisabled() throws Exception {
+        when(searchProperties.isSortEnabled()).thenReturn(false);
+
+        mockMvc.perform(post("/")
+                .with(csrf())
+                .param("providerAccountNumber", "12345")
+            )
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl("/?providerAccountNumber=12345&page=1"));
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/SortTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/SortTest.java
@@ -64,25 +64,19 @@ public class SortTest {
     class ToStringTests {
         @Test
         void shouldConvertSortToStringWhenAscendingOrder() {
-            Sort sort = new Sort();
-            sort.setField("uniqueFileNumber");
-            sort.setDirection(SortDirection.ASCENDING);
+            Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
             Assertions.assertEquals("uniqueFileNumber,asc", sort.toString());
         }
 
         @Test
         void shouldConvertSortToStringWhenDescendingOrder() {
-            Sort sort = new Sort();
-            sort.setField("caseReferenceNumber");
-            sort.setDirection(SortDirection.DESCENDING);
+            Sort sort = Sort.builder().field("caseReferenceNumber").direction(SortDirection.DESCENDING).build();
             Assertions.assertEquals("caseReferenceNumber,desc", sort.toString());
         }
 
         @Test
         void shouldConvertSortToStringWhenNoOrder() {
-            Sort sort = new Sort();
-            sort.setField("scheduleReference");
-            sort.setDirection(SortDirection.NONE);
+            Sort sort = Sort.builder().field("scheduleReference").direction(SortDirection.NONE).build();
             Assertions.assertNull(sort.toString());
         }
     }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/SortsTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/SortsTest.java
@@ -20,4 +20,19 @@ public class SortsTest {
         sorts.setValue(Map.of("uniqueFileNumber", SortDirection.ASCENDING));
         Assertions.assertEquals(SortDirection.ASCENDING, sorts.getDirection("uniqueFileNumber"));
     }
+
+    @Test
+    void returnsValueWhenEnabled() {
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
+        Sorts sorts = new Sorts(sort);
+        Assertions.assertEquals(SortDirection.ASCENDING, sorts.getDirection("uniqueFileNumber"));
+        Assertions.assertTrue(sorts.isEnabled());
+    }
+
+    @Test
+    void returnsNullValueWhenDisabled() {
+        Sorts sorts = Sorts.disabled();
+        Assertions.assertNull(sorts.getValue());
+        Assertions.assertFalse(sorts.isEnabled());
+    }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
@@ -45,8 +45,8 @@ class ClaimServiceTest {
 
 
     @Test
-    @DisplayName("Should return valid ClaimResultSet when API client provides valid response")
-    void testSearchClaims_ValidResponse() {
+    @DisplayName("Should return sorted valid ClaimResultSet when API client provides valid response")
+    void testSortedSearchClaims_ValidResponse() {
         // Arrange
         var mockApiResponse = new ClaimResultSet(); // Replace with appropriate type or mock object
 
@@ -62,6 +62,25 @@ class ClaimServiceTest {
         assertEquals(mockApiResponse, result);
 
         verify(claimsApiClient, times(1)).searchClaims("0P322F", null, null, null, 0, 10, "uniqueFileNumber,asc");
+    }
+
+    @Test
+    @DisplayName("Should return valid unsorted ClaimResultSet when API client provides valid response")
+    void testUnsortedSearchClaims_ValidResponse() {
+        // Arrange
+        var mockApiResponse = new ClaimResultSet(); // Replace with appropriate type or mock object
+
+        when(claimsApiClient.searchClaims("0P322F", null, null, null, 0, 10, null))
+            .thenReturn(Mono.just(mockApiResponse));
+
+        // Act
+        ClaimResultSet result = claimService.searchClaims("0p322f", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, null);
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(mockApiResponse, result);
+
+        verify(claimsApiClient, times(1)).searchClaims("0P322F", null, null, null, 0, 10, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
@@ -7,10 +7,11 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
-import uk.gov.justice.laa.amend.claim.client.config.SearchProperties;
 import uk.gov.justice.laa.amend.claim.exceptions.ClaimNotFoundException;
 import uk.gov.justice.laa.amend.claim.mappers.ClaimMapper;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.Sort;
+import uk.gov.justice.laa.amend.claim.models.SortDirection;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResultSet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionResponse;
@@ -35,9 +36,6 @@ class ClaimServiceTest {
     @Mock
     private ClaimMapper claimMapper;
 
-    @Mock
-    private SearchProperties searchProperties;
-
     @InjectMocks
     private ClaimService claimService;
 
@@ -52,12 +50,12 @@ class ClaimServiceTest {
         // Arrange
         var mockApiResponse = new ClaimResultSet(); // Replace with appropriate type or mock object
 
-        when(searchProperties.isSortEnabled()).thenReturn(true);
         when(claimsApiClient.searchClaims("0P322F", null, null, null, 0, 10, "uniqueFileNumber,asc"))
                 .thenReturn(Mono.just(mockApiResponse));
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
 
         // Act
-        ClaimResultSet result = claimService.searchClaims("0p322f", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, "uniqueFileNumber,asc");
+        ClaimResultSet result = claimService.searchClaims("0p322f", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, sort);
 
         // Assert
         assertNotNull(result);
@@ -70,13 +68,13 @@ class ClaimServiceTest {
     @DisplayName("Should throw RuntimeException when API client throws exception")
     void testSearchClaims_ApiClientThrowsException() {
         // Arrange
-        when(searchProperties.isSortEnabled()).thenReturn(true);
         when(claimsApiClient.searchClaims("0P322F", null, null, null, 0, 10, "uniqueFileNumber,asc"))
                 .thenThrow(new RuntimeException("API Error"));
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
 
         // Act & Assert
         RuntimeException exception = assertThrows(RuntimeException.class, () ->
-                claimService.searchClaims("0P322F", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, "uniqueFileNumber,asc")
+                claimService.searchClaims("0P322F", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, sort)
         );
         assertTrue(exception.getMessage().contains("API Error"));
 
@@ -87,12 +85,12 @@ class ClaimServiceTest {
     @DisplayName("Should handle empty API response without exception")
     void testSearchClaims_EmptyResponse() {
         // Arrange
-        when(searchProperties.isSortEnabled()).thenReturn(true);
         when(claimsApiClient.searchClaims("0P322F", null, null, null, 0, 10, "uniqueFileNumber,asc"))
                 .thenReturn(Mono.empty());
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
 
         // Act
-        ClaimResultSet result = claimService.searchClaims("0P322F", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, "uniqueFileNumber,asc");
+        ClaimResultSet result = claimService.searchClaims("0P322F", Optional.empty(), Optional.empty(), Optional.empty(), 1, 10, sort);
 
         // Assert
         assertNull(result);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/utils/RedirectUrlUtilsTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/utils/RedirectUrlUtilsTest.java
@@ -1,18 +1,21 @@
 package uk.gov.justice.laa.amend.claim.utils;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.thymeleaf.spring6.util.DetailedError;
 import uk.gov.justice.laa.amend.claim.forms.SearchForm;
-import uk.gov.justice.laa.amend.claim.forms.errors.SearchFormError;
 import uk.gov.justice.laa.amend.claim.models.Sort;
 import uk.gov.justice.laa.amend.claim.models.SortDirection;
 
-import java.util.List;
-import java.util.stream.Stream;
-
 public class RedirectUrlUtilsTest {
+
+    @Test
+    void createRedirectUrlWhenUnsorted() {
+        SearchForm form = new SearchForm();
+
+        String result = RedirectUrlUtils.getRedirectUrl(form, 1, null);
+
+        Assertions.assertEquals("/?page=1", result);
+    }
 
     @Test
     void createRedirectUrlWhenAccountNumberPresent() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/utils/RedirectUrlUtilsTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/utils/RedirectUrlUtilsTest.java
@@ -19,7 +19,8 @@ public class RedirectUrlUtilsTest {
         SearchForm form = new SearchForm();
         form.setProviderAccountNumber("123");
 
-        String result = RedirectUrlUtils.getRedirectUrl(form, 1, new Sort("uniqueFileNumber", SortDirection.ASCENDING));
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
+        String result = RedirectUrlUtils.getRedirectUrl(form, 1, sort);
 
         Assertions.assertEquals("/?providerAccountNumber=123&page=1&sort=uniqueFileNumber,asc", result);
     }
@@ -32,7 +33,8 @@ public class RedirectUrlUtilsTest {
         form.setSubmissionDateMonth("3");
         form.setSubmissionDateYear("2007");
 
-        String result = RedirectUrlUtils.getRedirectUrl(form, 2, new Sort("uniqueFileNumber", SortDirection.ASCENDING));
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
+        String result = RedirectUrlUtils.getRedirectUrl(form, 2, sort);
 
         Assertions.assertEquals("/?providerAccountNumber=123&submissionDateMonth=3&submissionDateYear=2007&page=2&sort=uniqueFileNumber,asc", result);
     }
@@ -47,7 +49,8 @@ public class RedirectUrlUtilsTest {
         form.setUniqueFileNumber("456");
         form.setCaseReferenceNumber("789");
 
-        String result = RedirectUrlUtils.getRedirectUrl(form, 3, new Sort("uniqueFileNumber", SortDirection.ASCENDING));
+        Sort sort = Sort.builder().field("uniqueFileNumber").direction(SortDirection.ASCENDING).build();
+        String result = RedirectUrlUtils.getRedirectUrl(form, 3, sort);
 
         Assertions.assertEquals("/?providerAccountNumber=123&submissionDateMonth=3&submissionDateYear=2007&uniqueFileNumber=456&caseReferenceNumber=789&page=3&sort=uniqueFileNumber,asc", result);
     }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/IndexViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/IndexViewTest.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import uk.gov.justice.laa.amend.claim.client.config.SearchProperties;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.controllers.HomePageController;
 import uk.gov.justice.laa.amend.claim.mappers.ClaimMapper;
@@ -36,6 +37,9 @@ class IndexViewTest extends ViewTestBase {
 
     @MockitoBean
     private ClaimMapper claimMapper;
+
+    @MockitoBean
+    private SearchProperties searchProperties;
 
     IndexViewTest() {
         super("/");


### PR DESCRIPTION
## BC-340

[Link to story](https://dsdmoj.atlassian.net/browse/BC-340)

Ensuring columns are not sortable when feature flag is disabled.

### Sorting enabled

https://github.com/user-attachments/assets/ee5ea863-207e-49d4-909d-643b495f13a4

### Sorting diasbled

https://github.com/user-attachments/assets/962f542f-140d-423c-b4eb-de445fc8f2ca

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

