### PR TITLE
Removed redundant navigateTo invocations.

### DIFF
--- a/e2e.sh
+++ b/e2e.sh
@@ -60,6 +60,9 @@ wait_for() {
 wait_for "http://localhost:8182/actuator/health" "UP"
 wait_for "http://localhost:8082/v3/api-docs" "openapi"
 
+echo "[INFO] Installing node dependencies..."
+(cd src/e2e/ && npm install)
+
 CMD="./gradlew test"
 for arg in "$@"; do
   case $arg in

--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -65,11 +65,7 @@ Again, the order matters here due to foreign key constraints.
 
 ## Run all E2E tests
 
-Before you run these for the first time, you will need to run:
-1. `cd src/e2e/`
-2. `npm install`
-
-Then from the root directory you can run: `./e2e.sh`
+`./e2e.sh`
 
 ## Run a particular test class
 

--- a/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/SearchPage.java
+++ b/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/SearchPage.java
@@ -45,11 +45,6 @@ public class SearchPage extends LaaPage {
         this.noResultsMessage = page.locator("h2.govuk-heading-m:has-text('no results')");
     }
 
-    public SearchPage navigateTo(String baseUrl) {
-        page.navigate(baseUrl);
-        return this;
-    }
-
     public void enterProviderAccountNumber(String number) {
         providerAccountNumberInput.fill(number);
     }

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessCostsValidationTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessCostsValidationTest.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -112,9 +111,7 @@ public class AssessCostsValidationTest extends BaseTest {
     }
 
     private void navigateToReviewAndAmend(String provider, String month, String year, String ufn) {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
         search.searchForClaim(provider, month, year, ufn, "");
         search.clickViewForUfn(ufn);
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessTotalsValidationTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessTotalsValidationTest.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -69,9 +68,7 @@ public class AssessTotalsValidationTest extends BaseTest {
     }
 
     private void navigateToReviewAndAmend() {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
         search.searchForClaim(PROVIDER_ACCOUNT, MONTH, YEAR, UFN, "");
         search.clickViewForUfn(UFN);
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessedClaimDetailsTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessedClaimDetailsTest.java
@@ -7,7 +7,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.AssessmentInsert;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
@@ -75,7 +74,7 @@ public class AssessedClaimDetailsTest extends BaseTest {
     @Test
     @DisplayName("E2E: Assessed ClaimDetails")
     void assessed() throws InterruptedException {
-        SearchPage search = new SearchPage(page).navigateTo(EnvConfig.baseUrl());
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(PROVIDER_ACCOUNT, "", "", UFN, "");
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessmentFlowE2ETest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessmentFlowE2ETest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -76,9 +75,7 @@ public class AssessmentFlowE2ETest extends BaseTest {
     @Test
     @DisplayName("E2E: Full Crime Assessment Flow – Search → View → Outcome → Amend All → Submit")
     void fullAssessmentFlow() {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(PROVIDER_ACCOUNT, "03", "2020", UFN, "");
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessmentOutcomeTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessmentOutcomeTest.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -64,9 +63,7 @@ public class AssessmentOutcomeTest extends BaseTest {
     }
 
     private void navigateToAssessmentOutcome() {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(PROVIDER_ACCOUNT, "04", "2025", UFN, "");
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/ClaimDetailsTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/ClaimDetailsTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetailsFixture;
@@ -146,9 +145,7 @@ public class ClaimDetailsTest extends BaseTest {
     @DisplayName("Claim Details: Add assessment outcome is disabled for non-escape claims")
     @Severity(SeverityLevel.CRITICAL)
     void addAssessmentOutcomeIsDisabledForNonEscapeClaim() {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(CRIME_PROVIDER_ACCOUNT, "11", "2025", UNESCAPED_UFN, "");
 
@@ -171,9 +168,7 @@ public class ClaimDetailsTest extends BaseTest {
     @DisplayName("Claim Details: Values match fixture")
     @Severity(SeverityLevel.CRITICAL)
     void claimValuesMatchFixture(ClaimDetailsFixture claimDetailsFixture) {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(claimDetailsFixture.getProviderAccount(), "", "", claimDetailsFixture.getUfn(), "");
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/DiscardAssessmentTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/DiscardAssessmentTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -140,9 +139,7 @@ public class DiscardAssessmentTest extends BaseTest {
     }
 
     private ReviewAndAmendPage goToReviewAndAmendPage() {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(PROVIDER_ACCOUNT, MONTH, YEAR, UFN, "");
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/E2eBaseTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/E2eBaseTest.java
@@ -4,7 +4,6 @@ import static uk.gov.justice.laa.amend.claim.utils.TestDataUtils.generateUfn;
 
 import org.junit.jupiter.api.Assertions;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.pages.AssessAllowedTotalsPage;
 import uk.gov.justice.laa.amend.claim.pages.AssessAssessedTotalsPage;
 import uk.gov.justice.laa.amend.claim.pages.AssessProfitCostsPage;
@@ -102,7 +101,7 @@ public abstract class E2eBaseTest extends BaseTest {
     }
 
     private void findClaim() {
-        SearchPage search = new SearchPage(page).navigateTo(EnvConfig.baseUrl());
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim(PROVIDER_ACCOUNT, "", "", UFN, "");
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/ReviewAndAmendTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/ReviewAndAmendTest.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -105,9 +104,7 @@ public class ReviewAndAmendTest extends BaseTest {
     }
 
     private void navigateToReviewAndAmend(String providerAccount, String month, String year, String ufn) {
-        String baseUrl = EnvConfig.baseUrl();
-
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
         search.searchForClaim(providerAccount, month, year, ufn, "");
         search.clickViewForUfn(ufn);
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/SearchTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/SearchTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import uk.gov.justice.laa.amend.claim.base.BaseTest;
-import uk.gov.justice.laa.amend.claim.config.EnvConfig;
 import uk.gov.justice.laa.amend.claim.models.BulkSubmissionInsert;
 import uk.gov.justice.laa.amend.claim.models.CalculatedFeeDetailInsert;
 import uk.gov.justice.laa.amend.claim.models.ClaimInsert;
@@ -110,8 +109,7 @@ public class SearchTest extends BaseTest {
     @Severity(SeverityLevel.CRITICAL)
     @DisplayName("Search: submit form and results available")
     void canSearchForClaim(SearchData config) {
-        String baseUrl = EnvConfig.baseUrl();
-        SearchPage searchPage = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage searchPage = new SearchPage(page);
 
         searchPage.searchForClaim(
                 config.getProviderAccountNumber(),
@@ -128,8 +126,7 @@ public class SearchTest extends BaseTest {
     @Test
     @DisplayName("Search values retained upon 'Back to search' click")
     void backToSearch() {
-        String baseUrl = EnvConfig.baseUrl();
-        SearchPage search = new SearchPage(page).navigateTo(baseUrl);
+        SearchPage search = new SearchPage(page);
 
         search.searchForClaim("123456", "04", "2025", "", "");
 


### PR DESCRIPTION
## What is this PR?

Removing redundant `navigateTo` invocations. The `BeforeEach` hook already navigates to `EnvConfig.baseUrl()`.

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

