### PR TITLE
BC-265 : Assessment outcome fixes

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAssessedTotalsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAssessedTotalsController.java
@@ -40,7 +40,7 @@ public class ChangeAssessedTotalsController {
     ) {
         ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
 
-        if (ClaimFieldStatus.MODIFIABLE != claim.getAssessedTotalVat().getStatus() || ClaimFieldStatus.MODIFIABLE != claim.getAssessedTotalInclVat().getStatus()) {
+        if (claim.getAssessedTotalVat().isNotAssessable() || claim.getAssessedTotalInclVat().isNotAssessable()) {
             log.warn("The assessed totals are not modifiable for claim {}. Returning 404.", claimId);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND);
         }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewController.java
@@ -16,7 +16,6 @@ import uk.gov.justice.laa.amend.claim.handlers.ClaimStatusHandler;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 import uk.gov.justice.laa.amend.claim.viewmodels.ClaimDetailsView;
-import uk.gov.justice.laa.amend.claim.viewmodels.PageType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateAssessment201Response;
 
 @Controller
@@ -97,7 +96,6 @@ public class ClaimReviewController {
         model.addAttribute("submissionId", submissionId);
         model.addAttribute("submissionFailed", submissionFailed);
         model.addAttribute("validationFailed", validationFailed);
-        model.addAttribute("pageType", PageType.REVIEW);
 
         return "review-and-amend";
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
 import uk.gov.justice.laa.amend.claim.service.UserRetrievalService;
-import uk.gov.justice.laa.amend.claim.viewmodels.PageType;
 
 
 @Controller
@@ -42,7 +41,6 @@ public class ClaimSummaryController {
         model.addAttribute("claimId", claimId);
         model.addAttribute("submissionId", submissionId);
         model.addAttribute("claim", claimDetails.toViewModel());
-        model.addAttribute("pageType", PageType.CLAIM_DETAILS);
         return "claim-summary";
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/CivilClaimDetails.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/CivilClaimDetails.java
@@ -28,6 +28,8 @@ public class CivilClaimDetails extends ClaimDetails {
         applyIfNotNull(counselsCost, ClaimField::setNilled);
         applyIfNotNull(detentionTravelWaitingCosts, ClaimField::setNilled);
         applyIfNotNull(jrFormFillingCost, ClaimField::setNilled);
+
+        // Bolt-ons get set to 0
         applyIfNotNull(adjournedHearing, ClaimField::setNilled);
         applyIfNotNull(cmrhTelephone, ClaimField::setNilled);
         applyIfNotNull(cmrhOral, ClaimField::setNilled);
@@ -38,42 +40,45 @@ public class CivilClaimDetails extends ClaimDetails {
     @Override
     public void setReducedToFixedFeeValues() {
         super.setReducedToFixedFeeValues();
+        applyIfNotNull(counselsCost, ClaimField::setAssessedToCalculated);
         applyIfNotNull(detentionTravelWaitingCosts, ClaimField::setAssessedToCalculated);
         applyIfNotNull(jrFormFillingCost, ClaimField::setAssessedToCalculated);
+
+        // Bolt-ons get set to calculated
         applyIfNotNull(adjournedHearing, ClaimField::setAssessedToCalculated);
         applyIfNotNull(cmrhTelephone, ClaimField::setAssessedToCalculated);
         applyIfNotNull(cmrhOral, ClaimField::setAssessedToCalculated);
         applyIfNotNull(hoInterview, ClaimField::setAssessedToCalculated);
         applyIfNotNull(substantiveHearing, ClaimField::setAssessedToCalculated);
-        applyIfNotNull(counselsCost, ClaimField::setAssessedToCalculated);
     }
 
     @Override
     public void setReducedValues() {
         super.setReducedValues();
+        applyIfNotNull(counselsCost, ClaimField::setAssessedToSubmitted);
         applyIfNotNull(detentionTravelWaitingCosts, ClaimField::setAssessedToSubmitted);
         applyIfNotNull(jrFormFillingCost, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(counselsCost, ClaimField::setAssessedToSubmitted);
 
-        // Bolt-ons get set to 0
-        applyIfNotNull(adjournedHearing, ClaimField::setNilled);
-        applyIfNotNull(cmrhTelephone, ClaimField::setNilled);
-        applyIfNotNull(cmrhOral, ClaimField::setNilled);
-        applyIfNotNull(hoInterview, ClaimField::setNilled);
-        applyIfNotNull(substantiveHearing, ClaimField::setNilled);
+        // Bolt-ons get set to null
+        applyIfNotNull(adjournedHearing, ClaimField::setAssessedToNull);
+        applyIfNotNull(cmrhTelephone, ClaimField::setAssessedToNull);
+        applyIfNotNull(cmrhOral, ClaimField::setAssessedToNull);
+        applyIfNotNull(hoInterview, ClaimField::setAssessedToNull);
+        applyIfNotNull(substantiveHearing, ClaimField::setAssessedToNull);
     }
 
     public void setPaidInFullValues() {
         super.setPaidInFullValues();
+        applyIfNotNull(counselsCost, ClaimField::setAssessedToSubmitted);
         applyIfNotNull(detentionTravelWaitingCosts, ClaimField::setAssessedToSubmitted);
         applyIfNotNull(jrFormFillingCost, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(counselsCost, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(adjournedHearing, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(cmrhTelephone, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(cmrhOral, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(hoInterview, ClaimField::setAssessedToSubmitted);
-        applyIfNotNull(substantiveHearing, ClaimField::setAssessedToSubmitted);
 
+        // Bolt-ons get set to null
+        applyIfNotNull(adjournedHearing, ClaimField::setAssessedToNull);
+        applyIfNotNull(cmrhTelephone, ClaimField::setAssessedToNull);
+        applyIfNotNull(cmrhOral, ClaimField::setAssessedToNull);
+        applyIfNotNull(hoInterview, ClaimField::setAssessedToNull);
+        applyIfNotNull(substantiveHearing, ClaimField::setAssessedToNull);
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
@@ -9,14 +9,7 @@ import uk.gov.justice.laa.amend.claim.utils.FormUtils;
 import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.util.List;
 
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.ADJOURNED_FEE;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_ORAL;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_TELEPHONE;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.HO_INTERVIEW;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.JR_FORM_FILLING;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.SUBSTANTIVE_HEARING;
 import static uk.gov.justice.laa.amend.claim.utils.NumberUtils.getOrElseZero;
 
 @Data
@@ -107,40 +100,36 @@ public class ClaimField implements Serializable {
     }
 
     public boolean isAssessableAndUnassessed() {
-        return status == ClaimFieldStatus.MODIFIABLE && !isAssessed();
+        return isAssessable() && !isAssessed();
     }
 
     public boolean isAssessableAndAssessed() {
-        return status == ClaimFieldStatus.MODIFIABLE && isAssessed();
+        return isAssessable() && isAssessed();
+    }
+
+    public boolean isAssessable() {
+        return status == ClaimFieldStatus.MODIFIABLE;
     }
 
     public boolean isNotAssessable() {
-        return status == ClaimFieldStatus.NOT_MODIFIABLE;
+        return !isAssessable();
     }
 
-    private static final List<String> HIDDEN_FIELDS = List.of(
-        CMRH_TELEPHONE,
-        CMRH_ORAL,
-        JR_FORM_FILLING, // all of these are bolt ons except this one - should this be here?
-        ADJOURNED_FEE,
-        HO_INTERVIEW,
-        SUBSTANTIVE_HEARING
-    );
-
-    public boolean display() {
-        if (isEmptyValue(this.getSubmitted())) {
-            return !HIDDEN_FIELDS.contains(this.getKey());
-        }
-        return true;
+    public boolean isAssessed() {
+        return assessed != null;
     }
 
-    private boolean isEmptyValue(Object value) {
-        return switch (value) {
+    private boolean hasNoSubmittedValue() {
+        return switch (this.getSubmitted()) {
             case null -> true;
             case BigDecimal bigDecimal -> BigDecimal.ZERO.compareTo(bigDecimal) == 0;
             case Integer i -> i == 0;
             default -> false;
         };
+    }
+
+    public boolean hasSubmittedValue() {
+        return !hasNoSubmittedValue();
     }
 
     public void setSubmittedForDisplay() {
@@ -153,9 +142,5 @@ public class ClaimField implements Serializable {
 
     public void setAssessedForDisplay() {
         setAssessed(getOrElseZero(assessed));
-    }
-
-    public boolean isAssessed() {
-        return assessed != null;
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
@@ -118,21 +118,20 @@ public class ClaimField implements Serializable {
         return status == ClaimFieldStatus.NOT_MODIFIABLE;
     }
 
-    // TODO - Revise the logic around the hidden fields
     private static final List<String> HIDDEN_FIELDS = List.of(
         CMRH_TELEPHONE,
         CMRH_ORAL,
-        JR_FORM_FILLING,
+        JR_FORM_FILLING, // all of these are bolt ons except this one - should this be here?
         ADJOURNED_FEE,
         HO_INTERVIEW,
         SUBSTANTIVE_HEARING
     );
 
     public boolean display() {
-        if (!isEmptyValue(this.getSubmitted())) {
-            return true;
+        if (isEmptyValue(this.getSubmitted())) {
+            return !HIDDEN_FIELDS.contains(this.getKey());
         }
-        return !HIDDEN_FIELDS.contains(this.getKey());
+        return true;
     }
 
     private boolean isEmptyValue(Object value) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
@@ -107,17 +107,18 @@ public class ClaimField implements Serializable {
     }
 
     public boolean isAssessableAndUnassessed() {
-        return status == ClaimFieldStatus.MODIFIABLE && assessed == null;
+        return status == ClaimFieldStatus.MODIFIABLE && !isAssessed();
     }
 
     public boolean isAssessableAndAssessed() {
-        return status == ClaimFieldStatus.MODIFIABLE && assessed != null;
+        return status == ClaimFieldStatus.MODIFIABLE && isAssessed();
     }
 
     public boolean isNotAssessable() {
         return status == ClaimFieldStatus.NOT_MODIFIABLE;
     }
 
+    // TODO - Revise the logic around the hidden fields
     private static final List<String> HIDDEN_FIELDS = List.of(
         CMRH_TELEPHONE,
         CMRH_ORAL,

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldStatus.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldStatus.java
@@ -10,13 +10,11 @@ import lombok.Getter;
  * <ul>
  *   <li>{@link #MODIFIABLE} - The claim field with status can be modified.</li>
  *   <li>{@link #NOT_MODIFIABLE} - The claim field with status cannot be modified.</li>
- *   <li>{@link #DO_NOT_DISPLAY} - The claim field with status should not be shown in the UI.</li>
  * </ul>
  */
 
 @Getter
 public enum ClaimFieldStatus {
     MODIFIABLE,
-    NOT_MODIFIABLE,
-    DO_NOT_DISPLAY
+    NOT_MODIFIABLE
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsView.java
@@ -22,7 +22,7 @@ public record CivilClaimDetailsView(CivilClaimDetails claim) implements ClaimDet
     public void addSchemeIdRow(Map<String, Object> summaryRows) {}
 
     @Override
-    public void addMatterTypeRow(Map<String, Object> summaryRows) {
+    public void addMatterTypeCodeRow(Map<String, Object> summaryRows) {
         summaryRows.put("matterTypeCodeOne", getMatterTypeCodeOne());
         summaryRows.put("matterTypeCodeTwo", getMatterTypeCodeTwo());
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsView.java
@@ -16,13 +16,13 @@ public record CivilClaimDetailsView(CivilClaimDetails claim) implements ClaimDet
     }
 
     @Override
-    public void addPoliceStationCourtPrisonId(Map<String, Object> summaryRows) {}
+    public void addPoliceStationCourtPrisonIdRow(Map<String, Object> summaryRows) {}
 
     @Override
-    public void addSchemeId(Map<String, Object> summaryRows) {}
+    public void addSchemeIdRow(Map<String, Object> summaryRows) {}
 
     @Override
-    public void addMatterTypeField(Map<String, Object> summaryRows) {
+    public void addMatterTypeRow(Map<String, Object> summaryRows) {
         summaryRows.put("matterTypeCodeOne", getMatterTypeCodeOne());
         summaryRows.put("matterTypeCodeTwo", getMatterTypeCodeTwo());
     }
@@ -50,12 +50,35 @@ public record CivilClaimDetailsView(CivilClaimDetails claim) implements ClaimDet
             fields,
             setDisplayForNulls(claim.getDetentionTravelWaitingCosts()),
             setDisplayForNulls(claim.getJrFormFillingCost()),
-            setDisplayForNulls(claim.getCounselsCost()),
+            setDisplayForNulls(claim.getCounselsCost())
+        );
+        return fields;
+    }
+
+    @Override
+    public List<ClaimField> summaryClaimFields() {
+        List<ClaimField> fields = claimFields();
+        addRowIfNotNull(
+            fields,
             checkSubmittedValue(claim.getCmrhOral()),
             checkSubmittedValue(claim.getCmrhTelephone()),
             checkSubmittedValue(claim.getHoInterview()),
             checkSubmittedValue(claim.getSubstantiveHearing()),
             checkSubmittedValue(claim.getAdjournedHearing())
+        );
+        return fields;
+    }
+
+    @Override
+    public List<ClaimField> reviewClaimFields() {
+        List<ClaimField> fields = claimFields();
+        addRowIfNotNull(
+            fields,
+            claim.getCmrhOral(),
+            claim.getCmrhTelephone(),
+            claim.getHoInterview(),
+            claim.getSubstantiveHearing(),
+            claim.getAdjournedHearing()
         );
         return fields;
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -104,7 +104,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
 
     default void addRowIfNotNull(List<ClaimField> list, ClaimField... claimFields) {
         for (ClaimField claimField : claimFields) {
-            if (claimField != null && claimField.getStatus() != ClaimFieldStatus.DO_NOT_DISPLAY) {
+            if (claimField != null) {
                 list.add(claimField);
             }
         }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -4,7 +4,6 @@ import uk.gov.justice.laa.amend.claim.forms.errors.ReviewAndAmendFormError;
 import uk.gov.justice.laa.amend.claim.models.AssessmentInfo;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
-import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 import uk.gov.justice.laa.amend.claim.models.MicrosoftApiUser;
 import uk.gov.justice.laa.amend.claim.utils.DateUtils;
 
@@ -31,7 +30,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
         rows.put("feeCodeDescription", claim().getFeeCodeDescription());
         addPoliceStationCourtPrisonIdRow(rows);
         addSchemeIdRow(rows);
-        addMatterTypeRow(rows);
+        addMatterTypeCodeRow(rows);
         rows.put("caseStartDate", claim().getCaseStartDate());
         rows.put("caseEndDate", claim().getCaseEndDate());
         rows.put("escaped", claim().getEscaped());
@@ -45,7 +44,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
 
     void addSchemeIdRow(Map<String, Object> summaryRows);
 
-    void addMatterTypeRow(Map<String, Object> summaryRows);
+    void addMatterTypeCodeRow(Map<String, Object> summaryRows);
 
     default List<ClaimField> getSummaryClaimFieldRows() {
         List<ClaimField> rows = summaryClaimFields();

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -16,6 +16,7 @@ import java.util.stream.Stream;
 
 public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<T> {
 
+    // 'Summary' rows for the 'Claim details' page
     default Map<String, Object> getSummaryRows() {
         Map<String, Object> rows = new LinkedHashMap<>();
         rows.put("clientName", getClientName());
@@ -46,6 +47,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
 
     void addMatterTypeCodeRow(Map<String, Object> summaryRows);
 
+    // 'Values' rows for the 'Claim details' page
     default List<ClaimField> getSummaryClaimFieldRows() {
         List<ClaimField> rows = summaryClaimFields();
         addRowIfNotNull(
@@ -56,6 +58,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
         return rows;
     }
 
+    // 'Claim costs' rows for the 'Review and amend' page
     default List<ClaimField> getReviewClaimFieldRows() {
         List<ClaimField> rows = reviewClaimFields();
         addRowIfNotNull(
@@ -65,6 +68,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
         return rows;
     }
 
+    // 'Total claim value' rows for the 'Review and amend' page
     default List<ClaimField> getAssessedTotals() {
         List<ClaimField> rows = new ArrayList<>();
         addRowIfNotNull(
@@ -83,6 +87,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
         return assessed;
     }
 
+    // 'Total allowed value' rows for the 'Review and amend' page
     default List<ClaimField> getAllowedTotals() {
         List<ClaimField> rows = new ArrayList<>();
         addRowIfNotNull(

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsView.java
@@ -23,7 +23,7 @@ public record CrimeClaimDetailsView(CrimeClaimDetails claim) implements ClaimDet
     }
 
     @Override
-    public void addMatterTypeRow(Map<String, Object> summaryRows) {
+    public void addMatterTypeCodeRow(Map<String, Object> summaryRows) {
         summaryRows.put("legalMatterCode", claim.getMatterTypeCode());
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsView.java
@@ -13,17 +13,17 @@ public record CrimeClaimDetailsView(CrimeClaimDetails claim) implements ClaimDet
     public void addUcnSummaryRow(Map<String, Object> summaryRows) {}
 
     @Override
-    public void addPoliceStationCourtPrisonId(Map<String, Object> summaryRows) {
+    public void addPoliceStationCourtPrisonIdRow(Map<String, Object> summaryRows) {
         summaryRows.put("policeStationCourtPrisonId", claim.getPoliceStationCourtPrisonId());
     }
 
     @Override
-    public void addSchemeId(Map<String, Object> summaryRows) {
+    public void addSchemeIdRow(Map<String, Object> summaryRows) {
         summaryRows.put("schemeId", claim.getSchemeId());
     }
 
     @Override
-    public void addMatterTypeField(Map<String, Object> summaryRows) {
+    public void addMatterTypeRow(Map<String, Object> summaryRows) {
         summaryRows.put("legalMatterCode", claim.getMatterTypeCode());
     }
 
@@ -36,5 +36,15 @@ public record CrimeClaimDetailsView(CrimeClaimDetails claim) implements ClaimDet
             setDisplayForNulls(claim.getWaitingCosts())
         );
         return fields;
+    }
+
+    @Override
+    public List<ClaimField> summaryClaimFields() {
+        return claimFields();
+    }
+
+    @Override
+    public List<ClaimField> reviewClaimFields() {
+        return claimFields();
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/PageType.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/PageType.java
@@ -1,9 +1,0 @@
-package uk.gov.justice.laa.amend.claim.viewmodels;
-
-/**
- * PageType Enum
- */
-public enum PageType {
-    REVIEW,
-    CLAIM_DETAILS,
-}

--- a/src/main/resources/templates/claim-summary.html
+++ b/src/main/resources/templates/claim-summary.html
@@ -48,7 +48,7 @@
                                             <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimSummary.submitted}"></dd>
                                             <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:if="${claim.hasAssessment}" th:text="#{claimSummary.assessed}"></dd>
                                         </div>
-                                        <div class="govuk-summary-list__row" th:each="row : ${claim.getTableRows(pageType)}" th:if="${row.display()}">
+                                        <div class="govuk-summary-list__row" th:each="row : ${claim.summaryClaimFieldRows}">
                                             <dt class="govuk-summary-list__key govuk-!-font-weight-bold" th:text="#{${row.label}}"></dt>
                                             <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></dd>
                                             <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></dd>
@@ -58,13 +58,14 @@
                                 </div>
                             </div>
 
-                            <div class="govuk-summary-card" th:if="${claim.hasAssessment and !claim.assessedTotals.isEmpty()}">
-                                <div class="govuk-summary-card__title-wrapper">
-                                    <h2 class="govuk-summary-card__title" th:text="#{claimSummary.assessedTotalsTableTitle}"/>
-                                </div>
-                                <div class="govuk-summary-card__content">
-                                    <table class="govuk-table govuk-!-margin-bottom-0">
-                                        <thead class="govuk-table__head">
+                            <th:block th:if="${claim.hasAssessment()}">
+                                <div class="govuk-summary-card" th:if="${!claim.assessedTotals.isEmpty()}">
+                                    <div class="govuk-summary-card__title-wrapper">
+                                        <h2 class="govuk-summary-card__title" th:text="#{claimSummary.assessedTotalsTableTitle}"/>
+                                    </div>
+                                    <div class="govuk-summary-card__content">
+                                        <table class="govuk-table govuk-!-margin-bottom-0">
+                                            <thead class="govuk-table__head">
                                             <tr class="govuk-table__row">
                                                 <th class="govuk-table__header" scope="col" th:text="#{claimSummary.item}"></th>
                                                 <th class="govuk-table__header" scope="col" th:text="#{claimSummary.calculated}"></th>
@@ -72,26 +73,26 @@
                                                 <th class="govuk-table__header" scope="col" th:text="#{claimSummary.assessed}"></th>
                                                 <th class="govuk-table__header" scope="col"></th>
                                             </tr>
-                                        </thead>
-                                        <tbody class="govuk-table__body">
+                                            </thead>
+                                            <tbody class="govuk-table__body">
                                             <tr class="govuk-table__row" th:each="row : ${claim.assessedTotals}">
                                                 <td class="govuk-table__cell govuk-!-font-weight-bold" th:text="#{${row.label}}"></td>
                                                 <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></td>
                                                 <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></td>
                                                 <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}"></td>
                                             </tr>
-                                        </tbody>
-                                    </table>
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
-                            </div>
 
-                            <div class="govuk-summary-card" th:if="${claim.hasAssessment and !claim.allowedTotals.isEmpty()}">
-                                <div class="govuk-summary-card__title-wrapper">
-                                    <h2 class="govuk-summary-card__title" th:text="#{claimSummary.allowedTotalsTableTitle}"/>
-                                </div>
-                                <div class="govuk-summary-card__content">
-                                    <table class="govuk-table govuk-!-margin-bottom-0">
-                                        <thead class="govuk-table__head">
+                                <div class="govuk-summary-card" th:if="${!claim.allowedTotals.isEmpty()}">
+                                    <div class="govuk-summary-card__title-wrapper">
+                                        <h2 class="govuk-summary-card__title" th:text="#{claimSummary.allowedTotalsTableTitle}"/>
+                                    </div>
+                                    <div class="govuk-summary-card__content">
+                                        <table class="govuk-table govuk-!-margin-bottom-0">
+                                            <thead class="govuk-table__head">
                                             <tr class="govuk-table__row">
                                                 <th class="govuk-table__header" scope="col" th:text="#{claimSummary.item}"></th>
                                                 <th class="govuk-table__header" scope="col" th:text="#{claimSummary.calculated}"></th>
@@ -99,8 +100,8 @@
                                                 <th class="govuk-table__header" scope="col" th:text="#{claimSummary.allowed}"></th>
                                                 <th class="govuk-table__header" scope="col"></th>
                                             </tr>
-                                        </thead>
-                                        <tbody class="govuk-table__body">
+                                            </thead>
+                                            <tbody class="govuk-table__body">
                                             <tr class="govuk-table__row" th:each="row : ${claim.allowedTotals}">
                                                 <td class="govuk-table__cell govuk-!-font-weight-bold" th:text="#{${row.label}}"></td>
                                                 <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></td>
@@ -108,10 +109,12 @@
                                                 <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}">
                                                 </td>
                                             </tr>
-                                        </tbody>
-                                    </table>
+                                            </tbody>
+                                        </table>
+                                    </div>
                                 </div>
-                            </div>
+                            </th:block>
+
                             <form method="post"
                                   th:action="@{/submissions/{submissionId}/claims/{claimId}(submissionId=${submissionId}, claimId=${claimId})}">
                                 <div class="govuk-button-group">

--- a/src/main/resources/templates/review-and-amend.html
+++ b/src/main/resources/templates/review-and-amend.html
@@ -34,58 +34,58 @@
         <div class="govuk-summary-card__content">
             <table class="govuk-table govuk-!-margin-bottom-0">
                 <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.item}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.calculated}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.submitted}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.assessed}"></th>
-                    <th scope="col" class="govuk-table__header"></th>
-                </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.item}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.calculated}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.submitted}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.assessed}"></th>
+                        <th scope="col" class="govuk-table__header"></th>
+                    </tr>
                 </thead>
                 <tbody class="govuk-table__body">
-                <tr class="govuk-table__row"
-                    th:each="row : ${viewModel.reviewClaimFieldRows}">
+                    <tr class="govuk-table__row" th:each="row : ${viewModel.reviewClaimFieldRows}">
 
-                    <td class="govuk-table__cell govuk-!-font-weight-bold" th:text="#{${row.label}}"></td>
-                    <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></td>
-                    <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></td>
+                        <td class="govuk-table__cell govuk-!-font-weight-bold" th:text="#{${row.label}}"></td>
+                        <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></td>
+                        <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></td>
 
-                <th:block th:if="${row.isAssessableAndUnassessed}">
-                    <td class="govuk-table__cell">
-                        <a th:href="${row.getChangeUrl(submissionId, claimId)}"
-                           th:id="${row.id}"
-                           th:data-testid="${'claim-field-' + row.key}"
-                           class="govuk-link govuk-link--no-visited-state">
-                            <th:block th:text="#{service.add}"></th:block>
-                            <span class="govuk-visually-hidden" th:text=" #{${row.label}}"></span>
-                        </a>
-                    </td>
+                        <th:block th:if="${row.isAssessableAndUnassessed}">
+                            <td class="govuk-table__cell">
+                                <a th:href="${row.getChangeUrl(submissionId, claimId)}"
+                                   th:id="${row.id}"
+                                   th:data-testid="${'claim-field-' + row.key}"
+                                   class="govuk-link govuk-link--no-visited-state">
+                                    <th:block th:text="#{service.add}"></th:block>
+                                    <span class="govuk-visually-hidden" th:text=" #{${row.label}}"></span>
+                                </a>
+                            </td>
 
-                        <td class="govuk-table__cell"></td>
-                    </th:block>
-                    <th:block th:if="${row.isAssessableAndAssessed}">
-                        <td class="govuk-table__cell"
-                            th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}">
-                        </td>
+                            <td class="govuk-table__cell"></td>
+                        </th:block>
 
-                        <td class="govuk-table__cell">
-                            <a th:if="${row.getChangeUrl(submissionId,claimId) != null}"
-                               th:href="${row.getChangeUrl(submissionId,claimId)}"
-                               th:data-testid="${'claim-field-' + row.key}"
-                               class="govuk-link govuk-link--no-visited-state">
-                                <th:block th:text="#{service.change}"></th:block>
-                                <span class="govuk-visually-hidden" th:text=" #{${row.label}}"></span>
-                            </a>
-                        </td>
-                    </th:block>
+                        <th:block th:if="${row.isAssessableAndAssessed}">
+                            <td class="govuk-table__cell"
+                                th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}">
+                            </td>
 
-                    <th:block th:if="${row.isNotAssessable()}">
-                        <td class="govuk-table__cell"
-                            th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}">
-                        </td>
-                        <td class="govuk-table__cell"></td>
-                    </th:block>
-                </tr>
+                            <td class="govuk-table__cell">
+                                <a th:if="${row.getChangeUrl(submissionId,claimId) != null}"
+                                   th:href="${row.getChangeUrl(submissionId,claimId)}"
+                                   th:data-testid="${'claim-field-' + row.key}"
+                                   class="govuk-link govuk-link--no-visited-state">
+                                    <th:block th:text="#{service.change}"></th:block>
+                                    <span class="govuk-visually-hidden" th:text=" #{${row.label}}"></span>
+                                </a>
+                            </td>
+                        </th:block>
+
+                        <th:block th:if="${row.isNotAssessable()}">
+                            <td class="govuk-table__cell"
+                                th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}">
+                            </td>
+                            <td class="govuk-table__cell"></td>
+                        </th:block>
+                    </tr>
                 </tbody>
             </table>
         </div>
@@ -98,13 +98,13 @@
         <div class="govuk-summary-card__content">
             <table class="govuk-table govuk-!-margin-bottom-0">
                 <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.item}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.calculated}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.submitted}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.assessed}"></th>
-                    <th scope="col" class="govuk-table__header"></th>
-                </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.item}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.calculated}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.submitted}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.assessed}"></th>
+                        <th scope="col" class="govuk-table__header"></th>
+                    </tr>
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row" th:each="row : ${viewModel.assessedTotals}">
@@ -148,13 +148,13 @@
         <div class="govuk-summary-card__content">
             <table class="govuk-table govuk-!-margin-bottom-0">
                 <thead class="govuk-table__head">
-                <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.item}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.calculated}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.submitted}"></th>
-                    <th scope="col" class="govuk-table__header" th:text="#{claimSummary.allowed}"></th>
-                    <th scope="col" class="govuk-table__header"></th>
-                </tr>
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.item}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.calculated}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.submitted}"></th>
+                        <th scope="col" class="govuk-table__header" th:text="#{claimSummary.allowed}"></th>
+                        <th scope="col" class="govuk-table__header"></th>
+                    </tr>
                 </thead>
                 <tbody class="govuk-table__body">
                     <tr class="govuk-table__row" th:each="row : ${viewModel.allowedTotals}">
@@ -172,7 +172,9 @@
                                 </a>
                             </td>
                         </th:block>
+
                         <td class="govuk-table__cell" th:if="${(row.isNotAssessable())}"></td>
+
                         <th:block th:if="${row.isAssessableAndAssessed()}">
                             <td class="govuk-table__cell">
                                 <a th:href="${row.getChangeUrl(submissionId, claimId)}"

--- a/src/main/resources/templates/review-and-amend.html
+++ b/src/main/resources/templates/review-and-amend.html
@@ -44,7 +44,7 @@
                 </thead>
                 <tbody class="govuk-table__body">
                 <tr class="govuk-table__row"
-                    th:each="row : ${viewModel.getTableRows(pageType)}">
+                    th:each="row : ${viewModel.reviewClaimFieldRows}">
 
                     <td class="govuk-table__cell govuk-!-font-weight-bold" th:text="#{${row.label}}"></td>
                     <td class="govuk-table__cell" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></td>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimReviewControllerTest.java
@@ -15,13 +15,12 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.handlers.ClaimStatusHandler;
-import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
+import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 import uk.gov.justice.laa.amend.claim.models.OutcomeType;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
-import uk.gov.justice.laa.amend.claim.viewmodels.PageType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateAssessment201Response;
 
 import java.util.UUID;
@@ -83,7 +82,6 @@ public class ClaimReviewControllerTest {
             .andExpect(model().attribute("claimId", claimId.toString()))
             .andExpect(model().attribute("submissionId", submissionId.toString()))
             .andExpect(model().attribute("submissionFailed", false))
-            .andExpect(model().attribute("pageType", PageType.REVIEW))
             .andExpect(model().attribute("validationFailed", false));
     }
 
@@ -192,8 +190,7 @@ public class ClaimReviewControllerTest {
 
         mockMvc.perform(get(path1).session(session))
             .andExpect(status().isOk())
-            .andExpect(model().attribute("claimId", claimId1))
-            .andExpect(model().attribute("pageType", PageType.REVIEW));
+            .andExpect(model().attribute("claimId", claimId1));
 
         // Verify both claims still in session
         Assertions.assertNotNull(session.getAttribute(claimId1));

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/CivilClaimDetailsTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/CivilClaimDetailsTest.java
@@ -244,19 +244,19 @@ public class CivilClaimDetailsTest {
             Assertions.assertEquals(BigDecimal.ONE, claim.getJrFormFillingCost().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.MODIFIABLE, claim.getJrFormFillingCost().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ONE, claim.getAdjournedHearing().getAssessed());
+            Assertions.assertNull(claim.getAdjournedHearing().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getAdjournedHearing().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ONE, claim.getCmrhTelephone().getAssessed());
+            Assertions.assertNull(claim.getCmrhTelephone().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getCmrhTelephone().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ONE, claim.getCmrhOral().getAssessed());
+            Assertions.assertNull(claim.getCmrhOral().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getCmrhOral().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ONE, claim.getHoInterview().getAssessed());
+            Assertions.assertNull(claim.getHoInterview().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getHoInterview().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ONE, claim.getSubstantiveHearing().getAssessed());
+            Assertions.assertNull(claim.getSubstantiveHearing().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getSubstantiveHearing().getStatus());
 
             Assertions.assertNull(claim.getAssessedTotalVat().getAssessed());
@@ -323,19 +323,19 @@ public class CivilClaimDetailsTest {
             Assertions.assertEquals(BigDecimal.ONE, claim.getJrFormFillingCost().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.MODIFIABLE, claim.getJrFormFillingCost().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ZERO, claim.getAdjournedHearing().getAssessed());
+            Assertions.assertNull(claim.getAdjournedHearing().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getAdjournedHearing().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ZERO, claim.getCmrhTelephone().getAssessed());
+            Assertions.assertNull(claim.getCmrhTelephone().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getCmrhTelephone().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ZERO, claim.getCmrhOral().getAssessed());
+            Assertions.assertNull(claim.getCmrhOral().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getCmrhOral().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ZERO, claim.getHoInterview().getAssessed());
+            Assertions.assertNull(claim.getHoInterview().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getHoInterview().getStatus());
 
-            Assertions.assertEquals(BigDecimal.ZERO, claim.getSubstantiveHearing().getAssessed());
+            Assertions.assertNull(claim.getSubstantiveHearing().getAssessed());
             Assertions.assertEquals(ClaimFieldStatus.NOT_MODIFIABLE, claim.getSubstantiveHearing().getStatus());
 
             Assertions.assertNull(claim.getAssessedTotalVat().getAssessed());

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldTest.java
@@ -6,14 +6,6 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.ADJOURNED_FEE;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_ORAL;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_TELEPHONE;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.FIXED_FEE;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.HO_INTERVIEW;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.JR_FORM_FILLING;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.SUBSTANTIVE_HEARING;
-
 public class ClaimFieldTest {
 
     @Test
@@ -51,71 +43,4 @@ public class ClaimFieldTest {
             Assertions.assertEquals(expectedResult, claimField.getChangeUrl(submissionId, claimId));
         }
     }
-
-//    @Nested
-//    class DisplayTest {
-//
-//        @Test
-//        void displayFixedFeeWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(FIXED_FEE);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertTrue(claimField.display());
-//        }
-//
-//        @Test
-//        void doNotDisplayCmrhTelephoneWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(CMRH_TELEPHONE);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertFalse(claimField.display());
-//        }
-//
-//        @Test
-//        void doNotDisplayCmrhOralWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(CMRH_ORAL);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertFalse(claimField.display());
-//        }
-//
-//        @Test
-//        void doNotDisplayJrFormFillingWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(JR_FORM_FILLING);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertFalse(claimField.display());
-//        }
-//
-//        @Test
-//        void doNotDisplayAdjournedFeeWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(ADJOURNED_FEE);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertFalse(claimField.display());
-//        }
-//
-//        @Test
-//        void doNotDisplayHoInterviewWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(HO_INTERVIEW);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertFalse(claimField.display());
-//        }
-//
-//        @Test
-//        void doNotDisplaySubstantiveHearingWhenSubmittedValueIsNull() {
-//            ClaimField claimField = new ClaimField();
-//            claimField.setKey(SUBSTANTIVE_HEARING);
-//            claimField.setSubmitted(null);
-//
-//            Assertions.assertFalse(claimField.display());
-//        }
-//    }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldTest.java
@@ -52,70 +52,70 @@ public class ClaimFieldTest {
         }
     }
 
-    @Nested
-    class DisplayTest {
-
-        @Test
-        void displayFixedFeeWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(FIXED_FEE);
-            claimField.setSubmitted(null);
-
-            Assertions.assertTrue(claimField.display());
-        }
-
-        @Test
-        void doNotDisplayCmrhTelephoneWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(CMRH_TELEPHONE);
-            claimField.setSubmitted(null);
-
-            Assertions.assertFalse(claimField.display());
-        }
-
-        @Test
-        void doNotDisplayCmrhOralWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(CMRH_ORAL);
-            claimField.setSubmitted(null);
-
-            Assertions.assertFalse(claimField.display());
-        }
-
-        @Test
-        void doNotDisplayJrFormFillingWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(JR_FORM_FILLING);
-            claimField.setSubmitted(null);
-
-            Assertions.assertFalse(claimField.display());
-        }
-
-        @Test
-        void doNotDisplayAdjournedFeeWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(ADJOURNED_FEE);
-            claimField.setSubmitted(null);
-
-            Assertions.assertFalse(claimField.display());
-        }
-
-        @Test
-        void doNotDisplayHoInterviewWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(HO_INTERVIEW);
-            claimField.setSubmitted(null);
-
-            Assertions.assertFalse(claimField.display());
-        }
-
-        @Test
-        void doNotDisplaySubstantiveHearingWhenSubmittedValueIsNull() {
-            ClaimField claimField = new ClaimField();
-            claimField.setKey(SUBSTANTIVE_HEARING);
-            claimField.setSubmitted(null);
-
-            Assertions.assertFalse(claimField.display());
-        }
-    }
+//    @Nested
+//    class DisplayTest {
+//
+//        @Test
+//        void displayFixedFeeWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(FIXED_FEE);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertTrue(claimField.display());
+//        }
+//
+//        @Test
+//        void doNotDisplayCmrhTelephoneWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(CMRH_TELEPHONE);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertFalse(claimField.display());
+//        }
+//
+//        @Test
+//        void doNotDisplayCmrhOralWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(CMRH_ORAL);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertFalse(claimField.display());
+//        }
+//
+//        @Test
+//        void doNotDisplayJrFormFillingWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(JR_FORM_FILLING);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertFalse(claimField.display());
+//        }
+//
+//        @Test
+//        void doNotDisplayAdjournedFeeWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(ADJOURNED_FEE);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertFalse(claimField.display());
+//        }
+//
+//        @Test
+//        void doNotDisplayHoInterviewWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(HO_INTERVIEW);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertFalse(claimField.display());
+//        }
+//
+//        @Test
+//        void doNotDisplaySubstantiveHearingWhenSubmittedValueIsNull() {
+//            ClaimField claimField = new ClaimField();
+//            claimField.setKey(SUBSTANTIVE_HEARING);
+//            claimField.setSubmitted(null);
+//
+//            Assertions.assertFalse(claimField.display());
+//        }
+//    }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/ClaimFieldTest.java
@@ -6,6 +6,14 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.ADJOURNED_FEE;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_ORAL;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.CMRH_TELEPHONE;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.FIXED_FEE;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.HO_INTERVIEW;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.JR_FORM_FILLING;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.SUBSTANTIVE_HEARING;
+
 public class ClaimFieldTest {
 
     @Test
@@ -41,6 +49,73 @@ public class ClaimFieldTest {
             claimField.setChangeUrl(Cost.PROFIT_COSTS.getChangeUrl());
             String expectedResult = "/submissions/foo/claims/bar/profit-costs";
             Assertions.assertEquals(expectedResult, claimField.getChangeUrl(submissionId, claimId));
+        }
+    }
+
+    @Nested
+    class DisplayTest {
+
+        @Test
+        void displayFixedFeeWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(FIXED_FEE);
+            claimField.setSubmitted(null);
+
+            Assertions.assertTrue(claimField.display());
+        }
+
+        @Test
+        void doNotDisplayCmrhTelephoneWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(CMRH_TELEPHONE);
+            claimField.setSubmitted(null);
+
+            Assertions.assertFalse(claimField.display());
+        }
+
+        @Test
+        void doNotDisplayCmrhOralWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(CMRH_ORAL);
+            claimField.setSubmitted(null);
+
+            Assertions.assertFalse(claimField.display());
+        }
+
+        @Test
+        void doNotDisplayJrFormFillingWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(JR_FORM_FILLING);
+            claimField.setSubmitted(null);
+
+            Assertions.assertFalse(claimField.display());
+        }
+
+        @Test
+        void doNotDisplayAdjournedFeeWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(ADJOURNED_FEE);
+            claimField.setSubmitted(null);
+
+            Assertions.assertFalse(claimField.display());
+        }
+
+        @Test
+        void doNotDisplayHoInterviewWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(HO_INTERVIEW);
+            claimField.setSubmitted(null);
+
+            Assertions.assertFalse(claimField.display());
+        }
+
+        @Test
+        void doNotDisplaySubstantiveHearingWhenSubmittedValueIsNull() {
+            ClaimField claimField = new ClaimField();
+            claimField.setKey(SUBSTANTIVE_HEARING);
+            claimField.setSubmitted(null);
+
+            Assertions.assertFalse(claimField.display());
         }
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
@@ -3,13 +3,12 @@ package uk.gov.justice.laa.amend.claim.viewmodels;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
 import uk.gov.justice.laa.amend.claim.forms.errors.ReviewAndAmendFormError;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -112,10 +111,10 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
     }
 
     @Nested
