### PR TITLE
Bc 384

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/handlers/ClaimStatusHandler.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/handlers/ClaimStatusHandler.java
@@ -8,8 +8,6 @@ import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.OutcomeType;
 import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 
-import java.util.Objects;
-
 /**
  * Handles the mapping between different outcome types and their corresponding field assessment statuses.
  */
@@ -30,12 +28,7 @@ public class ClaimStatusHandler {
     }
 
     private void updateFieldStatus(ClaimField field, OutcomeType outcome, ClaimDetails claim) {
-        boolean status = determineFieldStatus(field, outcome, claim);
-        field.setAssessable(status);
-    }
-
-    private boolean determineFieldStatus(ClaimField field, OutcomeType outcome, ClaimDetails claim) {
-        return switch (outcome) {
+        switch (outcome) {
             case NILLED -> handleNilledStatus(field);
             case PAID_IN_FULL -> handleAssessmentInFullStatus(field, claim);
             case REDUCED -> handleReducedStatus(field, claim);
@@ -43,34 +36,36 @@ public class ClaimStatusHandler {
         };
     }
 
-    private boolean handleNilledStatus(ClaimField field) {
-        return field instanceof VatLiabilityClaimField;
+    private void handleNilledStatus(ClaimField field) {
+        field.setAssessable(field instanceof VatLiabilityClaimField);
     }
 
     /**
      * Set the field status for REDUCED outcome status.
      */
-    private boolean handleReducedStatus(ClaimField field, ClaimDetails claim) {
+    private void handleReducedStatus(ClaimField field, ClaimDetails claim) {
         if (field instanceof AssessedClaimField) {
-            return claim.isAssessedTotalFieldAssessable();
+            field.setAssessable(claim.isAssessedTotalFieldAssessable());
+        } else {
+            field.setAssessableToDefault();
         }
-        return field.isAssessable();
     }
 
     /**
      * Set the field status for REDUCED_TO_FIXED_FEE outcome status.
      */
-    private boolean handleReducedToFixedFeeStatus(ClaimField field) {
-        return field.isAssessable();
+    private void handleReducedToFixedFeeStatus(ClaimField field) {
+        field.setAssessableToDefault();
     }
 
     /**
      * Set the field status for PAID_IN_FULL outcome status.
      */
-    private boolean handleAssessmentInFullStatus(ClaimField field, ClaimDetails claim) {
+    private void handleAssessmentInFullStatus(ClaimField field, ClaimDetails claim) {
         if (field instanceof AssessedClaimField) {
-            return claim.isAssessedTotalFieldAssessable();
+            field.setAssessable(claim.isAssessedTotalFieldAssessable());
+        } else {
+            field.setAssessableToDefault();
         }
-        return field.isAssessable();
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/handlers/ClaimStatusHandler.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/handlers/ClaimStatusHandler.java
@@ -33,7 +33,8 @@ public class ClaimStatusHandler {
             case PAID_IN_FULL -> handleAssessmentInFullStatus(field, claim);
             case REDUCED -> handleReducedStatus(field, claim);
             case REDUCED_TO_FIXED_FEE -> handleReducedToFixedFeeStatus(field);
-        };
+            default -> { }
+        }
     }
 
     private void handleNilledStatus(ClaimField field) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperHelper.java
@@ -10,6 +10,7 @@ import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.Cost;
 import uk.gov.justice.laa.amend.claim.models.CostClaimField;
 import uk.gov.justice.laa.amend.claim.models.FixedFeeClaimField;
+import uk.gov.justice.laa.amend.claim.models.TotalType;
 import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.FeeCalculationPatch;
@@ -172,12 +173,12 @@ public class ClaimMapperHelper {
 
     @Named("mapAssessedTotalVat")
     public ClaimField mapAssessedTotalVat() {
-        return new AssessedClaimField(ASSESSED_TOTAL_VAT);
+        return new AssessedClaimField(ASSESSED_TOTAL_VAT, TotalType.TOTAL_VAT);
     }
 
     @Named("mapAssessedTotalInclVat")
     public ClaimField mapAssessedTotalInclVat() {
-        return new AssessedClaimField(ASSESSED_TOTAL_INCL_VAT);
+        return new AssessedClaimField(ASSESSED_TOTAL_INCL_VAT, TotalType.TOTAL_INCL_VAT);
     }
 
     @Named("mapAllowedTotalVat")

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/AllowedClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/AllowedClaimField.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
 public class AllowedClaimField extends ClaimField {
 
@@ -21,5 +22,10 @@ public class AllowedClaimField extends ClaimField {
             case REDUCED, PAID_IN_FULL, REDUCED_TO_FIXED_FEE -> setAssessedToNull();
             default -> { }
         }
+    }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/AllowedClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/AllowedClaimField.java
@@ -8,6 +8,10 @@ public class AllowedClaimField extends ClaimField {
     @Builder
     public AllowedClaimField(String key, Object submitted, Object calculated, Object assessed) {
         super(key, submitted, calculated, assessed);
+    }
+
+    @Override
+    public void setAssessableToDefault() {
         this.assessable = true;
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/AssessedClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/AssessedClaimField.java
@@ -1,21 +1,32 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
+import lombok.Getter;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
+@Getter
 public class AssessedClaimField extends ClaimField {
 
+    protected final TotalType type;
+
     @Builder
-    public AssessedClaimField(String key, Object submitted, Object calculated, Object assessed) {
+    public AssessedClaimField(String key, Object submitted, Object calculated, Object assessed, TotalType type) {
         super(key, submitted, calculated, assessed);
         this.assessable = true;
+        this.type = type;
     }
 
-    public AssessedClaimField(String key) {
-        this(key, null, null, null);
+    public AssessedClaimField(String key, TotalType type) {
+        this(key, null, null, null, type);
     }
 
     @Override
     public void applyOutcome(OutcomeType outcome) {
         setAssessedToNull();
+    }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this, claim);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/AssessedClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/AssessedClaimField.java
@@ -12,7 +12,6 @@ public class AssessedClaimField extends ClaimField {
     @Builder
     public AssessedClaimField(String key, Object submitted, Object calculated, Object assessed, TotalType type) {
         super(key, submitted, calculated, assessed);
-        this.assessable = true;
         this.type = type;
     }
 
@@ -23,6 +22,11 @@ public class AssessedClaimField extends ClaimField {
     @Override
     public void applyOutcome(OutcomeType outcome) {
         setAssessedToNull();
+    }
+
+    @Override
+    public void setAssessableToDefault() {
+        this.assessable = true;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/BoltOnClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/BoltOnClaimField.java
@@ -8,6 +8,10 @@ public class BoltOnClaimField extends ClaimField {
     @Builder
     public BoltOnClaimField(String key, Object submitted, Object calculated, Object assessed) {
         super(key, submitted, calculated, assessed);
+    }
+
+    @Override
+    public void setAssessableToDefault() {
         this.assessable = false;
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/BoltOnClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/BoltOnClaimField.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
 public class BoltOnClaimField extends ClaimField {
 
@@ -22,5 +23,10 @@ public class BoltOnClaimField extends ClaimField {
             case REDUCED, PAID_IN_FULL -> setAssessedToNull();
             default -> { }
         }
+    }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/CalculatedTotalClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/CalculatedTotalClaimField.java
@@ -10,7 +10,6 @@ public class CalculatedTotalClaimField extends ClaimField {
     @Builder
     public CalculatedTotalClaimField(Object submitted, Object calculated, Object assessed) {
         super(TOTAL, submitted, calculated, assessed);
-        this.assessable = false;
     }
 
     public CalculatedTotalClaimField(Object submitted, Object calculated) {
@@ -19,6 +18,11 @@ public class CalculatedTotalClaimField extends ClaimField {
 
     @Override
     public void applyOutcome(OutcomeType outcome) { }
+
+    @Override
+    public void setAssessableToDefault() {
+        this.assessable = false;
+    }
 
     @Override
     public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/CalculatedTotalClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/CalculatedTotalClaimField.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.TOTAL;
 
@@ -17,6 +18,10 @@ public class CalculatedTotalClaimField extends ClaimField {
     }
 
     @Override
-    public void applyOutcome(OutcomeType outcome) {
+    public void applyOutcome(OutcomeType outcome) { }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
@@ -22,6 +22,7 @@ public abstract class ClaimField implements Serializable {
         this.submitted = submitted;
         this.calculated = calculated;
         this.assessed = assessed;
+        setAssessableToDefault();
     }
 
     public boolean hasSubmittedValue() {
@@ -37,6 +38,8 @@ public abstract class ClaimField implements Serializable {
             default -> false;
         };
     }
+
+    public abstract void setAssessableToDefault();
 
     public boolean isNotAssessable() {
         return !isAssessable();

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimField.java
@@ -41,12 +41,7 @@ public abstract class ClaimField implements Serializable {
         return !isAssessable();
     }
 
-    public ClaimFieldRow toClaimFieldRow() {
-        if (this instanceof BoltOnClaimField x) {
-            return hasSubmittedValue() ? new ClaimFieldRow(x) : null;
-        }
-        return new ClaimFieldRow(this);
-    }
+    public abstract ClaimFieldRow toClaimFieldRow(ClaimDetails claim);
 
     public abstract void applyOutcome(OutcomeType outcome);
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/CostClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/CostClaimField.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
 import lombok.Getter;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
 import java.util.Objects;
 
@@ -42,5 +43,10 @@ public class CostClaimField extends ClaimField {
             case PAID_IN_FULL -> setAssessedToSubmitted();
             default -> { }
         }
+    }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/CostClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/CostClaimField.java
@@ -14,7 +14,6 @@ public class CostClaimField extends ClaimField {
     @Builder
     public CostClaimField(String key, Object submitted, Object calculated, Object assessed, Cost cost) {
         super(key, submitted, calculated, assessed);
-        this.assessable = true;
         this.cost = Objects.requireNonNull(cost, "Cost must not be null for CostClaimField");
     }
 
@@ -43,6 +42,11 @@ public class CostClaimField extends ClaimField {
             case PAID_IN_FULL -> setAssessedToSubmitted();
             default -> { }
         }
+    }
+
+    @Override
+    public void setAssessableToDefault() {
+        this.assessable = true;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/FixedFeeClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/FixedFeeClaimField.java
@@ -10,7 +10,6 @@ public class FixedFeeClaimField extends ClaimField {
     @Builder
     public FixedFeeClaimField(Object submitted, Object calculated, Object assessed) {
         super(FIXED_FEE, submitted, calculated, assessed);
-        this.assessable = false;
     }
 
     public FixedFeeClaimField(Object calculated) {
@@ -25,6 +24,11 @@ public class FixedFeeClaimField extends ClaimField {
             case REDUCED, PAID_IN_FULL -> setAssessedToNull();
             default -> { }
         }
+    }
+
+    @Override
+    public void setAssessableToDefault() {
+        this.assessable = false;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/FixedFeeClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/FixedFeeClaimField.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.FIXED_FEE;
 
@@ -24,5 +25,10 @@ public class FixedFeeClaimField extends ClaimField {
             case REDUCED, PAID_IN_FULL -> setAssessedToNull();
             default -> { }
         }
+    }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/TotalType.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/TotalType.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.laa.amend.claim.models;
+
+public enum TotalType {
+
+    TOTAL_VAT,
+    TOTAL_INCL_VAT
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/VatLiabilityClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/VatLiabilityClaimField.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import lombok.Builder;
+import uk.gov.justice.laa.amend.claim.viewmodels.ClaimFieldRow;
 
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.VAT;
 
@@ -23,5 +24,10 @@ public class VatLiabilityClaimField extends ClaimField {
             case REDUCED, PAID_IN_FULL -> setAssessedToSubmitted();
             default -> { }
         }
+    }
+
+    @Override
+    public ClaimFieldRow toClaimFieldRow(ClaimDetails claim) {
+        return ClaimFieldRow.from(this);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/VatLiabilityClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/VatLiabilityClaimField.java
@@ -10,7 +10,6 @@ public class VatLiabilityClaimField extends ClaimField {
     @Builder
     public VatLiabilityClaimField(Object submitted, Object calculated, Object assessed) {
         super(VAT, submitted, calculated, assessed);
-        this.assessable = true;
     }
 
     public VatLiabilityClaimField(Object submitted, Object calculated) {
@@ -24,6 +23,11 @@ public class VatLiabilityClaimField extends ClaimField {
             case REDUCED, PAID_IN_FULL -> setAssessedToSubmitted();
             default -> { }
         }
+    }
+
+    @Override
+    public void setAssessableToDefault() {
+        this.assessable = true;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -126,7 +126,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
     private Stream<ClaimFieldRow> toClaimFieldRows(Stream<ClaimField> claimFields) {
         return claimFields
             .filter(Objects::nonNull)
-            .map(ClaimField::toClaimFieldRow)
+            .map(x -> x.toClaimFieldRow(claim()))
             .filter(Objects::nonNull);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
@@ -1,16 +1,21 @@
 package uk.gov.justice.laa.amend.claim.viewmodels;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import uk.gov.justice.laa.amend.claim.models.AllowedClaimField;
 import uk.gov.justice.laa.amend.claim.models.AssessedClaimField;
-import uk.gov.justice.laa.amend.claim.models.ClaimField;
+import uk.gov.justice.laa.amend.claim.models.BoltOnClaimField;
+import uk.gov.justice.laa.amend.claim.models.CalculatedTotalClaimField;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.CostClaimField;
+import uk.gov.justice.laa.amend.claim.models.FixedFeeClaimField;
 import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 import uk.gov.justice.laa.amend.claim.utils.FormUtils;
 
 import static uk.gov.justice.laa.amend.claim.utils.NumberUtils.getOrElseZero;
 
 @Getter
+@AllArgsConstructor
 public class ClaimFieldRow {
 
     private final String key;
@@ -20,33 +25,108 @@ public class ClaimFieldRow {
     private final boolean assessable;
     private final String changeUrl;
 
-    public ClaimFieldRow(ClaimField claimField) {
-        this.key = claimField.getKey();
-        this.submitted = claimField.getSubmitted();
-        this.calculated = claimField.getCalculated();
-        this.assessed = claimField.getAssessed();
-        this.assessable = claimField.isAssessable();
+    public static ClaimFieldRow from(AllowedClaimField claimField) {
+        return new ClaimFieldRow(
+            claimField.getKey(),
+            claimField.getSubmitted(),
+            getOrElseZero(claimField.getCalculated()),
+            claimField.getAssessed(),
+            claimField.isAssessable(),
+            "/submissions/%s/claims/%s/allowed-totals"
+        );
+    }
 
-        switch (claimField) {
-            case CostClaimField x -> {
-                switch (x.getCost()) {
-                    case PROFIT_COSTS, DISBURSEMENTS, DISBURSEMENTS_VAT -> { }
-                    default -> {
-                        this.submitted = getOrElseZero(submitted);
-                        this.calculated = getOrElseZero(calculated);
-                        this.assessed = getOrElseZero(assessed);
-                    }
-                }
-                this.changeUrl = x.getCost().getChangeUrl();
+    public static ClaimFieldRow from(AssessedClaimField claimField, ClaimDetails claim) {
+        Object assessed;
+        if (claimField.getAssessed() == null) {
+            switch (claimField.getType()) {
+                case TOTAL_VAT -> assessed = claim.getAllowedTotalVat().getAssessed();
+                case TOTAL_INCL_VAT -> assessed = claim.getAllowedTotalInclVat().getAssessed();
+                default -> assessed = null;
             }
-            case AllowedClaimField x -> {
-                this.calculated = getOrElseZero(calculated);
-                this.changeUrl = "/submissions/%s/claims/%s/allowed-totals";
-            }
-            case AssessedClaimField x -> this.changeUrl = "/submissions/%s/claims/%s/assessed-totals";
-            case VatLiabilityClaimField x -> this.changeUrl = "/submissions/%s/claims/%s/assessment-outcome";
-            default -> this.changeUrl = null;
+        } else {
+            assessed = claimField.getAssessed();
         }
+        return new ClaimFieldRow(
+            claimField.getKey(),
+            claimField.getSubmitted(),
+            claimField.getCalculated(),
+            assessed,
+            claimField.isAssessable(),
+            "/submissions/%s/claims/%s/assessed-totals"
+        );
+    }
+
+    public static ClaimFieldRow from(BoltOnClaimField claimField) {
+        return claimField.hasSubmittedValue() ?
+            new ClaimFieldRow(
+                claimField.getKey(),
+                claimField.getSubmitted(),
+                claimField.getCalculated(),
+                claimField.getAssessed(),
+                claimField.isAssessable(),
+                null
+            ) :
+            null;
+    }
+
+    public static ClaimFieldRow from(CostClaimField claimField) {
+        Object submitted;
+        Object calculated;
+        Object assessed;
+        switch (claimField.getCost()) {
+            case PROFIT_COSTS, DISBURSEMENTS, DISBURSEMENTS_VAT -> {
+                submitted = claimField.getSubmitted();
+                calculated = claimField.getCalculated();
+                assessed = claimField.getAssessed();
+            }
+            default -> {
+                submitted = getOrElseZero(claimField.getSubmitted());
+                calculated = getOrElseZero(claimField.getCalculated());
+                assessed = getOrElseZero(claimField.getAssessed());
+            }
+        }
+        return new ClaimFieldRow(
+            claimField.getKey(),
+            submitted,
+            calculated,
+            assessed,
+            claimField.isAssessable(),
+            claimField.getCost().getChangeUrl()
+        );
+    }
+
+    public static ClaimFieldRow from(CalculatedTotalClaimField claimField) {
+        return new ClaimFieldRow(
+            claimField.getKey(),
+            claimField.getSubmitted(),
+            claimField.getCalculated(),
+            claimField.getAssessed(),
+            claimField.isAssessable(),
+            null
+        );
+    }
+
+    public static ClaimFieldRow from(FixedFeeClaimField claimField) {
+        return new ClaimFieldRow(
+            claimField.getKey(),
+            claimField.getSubmitted(),
+            claimField.getCalculated(),
+            claimField.getAssessed(),
+            claimField.isAssessable(),
+            null
+        );
+    }
+
+    public static ClaimFieldRow from(VatLiabilityClaimField claimField) {
+        return new ClaimFieldRow(
+            claimField.getKey(),
+            claimField.getSubmitted(),
+            claimField.getCalculated(),
+            claimField.getAssessed(),
+            claimField.isAssessable(),
+            "/submissions/%s/claims/%s/assessment-outcome"
+        );
     }
 
     public String getLabel() {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
@@ -58,16 +58,17 @@ public class ClaimFieldRow {
     }
 
     public static ClaimFieldRow from(BoltOnClaimField claimField) {
-        return claimField.hasSubmittedValue() ?
-            new ClaimFieldRow(
+        if (claimField.hasSubmittedValue()) {
+            return new ClaimFieldRow(
                 claimField.getKey(),
                 claimField.getSubmitted(),
                 claimField.getCalculated(),
                 claimField.getAssessed(),
                 claimField.isAssessable(),
                 null
-            ) :
-            null;
+            );
+        }
+        return null;
     }
 
     public static ClaimFieldRow from(CostClaimField claimField) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperTest.java
@@ -7,10 +7,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants;
+import uk.gov.justice.laa.amend.claim.models.AssessedClaimField;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.TotalType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AreaOfLaw;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.BoltOnPatch;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponse;
@@ -410,11 +412,12 @@ class ClaimMapperTest {
 
         CrimeClaimDetails claim = (CrimeClaimDetails) mapper.mapToClaimDetails(response, submissionResponse);
 
-        ClaimField claimField = claim.getAssessedTotalVat();
+        AssessedClaimField claimField = (AssessedClaimField) claim.getAssessedTotalVat();
         assertEquals(AmendClaimConstants.Label.ASSESSED_TOTAL_VAT, claimField.getKey());
         assertNull(claimField.getSubmitted());
         assertNull(claimField.getCalculated());
         assertNull(claimField.getAssessed());
+        assertEquals(TotalType.TOTAL_VAT, claimField.getType());
     }
 
     @Test
@@ -425,11 +428,12 @@ class ClaimMapperTest {
 
         CrimeClaimDetails claim = (CrimeClaimDetails) mapper.mapToClaimDetails(response, submissionResponse);
 
-        ClaimField claimField = claim.getAssessedTotalInclVat();
+        AssessedClaimField claimField = (AssessedClaimField) claim.getAssessedTotalInclVat();
         assertEquals(AmendClaimConstants.Label.ASSESSED_TOTAL_INCL_VAT, claimField.getKey());
         assertNull(claimField.getSubmitted());
         assertNull(claimField.getCalculated());
         assertNull(claimField.getAssessed());
+        assertEquals(TotalType.TOTAL_INCL_VAT, claimField.getType());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimStatusHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimStatusHandlerTest.java
@@ -276,6 +276,26 @@ class ClaimStatusHandlerTest {
             assertThat(jrFormFillingCostField.isAssessable()).isTrue();
             assertThat(counselsCostField.isAssessable()).isTrue();
         }
+
+        @Test
+        void shouldResetWhetherAFieldIsAssessableOrNotAfterOutcomeChange() {
+            CrimeClaimDetails crimeClaim = new CrimeClaimDetails();
+            ClaimField assessedTotalVatField = MockClaimsFunctions.createAssessedTotalVatField();
+            ClaimField assessedTotalInclVatField = MockClaimsFunctions.createAssessedTotalInclVatField();
+            crimeClaim.setAssessedTotalVat(assessedTotalVatField);
+            crimeClaim.setAssessedTotalInclVat(assessedTotalInclVatField);
+            crimeClaim.setFeeCode("INVC");
+
+            claimStatusHandler.updateFieldStatuses(crimeClaim, OutcomeType.NILLED);
+
+            assertThat(assessedTotalVatField.isAssessable()).isFalse();
+            assertThat(assessedTotalInclVatField.isAssessable()).isFalse();
+
+            claimStatusHandler.updateFieldStatuses(crimeClaim, OutcomeType.REDUCED);
+
+            assertThat(assessedTotalVatField.isAssessable()).isTrue();
+            assertThat(assessedTotalInclVatField.isAssessable()).isTrue();
+        }
     }
 
     @Nested

--- a/src/test/java/uk/gov/justice/laa/amend/claim/resources/MockClaimsFunctions.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/resources/MockClaimsFunctions.java
@@ -13,6 +13,7 @@ import uk.gov.justice.laa.amend.claim.models.CostClaimField;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.FixedFeeClaimField;
 import uk.gov.justice.laa.amend.claim.models.OutcomeType;
+import uk.gov.justice.laa.amend.claim.models.TotalType;
 import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 
 import java.math.BigDecimal;
@@ -104,39 +105,39 @@ public class MockClaimsFunctions {
         return claimField;
     }
 
-    public static ClaimField createNetProfitCostField() {
+    public static CostClaimField createNetProfitCostField() {
         return createCostField(NET_PROFIT_COST, Cost.PROFIT_COSTS);
     }
 
-    public static ClaimField createDisbursementCostField() {
+    public static CostClaimField createDisbursementCostField() {
         return createCostField(NET_DISBURSEMENTS_COST, Cost.DISBURSEMENTS);
     }
 
-    public static ClaimField createDisbursementVatCostField() {
+    public static CostClaimField createDisbursementVatCostField() {
         return createCostField(DISBURSEMENT_VAT, Cost.DISBURSEMENTS_VAT);
     }
 
-    public static ClaimField createCounselCostField() {
+    public static CostClaimField createCounselCostField() {
         return createCostField(COUNSELS_COST, Cost.COUNSEL_COSTS);
     }
 
-    public static ClaimField createTravelCostField() {
+    public static CostClaimField createTravelCostField() {
         return createCostField(TRAVEL_COSTS, Cost.TRAVEL_COSTS);
     }
 
-    public static ClaimField createWaitingCostField() {
+    public static CostClaimField createWaitingCostField() {
         return createCostField(WAITING_COSTS, Cost.WAITING_COSTS);
     }
 
-    public static ClaimField createJrFormFillingCostField() {
+    public static CostClaimField createJrFormFillingCostField() {
         return createCostField(JR_FORM_FILLING, Cost.JR_FORM_FILLING_COSTS);
     }
 
-    public static ClaimField createDetentionCostField() {
+    public static CostClaimField createDetentionCostField() {
         return createCostField(DETENTION_TRAVEL_COST, Cost.DETENTION_TRAVEL_AND_WAITING_COSTS);
     }
     
-    private static ClaimField createCostField(String key, Cost cost) {
+    private static CostClaimField createCostField(String key, Cost cost) {
         return CostClaimField
             .builder()
             .key(key)
@@ -147,7 +148,7 @@ public class MockClaimsFunctions {
             .build();
     }
 
-    public static ClaimField createFixedFeeField() {
+    public static FixedFeeClaimField createFixedFeeField() {
         return FixedFeeClaimField
             .builder()
             .submitted(BigDecimal.valueOf(100))
@@ -156,7 +157,7 @@ public class MockClaimsFunctions {
             .build();
     }
 
-    public static ClaimField createTotalAmountField() {
+    public static CalculatedTotalClaimField createTotalAmountField() {
         return CalculatedTotalClaimField
             .builder()
             .submitted(BigDecimal.valueOf(100))
@@ -165,7 +166,7 @@ public class MockClaimsFunctions {
             .build();
     }
 
-    public static ClaimField createVatClaimedField() {
+    public static VatLiabilityClaimField createVatClaimedField() {
         return VatLiabilityClaimField
             .builder()
             .submitted(true)
@@ -174,27 +175,27 @@ public class MockClaimsFunctions {
             .build();
     }
 
-    public static ClaimField createAdjournedHearingField() {
+    public static BoltOnClaimField createAdjournedHearingField() {
         return createBoltOnField(ADJOURNED_FEE);
     }
 
-    public static ClaimField createCmrhOralField() {
+    public static BoltOnClaimField createCmrhOralField() {
         return createBoltOnField(CMRH_ORAL);
     }
 
-    public static ClaimField createCmrhTelephoneField() {
+    public static BoltOnClaimField createCmrhTelephoneField() {
         return createBoltOnField(CMRH_TELEPHONE);
     }
 
-    public static ClaimField createHoInterviewField() {
+    public static BoltOnClaimField createHoInterviewField() {
         return createBoltOnField(HO_INTERVIEW);
     }
 
-    public static ClaimField createSubstantiveHearingField() {
+    public static BoltOnClaimField createSubstantiveHearingField() {
         return createBoltOnField(SUBSTANTIVE_HEARING);
     }
 
-    private static ClaimField createBoltOnField(String key) {
+    private static BoltOnClaimField createBoltOnField(String key) {
         return BoltOnClaimField
             .builder()
             .key(key)
@@ -204,33 +205,34 @@ public class MockClaimsFunctions {
             .build();
     }
 
-    public static ClaimField createAssessedTotalVatField() {
-        return createAssessedTotalField(ASSESSED_TOTAL_VAT);
+    public static AssessedClaimField createAssessedTotalVatField() {
+        return createAssessedTotalField(ASSESSED_TOTAL_VAT, TotalType.TOTAL_VAT);
     }
 
-    public static ClaimField createAssessedTotalInclVatField() {
-        return createAssessedTotalField(ASSESSED_TOTAL_INCL_VAT);
+    public static AssessedClaimField createAssessedTotalInclVatField() {
+        return createAssessedTotalField(ASSESSED_TOTAL_INCL_VAT, TotalType.TOTAL_INCL_VAT);
     }
 
-    private static ClaimField createAssessedTotalField(String key) {
+    private static AssessedClaimField createAssessedTotalField(String key, TotalType type) {
         return AssessedClaimField
             .builder()
             .key(key)
             .submitted(BigDecimal.valueOf(100))
             .calculated(BigDecimal.valueOf(200))
             .assessed(BigDecimal.valueOf(300))
+            .type(type)
             .build();
     }
 
-    public static ClaimField createAllowedTotalVatField() {
+    public static AllowedClaimField createAllowedTotalVatField() {
         return createAllowedTotalField(ALLOWED_TOTAL_VAT);
     }
 
-    public static ClaimField createAllowedTotalInclVatField() {
+    public static AllowedClaimField createAllowedTotalInclVatField() {
         return createAllowedTotalField(ALLOWED_TOTAL_INCL_VAT);
     }
 
-    private static ClaimField createAllowedTotalField(String key) {
+    private static AllowedClaimField createAllowedTotalField(String key) {
         return AllowedClaimField
             .builder()
             .key(key)

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRowTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRowTest.java
@@ -2,8 +2,16 @@ package uk.gov.justice.laa.amend.claim.viewmodels;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.amend.claim.models.AllowedClaimField;
+import uk.gov.justice.laa.amend.claim.models.AssessedClaimField;
+import uk.gov.justice.laa.amend.claim.models.BoltOnClaimField;
+import uk.gov.justice.laa.amend.claim.models.CalculatedTotalClaimField;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.Cost;
+import uk.gov.justice.laa.amend.claim.models.CostClaimField;
+import uk.gov.justice.laa.amend.claim.models.FixedFeeClaimField;
+import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 
 import java.math.BigDecimal;
@@ -12,8 +20,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenProfitCostClaimField() {
-        ClaimField field = MockClaimsFunctions.createNetProfitCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createNetProfitCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -24,8 +32,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenDisbursementsClaimField() {
-        ClaimField field = MockClaimsFunctions.createDisbursementCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createDisbursementCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -36,8 +44,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenDisbursementsVatClaimField() {
-        ClaimField field = MockClaimsFunctions.createDisbursementVatCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createDisbursementVatCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -48,11 +56,11 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenTravelCostClaimFieldWhenValuesAreNull() {
-        ClaimField field = MockClaimsFunctions.createTravelCostField();
+        CostClaimField field = MockClaimsFunctions.createTravelCostField();
         field.setSubmitted(null);
         field.setCalculated(null);
         field.setAssessed(null);
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
         Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
@@ -63,8 +71,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenTravelCostClaimFieldWhenValuesAreNotNull() {
-        ClaimField field = MockClaimsFunctions.createTravelCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createTravelCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -75,11 +83,11 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenWaitingCostClaimFieldWhenValuesAreNull() {
-        ClaimField field = MockClaimsFunctions.createWaitingCostField();
+        CostClaimField field = MockClaimsFunctions.createWaitingCostField();
         field.setSubmitted(null);
         field.setCalculated(null);
         field.setAssessed(null);
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
         Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
@@ -90,8 +98,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenWaitingCostClaimFieldWhenValuesAreNotNull() {
-        ClaimField field = MockClaimsFunctions.createWaitingCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createWaitingCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -102,11 +110,11 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenDetentionCostClaimFieldWhenValuesAreNull() {
-        ClaimField field = MockClaimsFunctions.createDetentionCostField();
+        CostClaimField field = MockClaimsFunctions.createDetentionCostField();
         field.setSubmitted(null);
         field.setCalculated(null);
         field.setAssessed(null);
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
         Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
@@ -117,8 +125,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenDetentionCostClaimFieldWhenValuesAreNotNull() {
-        ClaimField field = MockClaimsFunctions.createDetentionCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createDetentionCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -129,11 +137,11 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenJrFormFillingCostClaimFieldWhenValuesAreNull() {
-        ClaimField field = MockClaimsFunctions.createJrFormFillingCostField();
+        CostClaimField field = MockClaimsFunctions.createJrFormFillingCostField();
         field.setSubmitted(null);
         field.setCalculated(null);
         field.setAssessed(null);
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
         Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
@@ -144,8 +152,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenJrFormFillingCostClaimFieldWhenValuesAreNotNull() {
-        ClaimField field = MockClaimsFunctions.createJrFormFillingCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createJrFormFillingCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -156,11 +164,11 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenCounselCostClaimFieldWhenValuesAreNull() {
-        ClaimField field = MockClaimsFunctions.createCounselCostField();
+        CostClaimField field = MockClaimsFunctions.createCounselCostField();
         field.setSubmitted(null);
         field.setCalculated(null);
         field.setAssessed(null);
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
         Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
@@ -171,8 +179,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenCounselCostClaimFieldWhenValuesAreNotNull() {
-        ClaimField field = MockClaimsFunctions.createCounselCostField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CostClaimField field = MockClaimsFunctions.createCounselCostField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -183,11 +191,11 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenAllowedClaimFieldWhenValuesAreNull() {
-        ClaimField field = MockClaimsFunctions.createAllowedTotalVatField();
+        AllowedClaimField field = MockClaimsFunctions.createAllowedTotalVatField();
         field.setSubmitted(null);
         field.setCalculated(null);
         field.setAssessed(null);
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertNull(result.getSubmitted());
         Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
@@ -198,8 +206,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenAllowedClaimFieldWhenValuesAreNotNull() {
-        ClaimField field = MockClaimsFunctions.createAllowedTotalVatField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        AllowedClaimField field = MockClaimsFunctions.createAllowedTotalVatField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -210,8 +218,9 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenAssessedClaimField() {
-        ClaimField field = MockClaimsFunctions.createAssessedTotalVatField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        AssessedClaimField field = MockClaimsFunctions.createAssessedTotalVatField();
+        ClaimFieldRow result = ClaimFieldRow.from(field, claim);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -221,9 +230,75 @@ public class ClaimFieldRowTest {
     }
 
     @Test
+    void whenAssessedTotalVatClaimFieldHasAssessedValue() {
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        ClaimField allowedField = MockClaimsFunctions.createAllowedTotalVatField();
+        claim.setAllowedTotalVat(allowedField);
+        ClaimField assessedField = MockClaimsFunctions.createAssessedTotalVatField();
+        ClaimFieldRow result = assessedField.toClaimFieldRow(claim);
+        Assertions.assertEquals(assessedField.getAssessed(), result.getAssessed());
+    }
+
+    @Test
+    void whenAssessedTotalVatClaimFieldHasNullAssessedValueAndAllowedTotalVatHasAssessedValue() {
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        ClaimField allowedField = MockClaimsFunctions.createAllowedTotalVatField();
+        claim.setAllowedTotalVat(allowedField);
+        ClaimField assessedField = MockClaimsFunctions.createAssessedTotalVatField();
+        assessedField.setAssessed(null);
+        ClaimFieldRow result = assessedField.toClaimFieldRow(claim);
+        Assertions.assertEquals(allowedField.getAssessed(), result.getAssessed());
+    }
+
+    @Test
+    void whenAssessedTotalVatClaimFieldHasNullAssessedValueAndAllowedTotalVatHasNullAssessedValue() {
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        ClaimField allowedField = MockClaimsFunctions.createAllowedTotalVatField();
+        allowedField.setAssessed(null);
+        claim.setAllowedTotalVat(allowedField);
+        ClaimField assessedField = MockClaimsFunctions.createAssessedTotalVatField();
+        assessedField.setAssessed(null);
+        ClaimFieldRow result = assessedField.toClaimFieldRow(claim);
+        Assertions.assertNull(result.getAssessed());
+    }
+
+    @Test
+    void whenAssessedTotalInclVatClaimFieldHasAssessedValue() {
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        ClaimField allowedField = MockClaimsFunctions.createAllowedTotalInclVatField();
+        claim.setAllowedTotalInclVat(allowedField);
+        ClaimField assessedField = MockClaimsFunctions.createAssessedTotalInclVatField();
+        ClaimFieldRow result = assessedField.toClaimFieldRow(claim);
+        Assertions.assertEquals(assessedField.getAssessed(), result.getAssessed());
+    }
+
+    @Test
+    void whenAssessedTotalInclVatClaimFieldHasNullAssessedValueAndAllowedTotalInclVatHasAssessedValue() {
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        ClaimField allowedField = MockClaimsFunctions.createAllowedTotalInclVatField();
+        claim.setAllowedTotalInclVat(allowedField);
+        ClaimField assessedField = MockClaimsFunctions.createAssessedTotalInclVatField();
+        assessedField.setAssessed(null);
+        ClaimFieldRow result = assessedField.toClaimFieldRow(claim);
+        Assertions.assertEquals(allowedField.getAssessed(), result.getAssessed());
+    }
+
+    @Test
+    void whenAssessedTotalInclVatClaimFieldHasNullAssessedValueAndAllowedTotalInclVatHasNullAssessedValue() {
+        ClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        ClaimField allowedField = MockClaimsFunctions.createAllowedTotalInclVatField();
+        allowedField.setAssessed(null);
+        claim.setAllowedTotalInclVat(allowedField);
+        ClaimField assessedField = MockClaimsFunctions.createAssessedTotalInclVatField();
+        assessedField.setAssessed(null);
+        ClaimFieldRow result = assessedField.toClaimFieldRow(claim);
+        Assertions.assertNull(result.getAssessed());
+    }
+
+    @Test
     void whenVatLiabilityClaimField() {
-        ClaimField field = MockClaimsFunctions.createVatClaimedField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        VatLiabilityClaimField field = MockClaimsFunctions.createVatClaimedField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -234,8 +309,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenBoltOnClaimField() {
-        ClaimField field = MockClaimsFunctions.createAdjournedHearingField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        BoltOnClaimField field = MockClaimsFunctions.createAdjournedHearingField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -245,9 +320,33 @@ public class ClaimFieldRowTest {
     }
 
     @Test
+    void whenBoltOnClaimFieldWithNullSubmittedValue() {
+        BoltOnClaimField field = MockClaimsFunctions.createAdjournedHearingField();
+        field.setSubmitted(null);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void whenBoltOnClaimFieldWithZeroSubmittedValue() {
+        BoltOnClaimField field = MockClaimsFunctions.createAdjournedHearingField();
+        field.setSubmitted(BigDecimal.ZERO);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void whenBoltOnClaimFieldWithNonZeroSubmittedValue() {
+        BoltOnClaimField field = MockClaimsFunctions.createAdjournedHearingField();
+        field.setSubmitted(BigDecimal.ONE);
+        ClaimFieldRow result = ClaimFieldRow.from(field);
+        Assertions.assertNotNull(result);
+    }
+
+    @Test
     void whenTotalClaimField() {
-        ClaimField field = MockClaimsFunctions.createTotalAmountField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        CalculatedTotalClaimField field = MockClaimsFunctions.createTotalAmountField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
@@ -258,8 +357,8 @@ public class ClaimFieldRowTest {
 
     @Test
     void whenFixedFeeClaimField() {
-        ClaimField field = MockClaimsFunctions.createFixedFeeField();
-        ClaimFieldRow result = new ClaimFieldRow(field);
+        FixedFeeClaimField field = MockClaimsFunctions.createFixedFeeField();
+        ClaimFieldRow result = ClaimFieldRow.from(field);
         Assertions.assertEquals(field.getKey(), result.getKey());
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());


### PR DESCRIPTION
## BC-384

[Link to story](https://dsdmoj.atlassian.net/browse/BC-384)

- Split out the `ClaimFieldRow` constructor method into several smaller static factory methods
- When an assessed total has no assessed value, we set it to be the corresponding allowed total value if there is one
- Ensuring claim fields reset to default `assessable` value for an assessment outcome change

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

