### PR TITLE
Fix truncation issue with sanitising branch names

### DIFF
--- a/.github/actions/sanitize-branch-name/action.yml
+++ b/.github/actions/sanitize-branch-name/action.yml
@@ -40,15 +40,15 @@ runs:
         # - Replace / and _ with -
         # - Remove special characters (keep only alphanumeric and hyphens)
         # - Replace multiple consecutive hyphens with single hyphen
-        # - Remove leading/trailing hyphens
         # - Truncate to 20 characters
+        # - Remove leading/trailing hyphens
         SANITIZED=$(echo "$BRANCH_NAME" \
           | tr '[:upper:]' '[:lower:]' \
           | sed 's/[^a-z0-9-]/-/g' \
           | sed 's/--*/-/g' \
           | sed 's/^-//' \
-          | sed 's/-$//' \
-          | cut -c1-20)
+          | cut -c1-20 \
+          | sed 's/-$//')
 
         # Create release name (prepend 'ephemeral-' to distinguish from static deployments)
         RELEASE_NAME="ephemeral-${SANITIZED}"


### PR DESCRIPTION
## What is this PR?

Swap order of events when create sanitised release name so removing invalid trailing characters happens after truncation

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

