### PR TITLE
BC-457 : Ensure users can't access pages for un-assessable claim fields

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsController.java
@@ -8,6 +8,8 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
@@ -16,6 +18,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.amend.claim.forms.AllowedTotalForm;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
@@ -23,12 +26,19 @@ import uk.gov.justice.laa.amend.claim.models.ClaimField;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/submissions/{submissionId}/claims/{claimId}/allowed-totals")
+@Slf4j
 public class ChangeAllowedTotalsController {
 
     @GetMapping()
     public String onPageLoad(
             @PathVariable String claimId, @PathVariable String submissionId, Model model, HttpServletRequest request) {
         ClaimDetails claim = (ClaimDetails) request.getAttribute(claimId);
+
+        if (claim.getAllowedTotalVat().isNotAssessable()
+                || claim.getAllowedTotalInclVat().isNotAssessable()) {
+            log.warn("The allowed totals are not modifiable for claim {}. Returning 404.", claimId);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+        }
 
         AllowedTotalForm allowedTotalForm = new AllowedTotalForm();
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ChangeMonetaryValueController.java
@@ -50,6 +50,11 @@ public class ChangeMonetaryValueController {
                 throw new ResponseStatusException(HttpStatus.NOT_FOUND);
             }
 
+            if (claimField.isNotAssessable()) {
+                log.warn("This claim field is not modifiable for claim {}. Returning 404.", claimId);
+                throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+            }
+
             BigDecimal value = (BigDecimal) claimField.getAssessed();
 
             MonetaryValueForm form = new MonetaryValueForm();

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAllowedTotalsControllerTest.java
@@ -25,6 +25,7 @@ import uk.gov.justice.laa.amend.claim.config.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.handlers.ClaimStatusHandler;
 import uk.gov.justice.laa.amend.claim.models.AllowedClaimField;
+import uk.gov.justice.laa.amend.claim.models.AssessedClaimField;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
@@ -79,6 +80,32 @@ class ChangeAllowedTotalsControllerTest {
                 .andExpect(view().name("allowed-totals"))
                 .andExpect(model().attribute("form", hasProperty("allowedTotalVat", nullValue())))
                 .andExpect(model().attribute("form", hasProperty("allowedTotalInclVat", nullValue())));
+    }
+
+    @Test
+    void testGetRedirectsWhenFieldIsNotAssessable_CivilClaim() throws Exception {
+        ClaimField allowedTotalVat = AssessedClaimField.builder().build();
+        ClaimField allowedTotalInclVat = AssessedClaimField.builder().build();
+        allowedTotalVat.setAssessable(false);
+        allowedTotalInclVat.setAssessable(false);
+        civilClaim.setAllowedTotalVat(allowedTotalVat);
+        civilClaim.setAllowedTotalInclVat(allowedTotalInclVat);
+        session.setAttribute(claimId, civilClaim);
+
+        mockMvc.perform(get(buildPath()).session(session)).andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testGetRedirectsWhenFieldIsNotAssessable_CrimeClaim() throws Exception {
+        ClaimField allowedTotalVat = AssessedClaimField.builder().build();
+        ClaimField allowedTotalInclVat = AssessedClaimField.builder().build();
+        allowedTotalVat.setAssessable(false);
+        allowedTotalInclVat.setAssessable(false);
+        crimeClaim.setAllowedTotalVat(allowedTotalVat);
+        crimeClaim.setAllowedTotalInclVat(allowedTotalInclVat);
+        session.setAttribute(claimId, crimeClaim);
+
+        mockMvc.perform(get(buildPath()).session(session)).andExpect(status().isNotFound());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAssessedTotalsControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ChangeAssessedTotalsControllerTest.java
@@ -82,7 +82,7 @@ class ChangeAssessedTotalsControllerTest {
     }
 
     @Test
-    void testGetRedirectsWhenStatusIsDoNotDisplay_CivilClaim() throws Exception {
+    void testGetRedirectsWhenFieldIsNotAssessable_CivilClaim() throws Exception {
         ClaimField assessedTotalVat = AssessedClaimField.builder().build();
         ClaimField assessedTotalInclVat = AssessedClaimField.builder().build();
         assessedTotalVat.setAssessable(false);
@@ -95,7 +95,7 @@ class ChangeAssessedTotalsControllerTest {
     }
 
     @Test
-    void testGetRedirectsWhenStatusIsDoNotDisplay_CrimeClaim() throws Exception {
+    void testGetRedirectsWhenFieldIsNotAssessable_CrimeClaim() throws Exception {
         ClaimField assessedTotalVat = AssessedClaimField.builder().build();
         ClaimField assessedTotalInclVat = AssessedClaimField.builder().build();
         assessedTotalVat.setAssessable(false);


### PR DESCRIPTION
## BC-457

[Link to story](https://dsdmoj.atlassian.net/browse/BC-457)

Ensure users can't access pages for un-assessable claim fields.

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

