### PR TITLE
BC-288 Logout and Session expiry form local session and Force login w…

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/amend/claim/config/ForceLoginFlowIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/amend/claim/config/ForceLoginFlowIntegrationTest.java
@@ -1,0 +1,74 @@
+package uk.gov.justice.laa.amend.claim.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.amend.claim.config.security.ForceLoginAuthorizationResolver;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.justice.laa.amend.claim.config.security.SecurityConstants.AUTHENTICATED;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class ForceLoginFlowIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void authenticatedShouldShowNoPromptParameterOnRedirect() throws Exception {
+
+        var mvcResult = mockMvc.perform(get("/oauth2/authorization/test-client")).andReturn();
+
+        MockHttpSession session = (MockHttpSession) mvcResult.getRequest().getSession(true);
+        session.setAttribute(AUTHENTICATED, true);
+
+        mockMvc.perform(get("/oauth2/authorization/test-client").session(session)).andExpect(status().is3xxRedirection())
+            .andExpect(header().string("Location", org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("prompt="))));
+    }
+
+    @Test
+    void nonAuthenticatedShouldShowPromptParameterOnRedirect() throws Exception {
+        var mvcResult = mockMvc.perform(get("/oauth2/authorization/test-client")).andReturn();
+
+        MockHttpSession session = (MockHttpSession) mvcResult.getRequest().getSession(true);
+        session.setAttribute(AUTHENTICATED, false);
+
+        mockMvc.perform(get("/oauth2/authorization/test-client").session(session)).andExpect(status().is3xxRedirection())
+            .andExpect(header().string("Location", org.hamcrest.Matchers.containsString("prompt=login")));
+    }
+
+    @Configuration
+    static class TestClientConfig {
+        @Bean
+        ClientRegistrationRepository clientRegistrationRepository() {
+            ClientRegistration registration = ClientRegistration
+                .withRegistrationId("test-client")
+                .clientId("test-client")
+                .clientSecret("secret")
+                .authorizationGrantType(org.springframework.security.oauth2.core.AuthorizationGrantType.AUTHORIZATION_CODE)
+                .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+                .scope("openid", "profile", "email")
+                .authorizationUri("https://auth.example.com/oauth2/v2/auth")
+                .tokenUri("https://auth.example.com/oauth2/v2/token")
+                .userInfoUri("https://auth.example.com/userinfo")
+                .userNameAttributeName("sub").clientName("Test Client").build();
+            return new InMemoryClientRegistrationRepository(registration);
+        }
+
+        @Bean
+        ForceLoginAuthorizationResolver forceLoginAuthorizationResolver(ClientRegistrationRepository repo) {
+            return new ForceLoginAuthorizationResolver(repo, "/oauth2/authorization", "login");
+        }
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/security/ForceLoginAuthorizationResolver.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/security/ForceLoginAuthorizationResolver.java
@@ -1,0 +1,86 @@
+package uk.gov.justice.laa.amend.claim.config.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static uk.gov.justice.laa.amend.claim.config.security.SecurityConstants.AUTHENTICATED;
+
+/**
+ * Wraps Spring's DefaultOAuth2AuthorizationRequestResolver and conditionally injects "prompt=login"
+ * (or "select_account") into the authorization request based on the current HttpServletRequest.
+ */
+public class ForceLoginAuthorizationResolver implements OAuth2AuthorizationRequestResolver {
+
+    private final DefaultOAuth2AuthorizationRequestResolver clientRegistrationRepository;
+    private final String authorizationRequestBaseUri;
+
+    private final String promptValue; // "login" or "select_account"
+
+    /**
+     * * @param clients ClientRegistrationRepository bean
+     *
+     * @param authorizationRequestBaseUri usually "/oauth2/authorization"
+     * @param promptValue                 "login" to force credential prompt, or "select_account" to force account
+     *                                    chooser
+     */
+    public ForceLoginAuthorizationResolver(ClientRegistrationRepository clientRegistrationRepository, String authorizationRequestBaseUri, String promptValue) {
+        this.clientRegistrationRepository = new DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, authorizationRequestBaseUri);
+        this.promptValue = promptValue == null ? "login" : promptValue;
+        this.authorizationRequestBaseUri = authorizationRequestBaseUri;
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest base = clientRegistrationRepository.resolve(request);
+        return maybeAddPrompt(request, base);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest base = clientRegistrationRepository.resolve(request, clientRegistrationId);
+        return maybeAddPrompt(request, base);
+    }
+
+    private OAuth2AuthorizationRequest maybeAddPrompt(HttpServletRequest request, OAuth2AuthorizationRequest base) {
+        if (base == null) {
+            return null;
+        }
+
+        if (!request.getRequestURI().startsWith(authorizationRequestBaseUri)) {
+            return base;
+        }
+
+        boolean force = shouldForcePrompt(request);
+
+        Map<String, Object> extra = new LinkedHashMap<>();
+        Map<String, Object> baseParams = base.getAdditionalParameters();
+        if (baseParams != null && !baseParams.isEmpty()) {
+            extra.putAll(baseParams);
+        }
+        if (force) {
+            extra.put("prompt", promptValue);
+            return OAuth2AuthorizationRequest.from(base).additionalParameters(extra).build();
+        }
+        return base;
+    }
+
+    /**
+     * Core policy for forcing prompt
+     */
+    private boolean shouldForcePrompt(HttpServletRequest request) {
+        var session = request.getSession(false);
+
+        if (session == null) {
+            return true;
+        }
+
+        var auth = request.getSession().getAttribute(AUTHENTICATED);
+        return auth == null || !Boolean.parseBoolean(String.valueOf(auth));
+    }
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/security/SecurityConstants.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/security/SecurityConstants.java
@@ -1,0 +1,15 @@
+package uk.gov.justice.laa.amend.claim.config.security;
+
+public class SecurityConstants {
+    public static final String AUTHENTICATED = "authenticated";
+
+    public static final String[] PUBLIC_PATHS = {
+        "/actuator/**",
+        "/logout",
+        "/logout-success",
+        "/css/**",
+        "/assets/**",
+        "/webjars/**",
+        "/favicon.ico"
+    };
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/LogoutController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/LogoutController.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.laa.amend.claim.controllers;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class LogoutController {
+
+
+    @GetMapping("/logout-success")
+    public String logoutSuccess(@RequestParam(required = false) String message, Model model) {
+        if (message != null && message.contains("expired")) {
+            model.addAttribute("timeout", true);
+        }
+        return "logout";
+    }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -284,3 +284,9 @@ discard.title=Confirm you want to discard this assessment
 discard.text=Any changes made will not be saved.
 discard.discard=Discard assessment
 discard.return=Return to claim
+
+signOut.title=You are now signed out of your account
+signOut.message=Sign in to continue using the service.
+sessionExpired.heading=For your security, we signed you out
+signOut.heading=You are now signed out of your account
+sessionExpired.message=This is because you were inactive for 15 minutes.

--- a/src/main/resources/templates/logout.html
+++ b/src/main/resources/templates/logout.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout :: layout(
+        title=#{signOut.title},
+        mainContent=~{::#main-content},
+        pageCategory='logout',
+        showBackLink=${false}
+    )}">
+
+
+<body>
+    <main class="govuk-main-wrapper" id="main-content">
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+                <th:block th:if="${timeout}">
+                    <div class="govuk-heading-l" th:text="#{sessionExpired.heading}">
+
+                    </div>
+                    <div class="govuk-body" th:text="#{sessionExpired.message}">
+                    </div>
+                </th:block>
+                <th:block th:unless="${timeout}">
+                    <div class="govuk-panel govuk-panel--confirmation">
+                        <h1 class="govuk-panel__title" th:text="#{signOut.heading}">
+                        </h1>
+                    </div>
+                    <div class="govuk-!-padding-top-4">
+                        <p class="govuk-body" th:text="#{signOut.message}">
+                        </p>
+                    </div>
+                </th:block>
+
+                <a href="/" class="govuk-button govuk-button--start" data-module="govuk-button">
+                    Sign in
+                    <svg aria-hidden="true" class="govuk-button__start-icon" focusable="false" height="19"
+                         viewBox="0 0 33 40" width="17.5" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M0 0h13l20 20-20 20H0l20-20z" fill="currentColor"></path>
+                    </svg>
+                </a>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/src/main/resources/templates/partials/header.html
+++ b/src/main/resources/templates/partials/header.html
@@ -49,7 +49,10 @@
                             </li>
 
                             <li class="moj-header__navigation-item moj-header__navigation-item-bold">
-                                <a class="moj-header__navigation-link" th:href="@{/logout}" th:text="#{service.signOut}"></a>
+                                <form th:action="@{/logout}" method="post" th:hidden="true" name="logoutForm">
+                                    <input type="submit" value="Logout" />
+                                </form>
+                                <a class="moj-header__navigation-link" href="#" onclick="document.logoutForm.submit()" th:text="#{service.signOut}"></a>
                             </li>
                         </ul>
                     </nav>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/config/SecurityConfigTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/config/SecurityConfigTest.java
@@ -4,8 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import uk.gov.justice.laa.amend.claim.config.security.SecurityConfig;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/uk/gov/justice/laa/amend/claim/config/security/ForceLoginAuthorizationResolverTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/config/security/ForceLoginAuthorizationResolverTest.java
@@ -1,0 +1,176 @@
+package uk.gov.justice.laa.amend.claim.config.security;
+
+import jakarta.servlet.http.HttpSession;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.gov.justice.laa.amend.claim.config.security.SecurityConstants.AUTHENTICATED;
+
+class ForceLoginAuthorizationResolverTest {
+
+    private static final String BASE_URI = "/oauth2/authorization";
+    private static final String REGISTRATION_ID = "test-client";
+    private static final String CLIENT_ID = "test-client";
+
+    private InMemoryClientRegistrationRepository clientRepo;
+    private ForceLoginAuthorizationResolver resolverLoginPrompt;
+    private ForceLoginAuthorizationResolver resolverSelectAccount;
+
+    @BeforeEach
+    void setUp() {
+        ClientRegistration registration = ClientRegistration.withRegistrationId(REGISTRATION_ID)
+            .clientId(CLIENT_ID)
+            .clientSecret("secret")
+            .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+            .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+            .scope("openid", "profile", "email")
+            .authorizationUri("https://auth.example.com/oauth2/v2/auth")
+            .tokenUri("https://auth.example.com/oauth2/v2/token")
+            .userInfoUri("https://auth.example.com/userinfo")
+            .userNameAttributeName("sub")
+            .clientName("Test Client")
+            .build();
+
+        clientRepo = new InMemoryClientRegistrationRepository(registration);
+
+        resolverLoginPrompt = new ForceLoginAuthorizationResolver(clientRepo, BASE_URI, "login");
+        resolverSelectAccount = new ForceLoginAuthorizationResolver(clientRepo, BASE_URI, "select_account");
+    }
+
+    @Test
+    void whenSessionAuthenticatedTrue_thenNoPromptAdded() {
+        MockHttpServletRequest req = authRequestPath();
+        HttpSession session = req.getSession(true);
+        session.setAttribute(AUTHENTICATED, true);
+
+        OAuth2AuthorizationRequest result = resolverLoginPrompt.resolve(req);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).doesNotContainKey("prompt");
+    }
+
+    @Test
+    void whenSessionAuthenticatedFalse_thenPromptAdded_login() {
+        MockHttpServletRequest req = authRequestPath();
+        req.getSession(true).setAttribute(AUTHENTICATED, false);
+
+        OAuth2AuthorizationRequest result = resolverLoginPrompt.resolve(req);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login");
+    }
+
+    @Test
+    void whenSessionAuthenticatedFalse_thenPromptAdded_selectAccount() {
+        MockHttpServletRequest req = authRequestPath();
+        req.getSession(true).setAttribute(AUTHENTICATED, false);
+
+        OAuth2AuthorizationRequest result = resolverSelectAccount.resolve(req);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "select_account");
+    }
+
+    @Test
+    void whenNoSession_thenPromptAdded_login() {
+        MockHttpServletRequest req = authRequestPath();
+        // no session created
+
+        OAuth2AuthorizationRequest result = resolverLoginPrompt.resolve(req);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login");
+    }
+
+    @Test
+    void whenAuthenticatedAttrIsMissing_thenPromptAdded() {
+        MockHttpServletRequest req = authRequestPath();
+        req.getSession(true); // create session but don't set AUTHENTICATED
+
+        OAuth2AuthorizationRequest result = resolverLoginPrompt.resolve(req);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login");
+    }
+
+    @Test
+    void whenAuthenticatedAttrNonBoolean_thenPromptAdded() {
+        MockHttpServletRequest req = authRequestPath();
+        req.getSession(true).setAttribute(AUTHENTICATED, "not-boolean");
+
+        OAuth2AuthorizationRequest result = resolverLoginPrompt.resolve(req);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login");
+    }
+
+    @Test
+    void whenRequestUriDoesNotStartWithBaseUri_thenNoPromptAndPossiblyNull() {
+        MockHttpServletRequest req = nonAuthPath();
+
+        OAuth2AuthorizationRequest result = resolverLoginPrompt.resolve(req);
+
+        // Default resolver returns null for non-matching path
+        assertThat(result).isNull();
+    }
+
+    // ----------------- Tests for resolve(request, registrationId) -----------
+
+    @Test
+    void resolveWithClientRegistrationId_authenticatedTrue_noPrompt() {
+        MockHttpServletRequest req = authRequestPath();
+        req.getSession(true).setAttribute(AUTHENTICATED, true);
+
+        OAuth2AuthorizationRequest result =
+            resolverLoginPrompt.resolve(req, REGISTRATION_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).doesNotContainKey("prompt");
+    }
+
+    @Test
+    void resolveWithClientRegistrationId_authenticatedFalse_promptAdded() {
+        MockHttpServletRequest req = authRequestPath();
+        req.getSession(true).setAttribute(AUTHENTICATED, false);
+
+        OAuth2AuthorizationRequest result =
+            resolverLoginPrompt.resolve(req, REGISTRATION_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login");
+    }
+
+    @Test
+    void resolveWithClientRegistrationId_noSession_promptAdded() {
+        MockHttpServletRequest req = authRequestPath();
+
+        OAuth2AuthorizationRequest result =
+            resolverLoginPrompt.resolve(req, REGISTRATION_ID);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAdditionalParameters()).containsEntry("prompt", "login");
+    }
+
+    private MockHttpServletRequest authRequestPath() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("GET");
+        // Must match DefaultOAuth2AuthorizationRequestResolver’s expected pattern
+        req.setRequestURI(BASE_URI + "/" + REGISTRATION_ID);
+        req.setServletPath(BASE_URI + "/" + REGISTRATION_ID);
+        return req;
+    }
+
+    private MockHttpServletRequest nonAuthPath() {
+        MockHttpServletRequest req = new MockHttpServletRequest();
+        req.setMethod("GET");
+        req.setRequestURI("/not/oauth2/authorization");
+        req.setServletPath("/not/oauth2/authorization");
+        return req;
+    }
+}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/LogoutViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/LogoutViewTest.java
@@ -1,0 +1,28 @@
+package uk.gov.justice.laa.amend.claim.views;
+
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
+import uk.gov.justice.laa.amend.claim.controllers.LogoutController;
+
+@ActiveProfiles("local")
+@WebMvcTest(LogoutController.class)
+@Import(LocalSecurityConfig.class)
+public class LogoutViewTest extends ViewTestBase{
+    protected LogoutViewTest() {
+        super("/logout-success");
+    }
+
+    @Test
+    void testPage() throws Exception {
+        Document doc = renderDocument();
+
+        assertPageHasTitle(doc, "You are now signed out of your account");
+        assertPageHasHeading(doc, "You are now signed out of your account");
+        assertPageHasContent(doc, "Sign in to continue using the service.");
+        assertPageHasPrimaryButton(doc, "Sign in");
+    }
+}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/SessionExpiredViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/SessionExpiredViewTest.java
@@ -1,0 +1,28 @@
+package uk.gov.justice.laa.amend.claim.views;
+
+import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
+import uk.gov.justice.laa.amend.claim.controllers.LogoutController;
+
+@ActiveProfiles("local")
+@WebMvcTest(LogoutController.class)
+@Import(LocalSecurityConfig.class)
+public class SessionExpiredViewTest extends ViewTestBase {
+    protected SessionExpiredViewTest() {
+        super("/logout-success?message=expired");
+    }
+
+    @Test
+    void testPage() throws Exception {
+        Document doc = renderDocument();
+
+        assertPageHasTitle(doc, "You are now signed out of your account");
+        assertPageHasContent(doc, "For your security, we signed you out");
+        assertPageHasContent(doc, "This is because you were inactive for 15 minutes.");
+        assertPageHasPrimaryButton(doc, "Sign in");
+    }
+}


### PR DESCRIPTION
## What is this PR?

PR inclucdes work for BC-288 and BC-287 tickets

- Logout (BC-287) -> When User clicks on Signout link, user will see logout page. Any page accessed after logout will force user to login.

- Session Expiry (BC-288) -> When user session timed out, user will see session expired page. Any page accessed after session expired will force user to login.



[BC-288](https://dsdmoj.atlassian.net/browse/BC-288)
[BC-287](https://dsdmoj.atlassian.net/browse/BC-288)


## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.



[BC-288]: https://dsdmoj.atlassian.net/browse/BC-288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BC-287]: https://dsdmoj.atlassian.net/browse/BC-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