-    class GetTableRowsTests {
-        @ParameterizedTest
-        @EnumSource(PageType.class)
-        void rowsRenderedForClaimValues(PageType pageType) {
+    class GetSummaryClaimFieldRowsTests {
+
+        @Test
+        void rowsRenderedForClaimValuesWhenClaimHasAnAssessment() {
             ClaimField fixedFee = new ClaimField("1", null, null);
             ClaimField netProfitCost = new ClaimField("2", null, null);
             ClaimField netDisbursementAmount = new ClaimField("3", null, null);
@@ -150,29 +149,80 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
 
             CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
             ArrayList<ClaimField> expectedRows = new ArrayList<>(List.of(
-                    fixedFee,
-                    netProfitCost,
-                    netDisbursementAmount,
-                    disbursementVatAmount,
-                    detention,
-                    jrFormFilling,
-                    counselCost,
-                    cmrhOral,
-                    cmrhTelephone,
-                    hoInterview,
-                    substantiveHearing,
-                    adjournedHearing,
-                    vatClaimed
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost,
+                cmrhOral,
+                cmrhTelephone,
+                hoInterview,
+                substantiveHearing,
+                adjournedHearing,
+                vatClaimed
             ));
-            if (PageType.CLAIM_DETAILS.equals(pageType) && !claim.isHasAssessment()) {
-                expectedRows.add(totalAmount);
-            }
-            Assertions.assertEquals(expectedRows, viewModel.getTableRows(pageType));
+
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
         }
 
-        @ParameterizedTest
-        @EnumSource(PageType.class)
-        void onlyRowsWithValuesRendered(PageType pageType) {
+        @Test
+        void rowsRenderedForClaimValuesWhenClaimDoesNotHaveAnAssessment() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField counselCost = new ClaimField("5", null, null);
+            ClaimField detention = new ClaimField("6", null, null);
+            ClaimField jrFormFilling = new ClaimField("7", null, null);
+            ClaimField adjournedHearing = new ClaimField("8", 100, 100);
+            ClaimField cmrhTelephone = new ClaimField("9", 100, 100);
+            ClaimField cmrhOral = new ClaimField("10", 100, 100);
+            ClaimField hoInterview = new ClaimField("11", 100, 100);
+            ClaimField substantiveHearing = new ClaimField("12", 100, 100);
+            ClaimField vatClaimed = new ClaimField("13", 100, 100);
+            ClaimField totalAmount = new ClaimField("14", 100, 100);
+
+            CivilClaimDetails claim = new CivilClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setCounselsCost(counselCost);
+            claim.setDetentionTravelWaitingCosts(detention);
+            claim.setJrFormFillingCost(jrFormFilling);
+            claim.setAdjournedHearing(adjournedHearing);
+            claim.setCmrhTelephone(cmrhTelephone);
+            claim.setCmrhOral(cmrhOral);
+            claim.setHoInterview(hoInterview);
+            claim.setSubstantiveHearing(substantiveHearing);
+            claim.setVatClaimed(vatClaimed);
+            claim.setTotalAmount(totalAmount);
+            claim.setHasAssessment(false);
+
+            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            ArrayList<ClaimField> expectedRows = new ArrayList<>(List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost,
+                cmrhOral,
+                cmrhTelephone,
+                hoInterview,
+                substantiveHearing,
+                adjournedHearing,
+                vatClaimed,
+                totalAmount
+            ));
+
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
+        }
+
+        @Test void onlyRowsWithValuesRendered() {
             ClaimField fixedFee = new ClaimField("1", null, null);
             ClaimField netProfitCost = new ClaimField("2", null, null);
             ClaimField netDisbursementAmount = new ClaimField("3", null, null);
@@ -214,13 +264,11 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
                 jrFormFilling,
                 counselCost,
                 adjournedHearing,
-                vatClaimed
+                vatClaimed,
+                totalAmount
             ));
 
-            if (PageType.CLAIM_DETAILS.equals(pageType) && !claim.isHasAssessment()) {
-                expectedRows.add(totalAmount);
-            }
-            Assertions.assertEquals(expectedRows, viewModel.getTableRows(pageType));
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
         }
 
         @Test
