### PR TITLE
BC-471: Add Pact consumer tests for void claim endpoint.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ on:
         type: string
         default: 'values.yaml'
         description: 'Environment-specific values file (e.g., values/staging.yaml)'
+      claim_api_environment_name:
+        required: true
+        type: string
+        description: 'Claims API environment name for Pact broker (e.g., main, stg, prod)'
     secrets:
       ECR_ROLE_TO_ASSUME:
         required: true
@@ -37,6 +41,10 @@ on:
       KUBE_TOKEN:
         required: true
       KUBE_CERT:
+        required: true
+      PACT_BROKER_USERNAME:
+        required: true
+      PACT_BROKER_PASSWORD:
         required: true
 
 jobs:
@@ -90,6 +98,15 @@ jobs:
           kube-namespace: ${{ secrets.KUBE_NAMESPACE }}
           kube-sa: deploy-user
 
+      - name: Can I deploy?
+        uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/pact-can-i-deploy@v1
+        with:
+          pacticipant: 'laa-amend-a-claim'
+          environment: ${{ inputs.claim_api_environment_name }}
+          pact_broker_url: 'https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/'
+          pact_broker_username: ${{ secrets.PACT_BROKER_USERNAME }}
+          pact_broker_password: ${{ secrets.PACT_BROKER_PASSWORD }}
+
       - name: Deploy to Cloud Platform with Helm
         run: |
           helm upgrade --install laa-amend-a-claim .helm/laa-amend-a-claim \
@@ -111,3 +128,12 @@ jobs:
           KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
           INPUT_VALUES: ${{ inputs.values_file }}
           SENTRY_ENV: ${{ inputs.sentry_env }}
+
+      - name: Record deployment to pact broker
+        uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/pact-record-deployment@v1
+        with:
+          pacticipant: 'laa-amend-a-claim'
+          environment: ${{ inputs.claim_api_environment_name }}
+          pact_broker_url: 'https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/'
+          pact_broker_username: ${{ secrets.PACT_BROKER_USERNAME }}
+          pact_broker_password: ${{ secrets.PACT_BROKER_PASSWORD }}

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,6 +22,25 @@ jobs:
       ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
+  pact-test:
+    name: Pact Test
+    needs: build
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/pact-and-publish.yml@v1
+    permissions:
+      contents: write
+      packages: write
+    with:
+      pacticipant_name: "laa-amend-a-claim"
+      pact_test_task: "pactTest"
+      publish_pact_results: true
+      enable_can_i_merge: true
+      provider_name: "laa-data-claims-api"
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      pact_broker_url: 'https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/'
+      pact_broker_username: ${{ secrets.PACT_BROKER_USERNAME }}
+      pact_broker_password: ${{ secrets.PACT_BROKER_PASSWORD }}
+
   deploy-ephemeral:
     name: Deploy Ephemeral Environment
     needs: build
@@ -74,7 +93,7 @@ jobs:
 
   deploy-dev:
     name: Deploy to Dev
-    needs: [ build, test ]
+    needs: [ build, test, pact-test ]
     uses: ./.github/workflows/deploy.yml
     with:
       branch: ${{ github.ref_name }}
