### PR TITLE
BC-385: Warning log if assessment exceeds 25k

### DIFF
--- a/src/integrationTest/resources/application.yml
+++ b/src/integrationTest/resources/application.yml
@@ -28,3 +28,5 @@ provider-api:
   access-token: ""
 search:
   sort-enabled: true
+submission:
+  high-value-assessment-limit: 25000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,6 +43,8 @@ provider-api:
   access-token: ${PROVIDER_TOKEN}
 search:
   sort-enabled: true
+submission:
+  high-value-assessment-limit: 25000
 app:
   feedback-url: ${FEEDBACK_URL}
   laa-url: ${LAA_URL}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
@@ -15,9 +15,10 @@ import static org.mockito.Mockito.when;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
 import uk.gov.justice.laa.amend.claim.client.ProviderApiClient;
@@ -32,6 +33,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResultSet;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.SubmissionResponse;
 import uk.gov.justice.laadata.providers.model.ProviderFirmOfficeDto;
 
+@ExtendWith(MockitoExtension.class)
 class ClaimServiceTest {
 
     @Mock
@@ -45,10 +47,6 @@ class ClaimServiceTest {
 
     @InjectMocks
     private ClaimService claimService;
-
-    public ClaimServiceTest() {
-        MockitoAnnotations.openMocks(this);
-    }
 
     @Test
     @DisplayName("Should return sorted valid ClaimResultSet when API client provides valid response")


### PR DESCRIPTION
## What is this PR?

https://dsdmoj.atlassian.net/browse/BC-XXX)](https://dsdmoj.atlassian.net/browse/BC-385
Adding a log after submission which will allow us to alert if submissions exceed a given amount.

Example log:

> 2026-02-10T11:10:07.120Z  WARN 65829 --- [LAA Amend a Claim Service] [nio-8080-exec-3] u.g.j.l.a.c.service.AssessmentService    : HIGH_VALUE_ASSESSMENT: detected for claimId 0199c9a4-64ec-79c6-a292-e250278f5f71, providerAccountNumber string, uniqueFileNumber 290419/711, assessmentId 40327a67-5972-477b-bdf9-f138e03cebd6, assessmentOutcome PAID_IN_FULL, assessedTotalInclVat 123456.00, allowedTotalInclVat 123456.00



## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