@@ -252,7 +300,242 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
                 jrFormFilling,
                 counselCost
             );
-            Assertions.assertEquals(expectedRows, viewModel.getTableRows(PageType.CLAIM_DETAILS));
+
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
+        }
+
+        @Test
+        void rowsRenderedForZeroBoltOnClaimValues() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField counselCost = new ClaimField("5", null, null);
+            ClaimField detention = new ClaimField("6", null, null);
+            ClaimField jrFormFilling = new ClaimField("7", null, null);
+            ClaimField adjournedHearing = new ClaimField("8", BigDecimal.ZERO, 100);
+            ClaimField cmrhTelephone = new ClaimField("9", 0, null);
+            ClaimField cmrhOral = new ClaimField("10", 0, null);
+            ClaimField hoInterview = new ClaimField("11", 0, null);
+            ClaimField substantiveHearing = new ClaimField("12", BigDecimal.ZERO, null);
+
+            CivilClaimDetails claim = new CivilClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setCounselsCost(counselCost);
+            claim.setDetentionTravelWaitingCosts(detention);
+            claim.setJrFormFillingCost(jrFormFilling);
+            claim.setAdjournedHearing(adjournedHearing);
+            claim.setCmrhTelephone(cmrhTelephone);
+            claim.setCmrhOral(cmrhOral);
+            claim.setHoInterview(hoInterview);
+            claim.setSubstantiveHearing(substantiveHearing);
+
+            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            List<ClaimField> expectedRows = List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost
+            );
+
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
+        }
+    }
+
+    @Nested
+    class GetReviewClaimFieldRowsTests {
+
+        @Test
+        void rowsRenderedForClaimValues() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField counselCost = new ClaimField("5", null, null);
+            ClaimField detention = new ClaimField("6", null, null);
+            ClaimField jrFormFilling = new ClaimField("7", null, null);
+            ClaimField adjournedHearing = new ClaimField("8", 100, 100);
+            ClaimField cmrhTelephone = new ClaimField("9", 100, 100);
+            ClaimField cmrhOral = new ClaimField("10", 100, 100);
+            ClaimField hoInterview = new ClaimField("11", 100, 100);
+            ClaimField substantiveHearing = new ClaimField("12", 100, 100);
+            ClaimField vatClaimed = new ClaimField("13", 100, 100);
+            ClaimField totalAmount = new ClaimField("14", 100, 100);
+
+            CivilClaimDetails claim = new CivilClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setCounselsCost(counselCost);
+            claim.setDetentionTravelWaitingCosts(detention);
+            claim.setJrFormFillingCost(jrFormFilling);
+            claim.setAdjournedHearing(adjournedHearing);
+            claim.setCmrhTelephone(cmrhTelephone);
+            claim.setCmrhOral(cmrhOral);
+            claim.setHoInterview(hoInterview);
+            claim.setSubstantiveHearing(substantiveHearing);
+            claim.setVatClaimed(vatClaimed);
+            claim.setTotalAmount(totalAmount);
+            claim.setHasAssessment(true);
+
+            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            ArrayList<ClaimField> expectedRows = new ArrayList<>(List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost,
+                cmrhOral,
+                cmrhTelephone,
+                hoInterview,
+                substantiveHearing,
+                adjournedHearing,
+                vatClaimed
+            ));
+
+            Assertions.assertEquals(expectedRows, viewModel.getReviewClaimFieldRows());
+        }
+
+        @Test void nullBoltOnRowsRenderedForClaimValues() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField counselCost = new ClaimField("5", null, null);
+            ClaimField detention = new ClaimField("6", null, null);
+            ClaimField jrFormFilling = new ClaimField("7", null, null);
+            ClaimField adjournedHearing = new ClaimField("8", null, 100);
+            ClaimField cmrhTelephone = new ClaimField("9", null, null);
+            ClaimField cmrhOral = new ClaimField("10", null, null);
+            ClaimField hoInterview = new ClaimField("11", null, null);
+            ClaimField substantiveHearing = new ClaimField("12", null, null);
+            ClaimField vatClaimed = new ClaimField("13", null, 100);
+            ClaimField totalAmount = new ClaimField("14", 100, null);
+
+            CivilClaimDetails claim = new CivilClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setCounselsCost(counselCost);
+            claim.setDetentionTravelWaitingCosts(detention);
+            claim.setJrFormFillingCost(jrFormFilling);
+            claim.setAdjournedHearing(adjournedHearing);
+            claim.setCmrhTelephone(cmrhTelephone);
+            claim.setCmrhOral(cmrhOral);
+            claim.setHoInterview(hoInterview);
+            claim.setSubstantiveHearing(substantiveHearing);
+            claim.setVatClaimed(vatClaimed);
+            claim.setTotalAmount(totalAmount);
+
+            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            List<ClaimField> expectedRows = new ArrayList<>(List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost,
+                cmrhOral,
+                cmrhTelephone,
+                hoInterview,
+                substantiveHearing,
+                adjournedHearing,
+                vatClaimed
+            ));
+
+            Assertions.assertEquals(expectedRows, viewModel.getReviewClaimFieldRows());
+        }
+
+        @Test
+        void rowsRenderedForNullBoltOnClaimValues() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField counselCost = new ClaimField("5", null, null);
+            ClaimField detention = new ClaimField("6", null, null);
+            ClaimField jrFormFilling = new ClaimField("7", null, null);
+
+            CivilClaimDetails claim = new CivilClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setCounselsCost(counselCost);
+            claim.setDetentionTravelWaitingCosts(detention);
+            claim.setJrFormFillingCost(jrFormFilling);
+
+            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            List<ClaimField> expectedRows = List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost
+            );
+
+            Assertions.assertEquals(expectedRows, viewModel.getReviewClaimFieldRows());
+        }
+
+        @Test
+        void rowsRenderedForZeroBoltOnClaimValues() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField counselCost = new ClaimField("5", null, null);
+            ClaimField detention = new ClaimField("6", null, null);
+            ClaimField jrFormFilling = new ClaimField("7", null, null);
+            ClaimField adjournedHearing = new ClaimField("8", BigDecimal.ZERO, 100);
+            ClaimField cmrhTelephone = new ClaimField("9", 0, null);
+            ClaimField cmrhOral = new ClaimField("10", 0, null);
+            ClaimField hoInterview = new ClaimField("11", 0, null);
+            ClaimField substantiveHearing = new ClaimField("12", BigDecimal.ZERO, null);
+
+            CivilClaimDetails claim = new CivilClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setCounselsCost(counselCost);
+            claim.setDetentionTravelWaitingCosts(detention);
+            claim.setJrFormFillingCost(jrFormFilling);
+            claim.setAdjournedHearing(adjournedHearing);
+            claim.setCmrhTelephone(cmrhTelephone);
+            claim.setCmrhOral(cmrhOral);
+            claim.setHoInterview(hoInterview);
+            claim.setSubstantiveHearing(substantiveHearing);
+
+            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            List<ClaimField> expectedRows = List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                detention,
+                jrFormFilling,
+                counselCost,
+                cmrhOral,
+                cmrhTelephone,
+                hoInterview,
+                substantiveHearing,
+                adjournedHearing
+            );
+
+            Assertions.assertEquals(expectedRows, viewModel.getReviewClaimFieldRows());
         }
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
@@ -9,8 +9,12 @@ import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDetails, CivilClaimDetailsView> {
 
@@ -30,7 +34,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeOneWhenInExpectedFormat() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode("IMLB+AHQS");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertEquals("IMLB", viewModel.getMatterTypeCodeOne());
         }
 