@@ -83,9 +102,12 @@ jobs:
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/dev.yaml
+      claim_api_environment_name: dev
     secrets:
       ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
       KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
       KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,23 @@ jobs:
       DATA_CLAIMS_API_IMAGE: ${{ secrets.DATA_CLAIMS_API_IMAGE }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
 
+  pact-test:
+    name: Pact Test
+    needs: build
+    uses: ministryofjustice/laa-ccms-common-workflows/.github/workflows/pact-and-publish.yml@v1
+    permissions:
+      contents: write
+      packages: write
+    with:
+      pacticipant_name: "laa-amend-a-claim"
+      pact_test_task: "pactTest"
+      publish_pact_results: true
+    secrets:
+      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      pact_broker_url: 'https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/'
+      pact_broker_username: ${{ secrets.PACT_BROKER_USERNAME }}
+      pact_broker_password: ${{ secrets.PACT_BROKER_PASSWORD }}
+
   security:
     name: Security
     needs: [ build, test ]
@@ -58,7 +75,7 @@ jobs:
 
   deploy-dev:
     name: Deploy to Dev
-    needs: [ build, test, security ]
+    needs: [ build, test, security, pact-test ]
     uses: ./.github/workflows/deploy.yml
     with:
       branch: ${{ github.ref_name }}
@@ -67,16 +84,19 @@ jobs:
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/dev.yaml
+      claim_api_environment_name: dev
     secrets:
       ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
       KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
       KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
 
   deploy-uat:
     name: Deploy to UAT
-    needs: [ build, test, security, deploy-dev ]
+    needs: [ build, test, security, pact-test, deploy-dev ]
     uses: ./.github/workflows/deploy.yml
     with:
       branch: ${{ github.ref_name }}
@@ -85,16 +105,19 @@ jobs:
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/uat.yaml
+      claim_api_environment_name: main
     secrets:
       ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
       KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
       KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
 
   deploy-staging:
     name: Deploy to Staging
-    needs: [ build, test, security, deploy-uat ]
+    needs: [ build, test, security, pact-test, deploy-uat ]
     uses: ./.github/workflows/deploy.yml
     with:
       branch: ${{ github.ref_name }}
@@ -103,16 +126,19 @@ jobs:
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/staging.yaml
+      claim_api_environment_name: stg
     secrets:
       ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
       KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
       KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
 
   deploy-production:
     name: Deploy to Production
-    needs: [ build, test, security, deploy-uat, deploy-staging ]
+    needs: [ build, test, security, pact-test, deploy-uat, deploy-staging ]
     uses: ./.github/workflows/deploy.yml
     with:
       branch: ${{ github.ref_name }}
@@ -121,9 +147,12 @@ jobs:
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/production.yaml
+      claim_api_environment_name: prod
     secrets:
       ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
       KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
       KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
       KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
       KUBE_CERT: ${{ secrets.KUBE_CERT }}
+      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
+      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "com.diffplug.spotless" version "8.2.1"
     id "com.palantir.java-format-spotless" version "2.89.0"
     id "io.sentry.jvm.gradle" version "6.0.0"
+    id 'au.com.dius.pact' version '4.6.19'
 }
 
 java {
@@ -67,6 +68,8 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.6.3'
 
+    // Pact consumer testing
+    testImplementation 'au.com.dius.pact.consumer:junit5:4.6.19'
     // test dependencies
     testImplementation 'org.springframework.cloud:spring-cloud-contract-wiremock:5.0.2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -106,4 +109,51 @@ tasks.register('checkstyleAll') {
 
 tasks.named('build') {
     dependsOn tasks.named('checkstyleAll')
+}
+
+// Pact consumer test source set
+sourceSets {
+    pactTest {
+        java.srcDir file('src/pactTest/java')
+        resources.srcDir file('src/pactTest/resources')
+        compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+        runtimeClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+    }
+}
+
+configurations {
+    pactTestImplementation.extendsFrom testImplementation
+    pactTestRuntimeOnly.extendsFrom testRuntimeOnly
+}
+
+tasks.register('pactTest', Test) {
+    systemProperty "pact.content_type.override.application/json", "application/json;charset=utf-8"
+    description = 'Runs the pact tests.'
+    group = 'verification'
+
+    def pactsDir = layout.buildDirectory.dir("pacts").get().asFile
+    doFirst {
+        if (pactsDir.exists()) { pactsDir.deleteDir() }
+    }
+
+    testClassesDirs = sourceSets.pactTest.output.classesDirs
+    classpath = sourceSets.pactTest.runtimeClasspath
+    useJUnitPlatform()
+    systemProperty 'pact.rootDir', layout.buildDirectory.dir("pacts").get().asFile.path
+}
+
+tasks.named('processPactTestResources') {
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
+}
+
+pact {
+    publish {
+        pactBrokerUrl = System.getenv('PACT_BROKER_URL') ?: 'https://laa-data-pact-broker.apps.live.cloud-platform.service.justice.gov.uk/'
+        pactBrokerUsername = System.getenv('PACT_BROKER_USERNAME') ?: 'ABC'
+        pactBrokerPassword = System.getenv('PACT_BROKER_PASSWORD') ?: 'ABC'
+        pactDirectory = layout.buildDirectory.dir("pacts").get().asFile.path
+        consumerVersion = providers.environmentVariable('GIT_SHA').getOrElse('1.0.0')
+        consumerBranch = providers.environmentVariable('GIT_BRANCH').getOrElse('main')
+        tags = [providers.environmentVariable('GIT_BRANCH').getOrElse('main')]
+    }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/ClaimsApiClient.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/ClaimsApiClient.java
@@ -49,7 +49,7 @@ public interface ClaimsApiClient {
             @RequestParam(value = "size", required = false) int size,
             @RequestParam(value = "sort", required = false) String sort);
 
-    @PostExchange(value = "/claims/{claimId}/void", contentType = MediaType.APPLICATION_JSON_VALUE)
+    @PostExchange(value = "/v1/claims/{claimId}/void", contentType = MediaType.APPLICATION_JSON_VALUE)
     Mono<ResponseEntity<VoidClaim201Response>> voidClaim(
             @PathVariable String claimId, @RequestBody VoidClaimRequest body);
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/ClaimsApiClient.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/ClaimsApiClient.java
@@ -50,5 +50,6 @@ public interface ClaimsApiClient {
             @RequestParam(value = "sort", required = false) String sort);
 
     @PostExchange(value = "/claims/{claimId}/void", contentType = MediaType.APPLICATION_JSON_VALUE)
-    Mono<ResponseEntity<VoidClaim201Response>> voidClaim(@PathVariable String claimId);
+    Mono<ResponseEntity<VoidClaim201Response>> voidClaim(
+            @PathVariable String claimId, @RequestBody VoidClaimRequest body);
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/ClaimsApiClient.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/ClaimsApiClient.java
@@ -48,4 +48,7 @@ public interface ClaimsApiClient {
             @RequestParam(value = "page", required = false) int page,
             @RequestParam(value = "size", required = false) int size,
             @RequestParam(value = "sort", required = false) String sort);
+
+    @PostExchange(value = "/claims/{claimId}/void", contentType = MediaType.APPLICATION_JSON_VALUE)
+    Mono<ResponseEntity<VoidClaim201Response>> voidClaim(@PathVariable String claimId);
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaim201Response.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaim201Response.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -9,5 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class VoidClaim201Response {
+
+    @JsonProperty("id")
     private UUID id;
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaim201Response.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaim201Response.java
@@ -1,0 +1,13 @@
+package uk.gov.justice.laa.amend.claim.client;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoidClaim201Response {
+    private UUID id;
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaimRequest.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaimRequest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -9,6 +10,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class VoidClaimRequest {
+
+    @JsonProperty("created_by_user_id")
     private UUID createdByUserId;
+
+    @JsonProperty("assessment_reason")
     private String assessmentReason;
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaimRequest.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/VoidClaimRequest.java
@@ -1,0 +1,14 @@
+package uk.gov.justice.laa.amend.claim.client;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class VoidClaimRequest {
+    private UUID createdByUserId;
+    private String assessmentReason;
+}

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/AbstractPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/AbstractPactTest.java
@@ -1,0 +1,17 @@
+package uk.gov.justice.laa.amend.claim;
+
+import java.util.UUID;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public abstract class AbstractPactTest {
+    public static final String CONSUMER = "laa-amend-a-claim";
+    public static final String PROVIDER = "laa-data-claims-api";
+
+    protected static final String UUID_REGEX = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+    protected static final UUID CLAIM_ID = UUID.randomUUID();
+
+    @MockitoBean
+    OAuth2AuthorizedClientManager authorizedClientManager;
+}

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentBadRequestPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentBadRequestPactTest.java
@@ -1,0 +1,93 @@
+package uk.gov.justice.laa.amend.claim;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import au.com.dius.pact.consumer.dsl.LambdaDsl;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTest;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest;
+import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
+import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"claims-api.url=http://localhost:1243"})
+@PactConsumerTest
+@PactTestFor(providerName = AbstractPactTest.PROVIDER)
+@MockServerConfig(port = "1243")
+@Import(ClaimsApiPactTestConfig.class)
+@DisplayName("POST: /api/v1/claims/{claimId}/assessments - 400 PACT test")
+public final class CreateAssessmentBadRequestPactTest extends AbstractPactTest {
+
+    @Autowired
+    ClaimsApiClient claimsApiClient;
+
+    @Pact(consumer = CONSUMER)
+    public RequestResponsePact createAssessment400(PactDslWithProvider builder) {
+        return builder.given("no claim exists")
+                .uponReceiving("a request to create an assessment for a non-existent claim")
+                .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/assessments")
+                .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
+                .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
+                .method("POST")
+                .body(LambdaDsl.newJsonBody(body -> {
+                            body.uuid("claimId");
+                            body.uuid("claimSummaryFeeId");
+                            body.stringType("assessmentOutcome", "PAID_IN_FULL");
+                            body.stringType("createdByUserId", "user-123");
+                            body.booleanType("isVatApplicable", true);
+                            body.decimalType("fixedFeeAmount", 100.00);
+                            body.decimalType("netProfitCostsAmount", 200.00);
+                            body.decimalType("disbursementAmount", 50.00);
+                            body.decimalType("disbursementVatAmount", 10.00);
+                            body.decimalType("assessedTotalVat", 60.00);
+                            body.decimalType("assessedTotalInclVat", 360.00);
+                            body.decimalType("allowedTotalVat", 60.00);
+                            body.decimalType("allowedTotalInclVat", 360.00);
+                        })
+                        .build())
+                .willRespondWith()
+                .status(400)
+                .headers(Map.of("Content-Type", "application/json"))
+                .toPact();
+    }
+
+    @Test
+    @DisplayName("Verify 400 response - claim does not exist")
+    @PactTestFor(pactMethod = "createAssessment400")
+    void verify400Response() {
+        AssessmentPost assessment = new AssessmentPost();
+        assessment.setClaimId(UUID.randomUUID());
+        assessment.setClaimSummaryFeeId(UUID.randomUUID());
+        assessment.setAssessmentOutcome(AssessmentOutcome.PAID_IN_FULL);
+        assessment.setCreatedByUserId("user-123");
+        assessment.setIsVatApplicable(true);
+        assessment.setFixedFeeAmount(new BigDecimal("100.00"));
+        assessment.setNetProfitCostsAmount(new BigDecimal("200.00"));
+        assessment.setDisbursementAmount(new BigDecimal("50.00"));
+        assessment.setDisbursementVatAmount(new BigDecimal("10.00"));
+        assessment.setAssessedTotalVat(new BigDecimal("60.00"));
+        assessment.setAssessedTotalInclVat(new BigDecimal("360.00"));
+        assessment.setAllowedTotalVat(new BigDecimal("60.00"));
+        assessment.setAllowedTotalInclVat(new BigDecimal("360.00"));
+
+        assertThrows(
+                BadRequest.class,
+                () -> claimsApiClient.submitAssessment(CLAIM_ID.toString(), assessment).block());
+    }
+}

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentBadRequestPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentBadRequestPactTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest;
+import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
 import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
@@ -31,14 +31,14 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
 @PactTestFor(providerName = AbstractPactTest.PROVIDER)
 @MockServerConfig(port = "1243")
 @Import(ClaimsApiPactTestConfig.class)
-@DisplayName("POST: /api/v1/claims/{claimId}/assessments - 400 PACT test")
+@DisplayName("POST: /api/v1/claims/{claimId}/assessments - 404 PACT test")
 public final class CreateAssessmentBadRequestPactTest extends AbstractPactTest {
 
     @Autowired
     ClaimsApiClient claimsApiClient;
 
     @Pact(consumer = CONSUMER)
-    public RequestResponsePact createAssessment400(PactDslWithProvider builder) {
+    public RequestResponsePact createAssessment404(PactDslWithProvider builder) {
         return builder.given("no claim exists")
                 .uponReceiving("a request to create an assessment for a non-existent claim")
                 .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/assessments")
@@ -46,31 +46,44 @@ public final class CreateAssessmentBadRequestPactTest extends AbstractPactTest {
                 .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
                 .method("POST")
                 .body(LambdaDsl.newJsonBody(body -> {
-                            body.uuid("claimId");
-                            body.uuid("claimSummaryFeeId");
-                            body.stringType("assessmentOutcome", "PAID_IN_FULL");
-                            body.stringType("createdByUserId", "user-123");
-                            body.booleanType("isVatApplicable", true);
-                            body.decimalType("fixedFeeAmount", 100.00);
-                            body.decimalType("netProfitCostsAmount", 200.00);
-                            body.decimalType("disbursementAmount", 50.00);
-                            body.decimalType("disbursementVatAmount", 10.00);
-                            body.decimalType("assessedTotalVat", 60.00);
-                            body.decimalType("assessedTotalInclVat", 360.00);
-                            body.decimalType("allowedTotalVat", 60.00);
-                            body.decimalType("allowedTotalInclVat", 360.00);
+                            body.nullValue("id");
+                            body.uuid("claim_id");
+                            body.uuid("claim_summary_fee_id");
+                            body.stringType("assessment_outcome", "PAID_IN_FULL");
+                            body.stringType("created_by_user_id", "user-123");
+                            body.nullValue("assessment_reason");
+                            body.nullValue("assessment_type");
+                            body.booleanType("is_vat_applicable", true);
+                            body.decimalType("fixed_fee_amount", 100.00);
+                            body.decimalType("net_profit_costs_amount", 200.00);
+                            body.decimalType("disbursement_amount", 50.00);
+                            body.decimalType("disbursement_vat_amount", 10.00);
+                            body.decimalType("assessed_total_vat", 60.00);
+                            body.decimalType("assessed_total_incl_vat", 360.00);
+                            body.decimalType("allowed_total_vat", 60.00);
+                            body.decimalType("allowed_total_incl_vat", 360.00);
+                            body.nullValue("net_cost_of_counsel_amount");
+                            body.nullValue("net_travel_costs_amount");
+                            body.nullValue("net_waiting_costs_amount");
+                            body.nullValue("detention_travel_and_waiting_costs_amount");
+                            body.nullValue("jr_form_filling_amount");
+                            body.nullValue("bolt_on_adjourned_hearing_fee");
+                            body.nullValue("bolt_on_cmrh_oral_fee");
+                            body.nullValue("bolt_on_cmrh_telephone_fee");
+                            body.nullValue("bolt_on_home_office_interview_fee");
+                            body.nullValue("bolt_on_substantive_hearing_fee");
                         })
                         .build())
                 .willRespondWith()
-                .status(400)
+                .status(404)
                 .headers(Map.of("Content-Type", "application/json"))
                 .toPact();
     }
 
     @Test
-    @DisplayName("Verify 400 response - claim does not exist")
-    @PactTestFor(pactMethod = "createAssessment400")
-    void verify400Response() {
+    @DisplayName("Verify 404 response - claim does not exist")
+    @PactTestFor(pactMethod = "createAssessment404")
+    void verify404Response() {
         AssessmentPost assessment = new AssessmentPost();
         assessment.setClaimId(UUID.randomUUID());
         assessment.setClaimSummaryFeeId(UUID.randomUUID());
@@ -87,7 +100,9 @@ public final class CreateAssessmentBadRequestPactTest extends AbstractPactTest {
         assessment.setAllowedTotalInclVat(new BigDecimal("360.00"));
 
         assertThrows(
-                BadRequest.class,
-                () -> claimsApiClient.submitAssessment(CLAIM_ID.toString(), assessment).block());
+                NotFound.class,
+                () -> claimsApiClient
+                        .submitAssessment(CLAIM_ID.toString(), assessment)
+                        .block());
     }
 }

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentSuccessPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentSuccessPactTest.java
@@ -48,19 +48,32 @@ public final class CreateAssessmentSuccessPactTest extends AbstractPactTest {
                 .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
                 .method("POST")
                 .body(LambdaDsl.newJsonBody(body -> {
-                            body.uuid("claimId");
-                            body.uuid("claimSummaryFeeId");
-                            body.stringType("assessmentOutcome", "PAID_IN_FULL");
-                            body.stringType("createdByUserId", "user-123");
-                            body.booleanType("isVatApplicable", true);
-                            body.decimalType("fixedFeeAmount", 100.00);
-                            body.decimalType("netProfitCostsAmount", 200.00);
-                            body.decimalType("disbursementAmount", 50.00);
-                            body.decimalType("disbursementVatAmount", 10.00);
-                            body.decimalType("assessedTotalVat", 60.00);
-                            body.decimalType("assessedTotalInclVat", 360.00);
-                            body.decimalType("allowedTotalVat", 60.00);
-                            body.decimalType("allowedTotalInclVat", 360.00);
+                            body.nullValue("id");
+                            body.uuid("claim_id");
+                            body.uuid("claim_summary_fee_id");
+                            body.stringType("assessment_outcome", "PAID_IN_FULL");
+                            body.stringType("created_by_user_id", "user-123");
+                            body.nullValue("assessment_reason");
+                            body.nullValue("assessment_type");
+                            body.booleanType("is_vat_applicable", true);
+                            body.decimalType("fixed_fee_amount", 100.00);
+                            body.decimalType("net_profit_costs_amount", 200.00);
+                            body.decimalType("disbursement_amount", 50.00);
+                            body.decimalType("disbursement_vat_amount", 10.00);
+                            body.decimalType("assessed_total_vat", 60.00);
+                            body.decimalType("assessed_total_incl_vat", 360.00);
+                            body.decimalType("allowed_total_vat", 60.00);
+                            body.decimalType("allowed_total_incl_vat", 360.00);
+                            body.nullValue("net_cost_of_counsel_amount");
+                            body.nullValue("net_travel_costs_amount");
+                            body.nullValue("net_waiting_costs_amount");
+                            body.nullValue("detention_travel_and_waiting_costs_amount");
+                            body.nullValue("jr_form_filling_amount");
+                            body.nullValue("bolt_on_adjourned_hearing_fee");
+                            body.nullValue("bolt_on_cmrh_oral_fee");
+                            body.nullValue("bolt_on_cmrh_telephone_fee");
+                            body.nullValue("bolt_on_home_office_interview_fee");
+                            body.nullValue("bolt_on_substantive_hearing_fee");
                         })
                         .build())
                 .willRespondWith()
@@ -92,8 +105,9 @@ public final class CreateAssessmentSuccessPactTest extends AbstractPactTest {
         assessment.setAllowedTotalVat(new BigDecimal("60.00"));
         assessment.setAllowedTotalInclVat(new BigDecimal("360.00"));
 
-        ResponseEntity<CreateAssessment201Response> response =
-                claimsApiClient.submitAssessment(CLAIM_ID.toString(), assessment).block();
+        ResponseEntity<CreateAssessment201Response> response = claimsApiClient
+                .submitAssessment(CLAIM_ID.toString(), assessment)
+                .block();
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentSuccessPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentSuccessPactTest.java
@@ -1,0 +1,103 @@
+package uk.gov.justice.laa.amend.claim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.com.dius.pact.consumer.dsl.LambdaDsl;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTest;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
+import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateAssessment201Response;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"claims-api.url=http://localhost:1242"})
+@PactConsumerTest
+@PactTestFor(providerName = AbstractPactTest.PROVIDER)
+@MockServerConfig(port = "1242")
+@Import(ClaimsApiPactTestConfig.class)
+@DisplayName("POST: /api/v1/claims/{claimId}/assessments - 201 PACT test")
+public final class CreateAssessmentSuccessPactTest extends AbstractPactTest {
+
+    @Autowired
+    ClaimsApiClient claimsApiClient;
+
+    @Pact(consumer = CONSUMER)
+    public RequestResponsePact createAssessment201(PactDslWithProvider builder) {
+        return builder.given("a claim exists")
+                .uponReceiving("a request to create an assessment for a valid claim")
+                .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/assessments")
+                .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
+                .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
+                .method("POST")
+                .body(LambdaDsl.newJsonBody(body -> {
+                            body.uuid("claimId");
+                            body.uuid("claimSummaryFeeId");
+                            body.stringType("assessmentOutcome", "PAID_IN_FULL");
+                            body.stringType("createdByUserId", "user-123");
+                            body.booleanType("isVatApplicable", true);
+                            body.decimalType("fixedFeeAmount", 100.00);
+                            body.decimalType("netProfitCostsAmount", 200.00);
+                            body.decimalType("disbursementAmount", 50.00);
+                            body.decimalType("disbursementVatAmount", 10.00);
+                            body.decimalType("assessedTotalVat", 60.00);
+                            body.decimalType("assessedTotalInclVat", 360.00);
+                            body.decimalType("allowedTotalVat", 60.00);
+                            body.decimalType("allowedTotalInclVat", 360.00);
+                        })
+                        .build())
+                .willRespondWith()
+                .status(201)
+                .headers(Map.of("Content-Type", "application/json"))
+                .body(LambdaDsl.newJsonBody(body -> {
+                            body.uuid("id", UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afa6"));
+                        })
+                        .build())
+                .toPact();
+    }
+
+    @Test
+    @DisplayName("Verify 201 response - assessment created successfully")
+    @PactTestFor(pactMethod = "createAssessment201")
+    void verify201Response() {
+        AssessmentPost assessment = new AssessmentPost();
+        assessment.setClaimId(UUID.randomUUID());
+        assessment.setClaimSummaryFeeId(UUID.randomUUID());
+        assessment.setAssessmentOutcome(AssessmentOutcome.PAID_IN_FULL);
+        assessment.setCreatedByUserId("user-123");
+        assessment.setIsVatApplicable(true);
+        assessment.setFixedFeeAmount(new BigDecimal("100.00"));
+        assessment.setNetProfitCostsAmount(new BigDecimal("200.00"));
+        assessment.setDisbursementAmount(new BigDecimal("50.00"));
+        assessment.setDisbursementVatAmount(new BigDecimal("10.00"));
+        assessment.setAssessedTotalVat(new BigDecimal("60.00"));
+        assessment.setAssessedTotalInclVat(new BigDecimal("360.00"));
+        assessment.setAllowedTotalVat(new BigDecimal("60.00"));
+        assessment.setAllowedTotalInclVat(new BigDecimal("360.00"));
+
+        ResponseEntity<CreateAssessment201Response> response =
+                claimsApiClient.submitAssessment(CLAIM_ID.toString(), assessment).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isNotNull();
+    }
+}

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
@@ -17,7 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest;
+import org.springframework.web.reactive.function.client.WebClientResponseException.NotFound;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
 import uk.gov.justice.laa.amend.claim.client.VoidClaimRequest;
 import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
@@ -29,14 +29,14 @@ import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
 @PactTestFor(providerName = AbstractPactTest.PROVIDER)
 @MockServerConfig(port = "1241")
 @Import(ClaimsApiPactTestConfig.class)
-@DisplayName("POST: /api/v1/claims/{claimId}/void - 400 PACT test")
+@DisplayName("POST: /api/v1/claims/{claimId}/void - 404 PACT test")
 public final class VoidClaimNotFoundPactTest extends AbstractPactTest {
 
     @Autowired
     ClaimsApiClient claimsApiClient;
 
     @Pact(consumer = CONSUMER)
-    public RequestResponsePact voidClaim400NoClaimExists(PactDslWithProvider builder) {
+    public RequestResponsePact voidClaim404NoClaimExists(PactDslWithProvider builder) {
         return builder.given("no claim exists")
                 .uponReceiving("a request to void a non-existent claim")
                 .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
@@ -44,23 +44,23 @@ public final class VoidClaimNotFoundPactTest extends AbstractPactTest {
                 .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
                 .method("POST")
                 .body(LambdaDsl.newJsonBody(body -> {
-                            body.uuid("createdByUserId");
-                            body.stringType("assessmentReason", "Void reason");
+                            body.uuid("created_by_user_id");
+                            body.stringType("assessment_reason", "Void reason");
                         })
                         .build())
                 .willRespondWith()
-                .status(400)
+                .status(404)
                 .headers(Map.of("Content-Type", "application/json"))
                 .toPact();
     }
 
     @Test
-    @DisplayName("Verify 400 response - claim does not exist")
-    @PactTestFor(pactMethod = "voidClaim400NoClaimExists")
-    void verify400Response() {
+    @DisplayName("Verify 404 response - claim does not exist")
+    @PactTestFor(pactMethod = "voidClaim404NoClaimExists")
+    void verify404Response() {
         VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), "Void reason");
         assertThrows(
-                BadRequest.class,
+                NotFound.class,
                 () -> claimsApiClient.voidClaim(CLAIM_ID.toString(), request).block());
     }
 }

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.amend.claim;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import au.com.dius.pact.consumer.dsl.LambdaDsl;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
 import au.com.dius.pact.consumer.junit.MockServerConfig;
 import au.com.dius.pact.consumer.junit5.PactConsumerTest;
@@ -9,6 +10,7 @@ import au.com.dius.pact.consumer.junit5.PactTestFor;
 import au.com.dius.pact.core.model.RequestResponsePact;
 import au.com.dius.pact.core.model.annotations.Pact;
 import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +19,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
+import uk.gov.justice.laa.amend.claim.client.VoidClaimRequest;
 import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
 
 @SpringBootTest(
@@ -39,6 +42,11 @@ public final class VoidClaimNotFoundPactTest extends AbstractPactTest {
                 .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
                 .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
                 .method("POST")
+                .body(LambdaDsl.newJsonBody(body -> {
+                            body.uuid("createdByUserId");
+                            body.stringType("assessmentReason", "Void reason");
+                        })
+                        .build())
                 .willRespondWith()
                 .status(400)
                 .headers(Map.of("Content-Type", "application/json"))
@@ -49,8 +57,9 @@ public final class VoidClaimNotFoundPactTest extends AbstractPactTest {
     @DisplayName("Verify 400 response - claim does not exist")
     @PactTestFor(pactMethod = "voidClaim400NoClaimExists")
     void verify400Response() {
+        VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), "Void reason");
         assertThrows(
                 BadRequest.class,
-                () -> claimsApiClient.voidClaim(CLAIM_ID.toString()).block());
+                () -> claimsApiClient.voidClaim(CLAIM_ID.toString(), request).block());
     }
 }

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
@@ -41,6 +41,7 @@ public final class VoidClaimNotFoundPactTest extends AbstractPactTest {
                 .uponReceiving("a request to void a non-existent claim")
                 .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
                 .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
+                .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
                 .method("POST")
                 .body(LambdaDsl.newJsonBody(body -> {
                             body.uuid("createdByUserId");

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimNotFoundPactTest.java
@@ -1,0 +1,56 @@
+package uk.gov.justice.laa.amend.claim;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTest;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClientResponseException.BadRequest;
+import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
+import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"claims-api.url=http://localhost:1241"})
+@PactConsumerTest
+@PactTestFor(providerName = AbstractPactTest.PROVIDER)
+@MockServerConfig(port = "1241")
+@Import(ClaimsApiPactTestConfig.class)
+@DisplayName("POST: /api/v1/claims/{claimId}/void - 400 PACT test")
+public final class VoidClaimNotFoundPactTest extends AbstractPactTest {
+
+    @Autowired
+    ClaimsApiClient claimsApiClient;
+
+    @Pact(consumer = CONSUMER)
+    public RequestResponsePact voidClaim400NoClaimExists(PactDslWithProvider builder) {
+        return builder.given("no claim exists")
+                .uponReceiving("a request to void a non-existent claim")
+                .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
+                .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
+                .method("POST")
+                .willRespondWith()
+                .status(400)
+                .headers(Map.of("Content-Type", "application/json"))
+                .toPact();
+    }
+
+    @Test
+    @DisplayName("Verify 400 response - claim does not exist")
+    @PactTestFor(pactMethod = "voidClaim400NoClaimExists")
+    void verify400Response() {
+        assertThrows(
+                BadRequest.class,
+                () -> claimsApiClient.voidClaim(CLAIM_ID.toString()).block());
+    }
+}

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
@@ -1,0 +1,68 @@
+package uk.gov.justice.laa.amend.claim;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import au.com.dius.pact.consumer.dsl.LambdaDsl;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit.MockServerConfig;
+import au.com.dius.pact.consumer.junit5.PactConsumerTest;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
+import uk.gov.justice.laa.amend.claim.client.VoidClaim201Response;
+import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
+
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {"claims-api.url=http://localhost:1240"})
+@PactConsumerTest
+@PactTestFor(providerName = AbstractPactTest.PROVIDER)
+@MockServerConfig(port = "1240")
+@Import(ClaimsApiPactTestConfig.class)
+@DisplayName("POST: /api/v1/claims/{claimId}/void - 201 PACT test")
+public final class VoidClaimSuccessPactTest extends AbstractPactTest {
+
+    @Autowired
+    ClaimsApiClient claimsApiClient;
+
+    @Pact(consumer = CONSUMER)
+    public RequestResponsePact voidClaim201(PactDslWithProvider builder) {
+        return builder.given("a claim exists")
+                .uponReceiving("a request to void a valid claim")
+                .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
+                .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
+                .method("POST")
+                .willRespondWith()
+                .status(201)
+                .headers(Map.of("Content-Type", "application/json"))
+                .body(LambdaDsl.newJsonBody(body -> {
+                            body.uuid("id", UUID.fromString("3fa85f64-5717-4562-b3fc-2c963f66afa6"));
+                        })
+                        .build())
+                .toPact();
+    }
+
+    @Test
+    @DisplayName("Verify 201 response - claim voided successfully")
+    @PactTestFor(pactMethod = "voidClaim201")
+    void verify201Response() {
+        ResponseEntity<VoidClaim201Response> response =
+                claimsApiClient.voidClaim(CLAIM_ID.toString()).block();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getId()).isNotNull();
+    }
+}

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
@@ -43,6 +43,7 @@ public final class VoidClaimSuccessPactTest extends AbstractPactTest {
                 .uponReceiving("a request to void a valid claim")
                 .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
                 .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
+                .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
                 .method("POST")
                 .body(LambdaDsl.newJsonBody(body -> {
                             body.uuid("createdByUserId");

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
@@ -21,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
 import uk.gov.justice.laa.amend.claim.client.VoidClaim201Response;
+import uk.gov.justice.laa.amend.claim.client.VoidClaimRequest;
 import uk.gov.justice.laa.amend.claim.config.ClaimsApiPactTestConfig;
 
 @SpringBootTest(
@@ -43,6 +44,11 @@ public final class VoidClaimSuccessPactTest extends AbstractPactTest {
                 .matchPath("/api/v1/claims/(" + UUID_REGEX + ")/void")
                 .matchHeader(HttpHeaders.AUTHORIZATION, UUID_REGEX)
                 .method("POST")
+                .body(LambdaDsl.newJsonBody(body -> {
+                            body.uuid("createdByUserId");
+                            body.stringType("assessmentReason", "Void reason");
+                        })
+                        .build())
                 .willRespondWith()
                 .status(201)
                 .headers(Map.of("Content-Type", "application/json"))
@@ -57,8 +63,9 @@ public final class VoidClaimSuccessPactTest extends AbstractPactTest {
     @DisplayName("Verify 201 response - claim voided successfully")
     @PactTestFor(pactMethod = "voidClaim201")
     void verify201Response() {
+        VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), "Void reason");
         ResponseEntity<VoidClaim201Response> response =
-                claimsApiClient.voidClaim(CLAIM_ID.toString()).block();
+                claimsApiClient.voidClaim(CLAIM_ID.toString(), request).block();
 
         assertThat(response).isNotNull();
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimSuccessPactTest.java
@@ -46,8 +46,8 @@ public final class VoidClaimSuccessPactTest extends AbstractPactTest {
                 .matchHeader(HttpHeaders.CONTENT_TYPE, "application/json.*", "application/json")
                 .method("POST")
                 .body(LambdaDsl.newJsonBody(body -> {
-                            body.uuid("createdByUserId");
-                            body.stringType("assessmentReason", "Void reason");
+                            body.uuid("created_by_user_id");
+                            body.stringType("assessment_reason", "Void reason");
                         })
                         .build())
                 .willRespondWith()

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/config/ClaimsApiPactTestConfig.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/config/ClaimsApiPactTestConfig.java
@@ -1,0 +1,6 @@
+package uk.gov.justice.laa.amend.claim.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+
+@TestConfiguration
+public class ClaimsApiPactTestConfig {}

--- a/src/pactTest/resources/application.yml
+++ b/src/pactTest/resources/application.yml
@@ -1,0 +1,36 @@
+spring:
+  profiles:
+    active: local
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.session.SessionAutoConfiguration
+  data:
+    redis:
+      url: redis://localhost:6379
+  session:
+    store-type: none
+
+management:
+  health:
+    redis:
+      enabled: false
+
+claims-api:
+  url: http://localhost:1234
+  access-token: e37da3d4-b8bc-4204-9528-deb6fa3bb39d
+microsoft-graph-api:
+  url: http://localhost:1234
+provider-api:
+  url: http://localhost:1234
+  access-token: e37da3d4-b8bc-4204-9528-deb6fa3bb39d
+search:
+  sort-enabled: true
+submission:
+  high-value-assessment-limit: 25000
+app:
+  feedback-url: http://localhost
+  laa-url: http://localhost
+  email: test@example.com
+sentry:
+  dsn: ""

--- a/src/pactTest/resources/pact.properties
+++ b/src/pactTest/resources/pact.properties
@@ -1,0 +1,3 @@
+pactbroker.url = http://localhost:9292
+pactbroker.auth.username = $PACT_USER
+pactbroker.auth.password = $PACT_PASSWORD


### PR DESCRIPTION
## What is this PR?

[BC-471](https://dsdmoj.atlassian.net/browse/BC-471)

 Adds consumer-driven contract (Pact) tests for the new POST /api/v1/claims/{claimId}/void endpoint on the Claims API, and integrates Pact into the CI/CD pipeline.  
 

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