@@ -38,7 +42,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeOneWhenInUnexpectedFormat() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode("IMLB");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertEquals("IMLB", viewModel.getMatterTypeCodeOne());
         }
 
@@ -46,7 +50,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeOneWhenNull() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode(null);
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(null, viewModel.getMatterTypeCodeOne());
         }
 
@@ -54,7 +58,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeOneWhenEmpty() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode("");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(null, viewModel.getMatterTypeCodeOne());
         }
 
@@ -62,7 +66,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeOneWhenBlank() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode(" ");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(null, viewModel.getMatterTypeCodeOne());
         }
     }
@@ -73,7 +77,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeTwoWhenInExpectedFormat() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode("IMLB+AHQS");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertEquals("AHQS", viewModel.getMatterTypeCodeTwo());
         }
 
@@ -81,7 +85,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeTwoWhenInUnexpectedFormat() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode("IMLB");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(viewModel.getMatterTypeCodeTwo());
         }
 
@@ -89,7 +93,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeTwoWhenNull() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode(null);
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(null, viewModel.getMatterTypeCodeTwo());
         }
 
@@ -97,7 +101,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeTwoWhenEmpty() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode("");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(null, viewModel.getMatterTypeCodeTwo());
         }
 
@@ -105,8 +109,60 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
         void getMatterTypeCodeTwoWhenBlank() {
             CivilClaimDetails claim = new CivilClaimDetails();
             claim.setMatterTypeCode(" ");
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             Assertions.assertNull(null, viewModel.getMatterTypeCodeTwo());
+        }
+    }
+
+    @Nested
+    class GetSummaryRowsTests {
+        @Test
+        void createMapOfKeyValuePairs() {
+            LocalDateTime submittedDate = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+            LocalDate caseStartDate = LocalDate.of(2001, 1, 1);
+            LocalDate caseEndDate = LocalDate.of(2002, 1, 1);
+
+            CivilClaimDetails claim = createClaim();
+            claim.setClientForename("John");
+            claim.setClientSurname("Smith");
+            claim.setUniqueFileNumber("unique file number");
+            claim.setCaseReferenceNumber("case reference number");
+            claim.setProviderName("provider name");
+            claim.setProviderAccountNumber("provider account number");
+            claim.setSubmittedDate(submittedDate);
+            claim.setAreaOfLaw("area of law");
+            claim.setCategoryOfLaw("category of law");
+            claim.setFeeCode("fee code");
+            claim.setFeeCodeDescription("fee code description");
+            claim.setMatterTypeCode("IMLB+AHQS");
+            claim.setCaseStartDate(caseStartDate);
+            claim.setCaseEndDate(caseEndDate);
+            claim.setEscaped(true);
+            claim.setVatApplicable(false);
+
+            CivilClaimDetailsView viewModel = createView(claim);
+
+            Map<String, Object> result = viewModel.getSummaryRows();
+
+            Map<String, Object> expectedResult = new LinkedHashMap<>();
+            expectedResult.put("clientName", "John Smith");
+            expectedResult.put("ufn", "unique file number");
+            expectedResult.put("ucn", "case reference number");
+            expectedResult.put("providerName", "provider name");
+            expectedResult.put("providerAccountNumber", "provider account number");
+            expectedResult.put("submittedDate", submittedDate);
+            expectedResult.put("areaOfLaw", "area of law");
+            expectedResult.put("categoryOfLaw", "category of law");
+            expectedResult.put("feeCode", "fee code");
+            expectedResult.put("feeCodeDescription", "fee code description");
+            expectedResult.put("matterTypeCodeOne", "IMLB");
+            expectedResult.put("matterTypeCodeTwo", "AHQS");
+            expectedResult.put("caseStartDate", caseStartDate);
+            expectedResult.put("caseEndDate", caseEndDate);
+            expectedResult.put("escaped", true);
+            expectedResult.put("vatRequested", false);
+
+            Assertions.assertEquals(expectedResult, result);
         }
     }
 
@@ -147,7 +203,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setTotalAmount(totalAmount);
             claim.setHasAssessment(true);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             ArrayList<ClaimField> expectedRows = new ArrayList<>(List.of(
                 fixedFee,
                 netProfitCost,
@@ -201,7 +257,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setTotalAmount(totalAmount);
             claim.setHasAssessment(false);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             ArrayList<ClaimField> expectedRows = new ArrayList<>(List.of(
                 fixedFee,
                 netProfitCost,
@@ -254,7 +310,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setVatClaimed(vatClaimed);
             claim.setTotalAmount(totalAmount);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimField> expectedRows = new ArrayList<>(List.of(
                 fixedFee,
                 netProfitCost,
@@ -290,7 +346,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setDetentionTravelWaitingCosts(detention);
             claim.setJrFormFillingCost(jrFormFilling);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimField> expectedRows = List.of(
                 fixedFee,
                 netProfitCost,
@@ -333,7 +389,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setHoInterview(hoInterview);
             claim.setSubstantiveHearing(substantiveHearing);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimField> expectedRows = List.of(
                 fixedFee,
                 netProfitCost,
@@ -385,7 +441,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setTotalAmount(totalAmount);
             claim.setHasAssessment(true);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             ArrayList<ClaimField> expectedRows = new ArrayList<>(List.of(
                 fixedFee,
                 netProfitCost,
@@ -437,7 +493,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setVatClaimed(vatClaimed);
             claim.setTotalAmount(totalAmount);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimField> expectedRows = new ArrayList<>(List.of(
                 fixedFee,
                 netProfitCost,
@@ -476,7 +532,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setDetentionTravelWaitingCosts(detention);
             claim.setJrFormFillingCost(jrFormFilling);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimField> expectedRows = List.of(
                 fixedFee,
                 netProfitCost,
@@ -519,7 +575,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setHoInterview(hoInterview);
             claim.setSubstantiveHearing(substantiveHearing);
 
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimField> expectedRows = List.of(
                 fixedFee,
                 netProfitCost,
@@ -552,7 +608,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setAssessedTotalInclVat(createClaimField("assessedTotalInclVat", ClaimFieldStatus.MODIFIABLE));
             claim.setAllowedTotalVat(createClaimField("allowedTotalVat", ClaimFieldStatus.MODIFIABLE));
             claim.setAllowedTotalInclVat(createClaimField("allowedTotalInclVat", ClaimFieldStatus.MODIFIABLE));
-            CivilClaimDetailsView viewModel = new CivilClaimDetailsView(claim);
+            CivilClaimDetailsView viewModel = createView(claim);
 
             List<ReviewAndAmendFormError> expectedErrors = List.of(
                 new ReviewAndAmendFormError("profit-cost", "claimSummary.rows.profitCost.error"),

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
@@ -112,16 +112,6 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
             Assertions.assertEquals(claim.getAssessedTotalVat(), result.get(0));
             Assertions.assertEquals(claim.getAssessedTotalInclVat(), result.get(1));
         }
-
-        @Test
-        void getAssessedTotalsHandlesDoNotDisplayFields() {
-            C claim = createClaim();
-            claim.setAssessedTotalVat(createClaimField("assessedTotalVat", ClaimFieldStatus.DO_NOT_DISPLAY));
-            claim.setAssessedTotalInclVat(createClaimField("assessedTotalInclVat", ClaimFieldStatus.DO_NOT_DISPLAY));
-            V viewModel = createView(claim);
-
-            Assertions.assertEquals(List.of(), viewModel.getAssessedTotals());
-        }
     }
 
     @Nested

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
@@ -29,14 +29,6 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
         return claimField;
     }
 
-    public static ClaimField createClaimField(String key, ClaimFieldStatus status, BigDecimal calculated) {
-        ClaimField claimField = new ClaimField();
-        claimField.setKey(key);
-        claimField.setStatus(status);
-        claimField.setCalculated(calculated);
-        return claimField;
-    }
-
     @Nested
     class GetAccountNumberTests {
         @Test
@@ -112,6 +104,34 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
             Assertions.assertEquals(claim.getAssessedTotalVat(), result.get(0));
             Assertions.assertEquals(claim.getAssessedTotalInclVat(), result.get(1));
         }
+
+        @Test
+        void getAssessedTotalsHandlesNonAssessableFields() {
+            C claim = createClaim();
+            claim.setAssessedTotalVat(createClaimField("assessedTotalVat", ClaimFieldStatus.NOT_MODIFIABLE));
+            claim.setAssessedTotalInclVat(createClaimField("assessedTotalInclVat", ClaimFieldStatus.NOT_MODIFIABLE));
+
+            ClaimField allowedTotal = createClaimField("allowedTotalVat", ClaimFieldStatus.MODIFIABLE);
+            ClaimField allowedTotalInclVat = createClaimField("allowedTotalInclVat", ClaimFieldStatus.MODIFIABLE);
+
+            allowedTotal.setAssessed(BigDecimal.valueOf(100));
+            allowedTotalInclVat.setAssessed(BigDecimal.valueOf(100));
+
+            claim.setAllowedTotalVat(allowedTotal);
+            claim.setAllowedTotalInclVat(allowedTotalInclVat);
+
+            Assertions.assertNull(claim.getAssessedTotalVat().getAssessed());
+            Assertions.assertNull(claim.getAssessedTotalInclVat().getAssessed());
+
+            V viewModel = createView(claim);
+
+            List<ClaimField> result = viewModel.getAssessedTotals();
+
+            Assertions.assertEquals(2, result.size());
+
+            Assertions.assertEquals(BigDecimal.valueOf(100), claim.getAssessedTotalVat().getAssessed());
+            Assertions.assertEquals(BigDecimal.valueOf(100), claim.getAssessedTotalInclVat().getAssessed());
+        }
     }
 
     @Nested
@@ -140,8 +160,16 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
         @Test
         void getAllowedTotalsHandlesValid() {
             C claim = createClaim();
-            claim.setAllowedTotalVat(createClaimField("allowedTotalVat", ClaimFieldStatus.MODIFIABLE, BigDecimal.valueOf(100)));
-            claim.setAllowedTotalInclVat(createClaimField("allowedTotalInclVat", ClaimFieldStatus.MODIFIABLE, BigDecimal.valueOf(100)));
+
+            ClaimField allowedTotal = createClaimField("allowedTotalVat", ClaimFieldStatus.MODIFIABLE);
+            ClaimField allowedTotalInclVat = createClaimField("allowedTotalInclVat", ClaimFieldStatus.MODIFIABLE);
+
+            allowedTotal.setAssessed(BigDecimal.valueOf(100));
+            allowedTotalInclVat.setAssessed(BigDecimal.valueOf(100));
+
+            claim.setAllowedTotalVat(allowedTotal);
+            claim.setAllowedTotalInclVat(allowedTotalInclVat);
+
             V viewModel = createView(claim);
 
             List<ClaimField> result = viewModel.getAllowedTotals();

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
@@ -23,15 +23,16 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
     }
 
     @Nested
-    class GetTableRowsTests {
+    class GetSummaryClaimFieldRowsTests {
         @Test
-        void rowsRenderedForClaimValues() {
+        void rowsRenderedForClaimValuesWhenClaimHasAnAssessment() {
             ClaimField fixedFee = new ClaimField("1", null, null);
             ClaimField netProfitCost = new ClaimField("2", null, null);
             ClaimField netDisbursementAmount = new ClaimField("3", null, null);
             ClaimField disbursementVatAmount = new ClaimField("4", null, null);
             ClaimField travel = new ClaimField("5", null, null);
             ClaimField waiting = new ClaimField("6", null, null);
+            ClaimField totalAmount = new ClaimField("7", null, null);
 
             CrimeClaimDetails claim = new CrimeClaimDetails();
             claim.setFixedFee(fixedFee);
@@ -40,6 +41,8 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
             claim.setDisbursementVatAmount(disbursementVatAmount);
             claim.setTravelCosts(travel);
             claim.setWaitingCosts(waiting);
+            claim.setTotalAmount(totalAmount);
+            claim.setHasAssessment(true);
 
             CrimeClaimDetailsView viewModel = new CrimeClaimDetailsView(claim);
             List<ClaimField> expectedRows = List.of(
@@ -50,7 +53,77 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
                 travel,
                 waiting
             );
-            Assertions.assertEquals(expectedRows, viewModel.getTableRows(PageType.CLAIM_DETAILS));
+
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
+        }
+
+        @Test
+        void rowsRenderedForClaimValuesWhenClaimDoesNotHaveAnAssessment() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField travel = new ClaimField("5", null, null);
+            ClaimField waiting = new ClaimField("6", null, null);
+            ClaimField totalAmount = new ClaimField("7", null, null);
+
+            CrimeClaimDetails claim = new CrimeClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setTravelCosts(travel);
+            claim.setWaitingCosts(waiting);
+            claim.setTotalAmount(totalAmount);
+            claim.setHasAssessment(false);
+
+            CrimeClaimDetailsView viewModel = new CrimeClaimDetailsView(claim);
+            List<ClaimField> expectedRows = List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                travel,
+                waiting,
+                totalAmount
+            );
+
+            Assertions.assertEquals(expectedRows, viewModel.getSummaryClaimFieldRows());
+        }
+    }
+
+    @Nested
+    class GetReviewClaimFieldRowsTests {
+        @Test
+        void rowsRenderedForClaimValues() {
+            ClaimField fixedFee = new ClaimField("1", null, null);
+            ClaimField netProfitCost = new ClaimField("2", null, null);
+            ClaimField netDisbursementAmount = new ClaimField("3", null, null);
+            ClaimField disbursementVatAmount = new ClaimField("4", null, null);
+            ClaimField travel = new ClaimField("5", null, null);
+            ClaimField waiting = new ClaimField("6", null, null);
+            ClaimField totalAmount = new ClaimField("7", null, null);
+
+            CrimeClaimDetails claim = new CrimeClaimDetails();
+            claim.setFixedFee(fixedFee);
+            claim.setNetProfitCost(netProfitCost);
+            claim.setNetDisbursementAmount(netDisbursementAmount);
+            claim.setDisbursementVatAmount(disbursementVatAmount);
+            claim.setTravelCosts(travel);
+            claim.setWaitingCosts(waiting);
+            claim.setTotalAmount(totalAmount);
+
+            CrimeClaimDetailsView viewModel = new CrimeClaimDetailsView(claim);
+            List<ClaimField> expectedRows = List.of(
+                fixedFee,
+                netProfitCost,
+                netDisbursementAmount,
+                disbursementVatAmount,
+                travel,
+                waiting
+            );
+
+            Assertions.assertEquals(expectedRows, viewModel.getReviewClaimFieldRows());
         }
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
@@ -4,11 +4,16 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.forms.errors.ReviewAndAmendFormError;
+import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDetails, CrimeClaimDetailsView> {
 
@@ -20,6 +25,60 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
     @Override
     protected CrimeClaimDetailsView createView(CrimeClaimDetails claim) {
         return new CrimeClaimDetailsView(claim);
+    }
+
+    @Nested
+    class GetSummaryRowsTests {
+        @Test
+        void createMapOfKeyValuePairs() {
+            LocalDateTime submittedDate = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+            LocalDate caseStartDate = LocalDate.of(2001, 1, 1);
+            LocalDate caseEndDate = LocalDate.of(2002, 1, 1);
+
+            CrimeClaimDetails claim = createClaim();
+            claim.setClientForename("John");
+            claim.setClientSurname("Smith");
+            claim.setUniqueFileNumber("unique file number");
+            claim.setCaseReferenceNumber("case reference number");
+            claim.setProviderName("provider name");
+            claim.setProviderAccountNumber("provider account number");
+            claim.setSubmittedDate(submittedDate);
+            claim.setAreaOfLaw("area of law");
+            claim.setCategoryOfLaw("category of law");
+            claim.setFeeCode("fee code");
+            claim.setFeeCodeDescription("fee code description");
+            claim.setPoliceStationCourtPrisonId("police station court prison id");
+            claim.setSchemeId("scheme id");
+            claim.setMatterTypeCode("matter type code");
+            claim.setCaseStartDate(caseStartDate);
+            claim.setCaseEndDate(caseEndDate);
+            claim.setEscaped(true);
+            claim.setVatApplicable(false);
+
+            CrimeClaimDetailsView viewModel = createView(claim);
+
+            Map<String, Object> result = viewModel.getSummaryRows();
+
+            Map<String, Object> expectedResult = new LinkedHashMap<>();
+            expectedResult.put("clientName", "John Smith");
+            expectedResult.put("ufn", "unique file number");
+            expectedResult.put("providerName", "provider name");
+            expectedResult.put("providerAccountNumber", "provider account number");
+            expectedResult.put("submittedDate", submittedDate);
+            expectedResult.put("areaOfLaw", "area of law");
+            expectedResult.put("categoryOfLaw", "category of law");
+            expectedResult.put("feeCode", "fee code");
+            expectedResult.put("feeCodeDescription", "fee code description");
+            expectedResult.put("policeStationCourtPrisonId", "police station court prison id");
+            expectedResult.put("schemeId", "scheme id");
+            expectedResult.put("legalMatterCode", "matter type code");
+            expectedResult.put("caseStartDate", caseStartDate);
+            expectedResult.put("caseEndDate", caseEndDate);
+            expectedResult.put("escaped", true);
+            expectedResult.put("vatRequested", false);
+
+            Assertions.assertEquals(expectedResult, result);
+        }
     }
 
     @Nested

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ChangeAssessedTotalViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ChangeAssessedTotalViewTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.views;
 
 import org.jsoup.nodes.Document;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
@@ -9,7 +10,6 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.controllers.ChangeAssessedTotalsController;
-import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimFieldStatus;
 import uk.gov.justice.laa.amend.claim.models.OutcomeType;
 
@@ -23,7 +23,9 @@ class ChangeAssessedTotalViewTest extends ViewTestBase {
     }
 
     @Override
-    protected void customiseClaim(ClaimDetails claim) {
+    @BeforeEach
+    public void setup() {
+        super.setup();
         claim.setAssessmentOutcome(OutcomeType.REDUCED_TO_FIXED_FEE);
         claim.getAssessedTotalVat().setStatus(ClaimFieldStatus.MODIFIABLE);
         claim.getAssessedTotalInclVat().setStatus(ClaimFieldStatus.MODIFIABLE);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ClaimSummaryViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ClaimSummaryViewTest.java
@@ -2,11 +2,7 @@ package uk.gov.justice.laa.amend.claim.views;
 
 import org.jetbrains.annotations.NotNull;
 import org.jsoup.nodes.Document;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
@@ -30,14 +26,11 @@ import uk.gov.justice.laa.amend.claim.service.UserRetrievalService;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.FeeCalculationPatch;
 
-import java.lang.reflect.Method;
-import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.stream.Stream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -277,47 +270,5 @@ class ClaimSummaryViewTest extends ViewTestBase {
         assertPageHasTitle(doc, "Claim details");
 
         assertPageHasHeading(doc, "Claim details");
-    }
-
-    @ParameterizedTest
-    @MethodSource("claimFieldValuesProvider")
-    void testHiddenFieldsAreDisplayed(String fieldLabel, CivilClaimDetails claimDetails, boolean display) throws Exception {
-        when(claimService.getClaimDetails(anyString(), anyString())).thenReturn(claimDetails);
-        Document doc = renderDocument();
-        Assertions.assertEquals(pageHasLabel(doc, fieldLabel), display);
-    }
-
-    static Stream<Arguments> claimFieldValuesProvider() {
-        return Stream.of(
-            Arguments.of("Adjourned hearing fee", withField(ADJOURNED_FEE, "setAdjournedHearing", 0), false),
-            Arguments.of("Adjourned hearing fee", withField(ADJOURNED_FEE, "setAdjournedHearing", 22), true),
-            Arguments.of("Adjourned hearing fee", withField(ADJOURNED_FEE, "setAdjournedHearing", null), false),
-            Arguments.of("Telephone CMRH", withField(CMRH_TELEPHONE, "setCmrhTelephone",  null), false),
-            Arguments.of("Telephone CMRH", withField(CMRH_TELEPHONE, "setCmrhTelephone",  3), true),
-            Arguments.of("Oral CMRH", withField(CMRH_ORAL, "setCmrhOral",  0), false),
-            Arguments.of("Home office interview", withField(HO_INTERVIEW, "setHoInterview",  0), false),
-            Arguments.of("Home office interview", withField(HO_INTERVIEW, "setHoInterview",  null), false),
-            Arguments.of("Substantive hearing", withField(SUBSTANTIVE_HEARING, "setSubstantiveHearing", 0), false),
-            Arguments.of("Substantive hearing", withField(SUBSTANTIVE_HEARING, "setSubstantiveHearing", 4), true),
-            Arguments.of("JR and form filling", withField(JR_FORM_FILLING, "setJrFormFillingCost", BigDecimal.ZERO), false),
-            Arguments.of("JR and form filling", withField(JR_FORM_FILLING, "setJrFormFillingCost", null), false),
-            Arguments.of("JR and form filling", withField(JR_FORM_FILLING, "setJrFormFillingCost", new BigDecimal(20)), true)
-        );
-    }
-
-    private static CivilClaimDetails withField(String label, String methodName, Object value) {
-        CivilClaimDetails claimDetails = new CivilClaimDetails();
-        claimDetails.setMatterTypeCode("IMLB:AHQS");
-        claimDetails.setAreaOfLaw("CIVIL");
-        claimDetails.setCategoryOfLaw("TEST");
-        createClaimSummary(claimDetails);
-        try {
-            Method method = CivilClaimDetails.class.getMethod(methodName, ClaimField.class);
-            method.invoke(claimDetails, new ClaimField(label, value, 10, 5));
-            return claimDetails;
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to set field: " + methodName, e);
-        }
-
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
@@ -35,9 +35,7 @@ public abstract class ViewTestBase {
   public void setup() {
     session = new MockHttpSession();
     claim = MockClaimsFunctions.createMockCivilClaim();
-    customiseClaim(claim);
   }
-  protected void customiseClaim(ClaimDetails claim) {}
 
   protected String mapping;
 


### PR DESCRIPTION
## BC-265
[Link to story](https://dsdmoj.atlassian.net/browse/BC-265)

- Bolt on Fees - where there are requested values, and Outcome = ‘Assessed in Full’ or ‘Reduced still escapes’ then display the Assessed Value as ‘Not Applicable’
- Moved `display()` logic out of `ClaimField` and into the view models

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

