### PR TITLE
BC-382: Use feature flag for Void claim button

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/FeatureFlagsConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/FeatureFlagsConfig.java
@@ -8,5 +8,5 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConfigurationProperties(prefix = "feature-flags")
 public class FeatureFlagsConfig {
-    private boolean isVoidingEnabled;
+    private Boolean isVoidingEnabled;
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.server.ResponseStatusException;
+import uk.gov.justice.laa.amend.claim.config.FeatureFlagsConfig;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
@@ -30,6 +31,7 @@ public class ClaimSummaryController {
     private final ClaimService claimService;
     private final AssessmentService assessmentService;
     private final UserRetrievalService userRetrievalService;
+    private final FeatureFlagsConfig featureFlagsConfig;
 
     @GetMapping("/submissions/{submissionId}/claims/{claimId}")
     public String onPageLoad(
@@ -57,6 +59,10 @@ public class ClaimSummaryController {
         model.addAttribute("claimId", claimId);
         model.addAttribute("submissionId", submissionId);
         model.addAttribute("claim", claim.toViewModel());
+
+        boolean isVoidClaimPresent = featureFlagsConfig.getIsVoidingEnabled() && !claim.isVoided();
+        model.addAttribute("isVoidClaimPresent", isVoidClaimPresent);
+
         return "claim-summary";
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/VoidConfirmationController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/VoidConfirmationController.java
@@ -7,26 +7,24 @@ import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import uk.gov.justice.laa.amend.claim.config.FeatureFlagsConfig;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 
+@AllArgsConstructor
 @Controller
 @RequestMapping("/submissions/{submissionId}/claims/{claimId}/void")
 @Slf4j
 public class VoidConfirmationController {
 
-    private final boolean isVoidingEnabled;
-
-    public VoidConfirmationController(@Value("${feature-flags.is-voiding-enabled}") boolean isVoidingEnabled) {
-        this.isVoidingEnabled = isVoidingEnabled;
-    }
+    private final FeatureFlagsConfig featureFlagsConfig;
 
     @GetMapping
     public String onPageLoad(
@@ -36,7 +34,7 @@ public class VoidConfirmationController {
             @PathVariable UUID submissionId,
             @PathVariable UUID claimId)
             throws IOException {
-        if (!isVoidingEnabled) {
+        if (!featureFlagsConfig.getIsVoidingEnabled()) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return null;
         }
@@ -54,7 +52,7 @@ public class VoidConfirmationController {
             @PathVariable UUID claimId,
             HttpServletResponse response)
             throws IOException {
-        if (!isVoidingEnabled) {
+        if (!featureFlagsConfig.getIsVoidingEnabled()) {
             response.sendError(HttpServletResponse.SC_NOT_FOUND);
             return null;
         }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/AssessmentService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/AssessmentService.java
@@ -11,7 +11,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
-import uk.gov.justice.laa.amend.claim.config.FeatureFlagsConfig;
 import uk.gov.justice.laa.amend.claim.handlers.ClaimStatusHandler;
 import uk.gov.justice.laa.amend.claim.mappers.AssessmentMapper;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
@@ -41,8 +40,7 @@ public class AssessmentService {
             AssessmentMapper assessmentMapper,
             ClaimStatusHandler claimStatusHandler,
             MeterRegistry meterRegistry,
-            @Value("${submission.high-value-assessment-limit}") BigDecimal highValueAssessmentLimit,
-            FeatureFlagsConfig featureFlagsConfig) {
+            @Value("${submission.high-value-assessment-limit}") BigDecimal highValueAssessmentLimit) {
         this.claimsApiClient = claimsApiClient;
         this.assessmentMapper = assessmentMapper;
         this.claimStatusHandler = claimStatusHandler;

--- a/src/main/resources/templates/claim-summary.html
+++ b/src/main/resources/templates/claim-summary.html
@@ -127,7 +127,7 @@
                                     </button>
                                 </th:block>
 
-                                <th:block sec:authorize="hasRole('ROLE_CLAIM_AMENDMENTS_CASEWORKER')" th:if="${!claim.isVoidClaim}">
+                                <th:block th:if="${isVoidClaimPresent}">
                                     <button class="govuk-button govuk-button--warning"
                                             data-module="govuk-button"
                                             th:data-testid="claim-details-void-button"

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryControllerTest.java
@@ -24,6 +24,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.amend.claim.config.FeatureFlagsConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.config.security.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.models.AssessmentInfo;
@@ -54,6 +55,9 @@ public class ClaimSummaryControllerTest {
 
     @MockitoBean
     private AssessmentService assessmentService;
+
+    @MockitoBean
+    private FeatureFlagsConfig featureFlagsConfig;
 
     private UUID submissionId;
     private UUID claimId;

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/VoidConfirmationControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/VoidConfirmationControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers;
 
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -19,6 +20,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.justice.laa.amend.claim.config.FeatureFlagsConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.config.security.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
@@ -27,9 +29,7 @@ import uk.gov.justice.laa.amend.claim.service.AssessmentService;
 import uk.gov.justice.laa.amend.claim.service.MaintenanceService;
 
 @ActiveProfiles("local")
-@WebMvcTest(
-        controllers = VoidConfirmationController.class,
-        properties = {"feature-flags.is-voiding-enabled=true"})
+@WebMvcTest(controllers = VoidConfirmationController.class)
 @Import({LocalSecurityConfig.class, ThymeleafConfig.class})
 public class VoidConfirmationControllerTest {
 
@@ -41,6 +41,9 @@ public class VoidConfirmationControllerTest {
 
     @MockitoBean
     private AssessmentService assessmentService;
+
+    @MockitoBean
+    private FeatureFlagsConfig featureFlagsConfig;
 
     private UUID submissionId;
     private UUID claimId;
@@ -57,6 +60,7 @@ public class VoidConfirmationControllerTest {
         claim.setClaimId(claimId.toString());
         MockClaimsFunctions.updateStatus(claim, claim.getAssessmentOutcome());
         session.setAttribute(claimId.toString(), claim);
+        when(featureFlagsConfig.getIsVoidingEnabled()).thenReturn(true);
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/AssessmentServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/AssessmentServiceTest.java
@@ -77,12 +77,7 @@ class AssessmentServiceTest {
         sort = "createdOn,desc";
         meterRegistry = new SimpleMeterRegistry();
         assessmentService = new AssessmentService(
-                claimsApiClient,
-                assessmentMapper,
-                claimStatusHandler,
-                meterRegistry,
-                HIGH_VALUE_ASSESSMENT_LIMIT,
-                featureFlagsConfig);
+                claimsApiClient, assessmentMapper, claimStatusHandler, meterRegistry, HIGH_VALUE_ASSESSMENT_LIMIT);
     }
 
     @Nested

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ViewTestBase.java
@@ -26,6 +26,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.util.MultiValueMap;
+import uk.gov.justice.laa.amend.claim.config.FeatureFlagsConfig;
 import uk.gov.justice.laa.amend.claim.config.ThymeleafConfig;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
@@ -39,6 +40,9 @@ public abstract class ViewTestBase {
 
     @MockitoBean
     private MaintenanceService maintenanceService;
+
+    @MockitoBean
+    protected FeatureFlagsConfig featureFlagsConfig;
 
     @BeforeEach
     public void setup() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/VoidConfirmationViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/VoidConfirmationViewTest.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.amend.claim.views;
 
+import static org.mockito.Mockito.when;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import org.jsoup.nodes.Document;
@@ -14,9 +16,7 @@ import uk.gov.justice.laa.amend.claim.controllers.VoidConfirmationController;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 
 @ActiveProfiles("local")
-@WebMvcTest(
-        controllers = VoidConfirmationController.class,
-        properties = {"feature-flags.is-voiding-enabled=true"})
+@WebMvcTest(VoidConfirmationController.class)
 @Import(LocalSecurityConfig.class)
 class VoidConfirmationViewTest extends ViewTestBase {
 
@@ -26,6 +26,8 @@ class VoidConfirmationViewTest extends ViewTestBase {
 
     @Test
     void testPageForCivilClaim() throws Exception {
+        when(featureFlagsConfig.getIsVoidingEnabled()).thenReturn(true);
+
         var claim = MockClaimsFunctions.createMockCivilClaim();
         this.claim = claim;
         claim.setSubmissionId(submissionId.toString());
@@ -62,6 +64,8 @@ class VoidConfirmationViewTest extends ViewTestBase {
 
     @Test
     void testPageForCrimeClaim() throws Exception {
+        when(featureFlagsConfig.getIsVoidingEnabled()).thenReturn(true);
+
         var claim = MockClaimsFunctions.createMockCrimeClaim();
         this.claim = claim;
         claim.setSubmissionId(submissionId.toString());

--- a/wiremock/__files/get-claims-response.json
+++ b/wiremock/__files/get-claims-response.json
@@ -152,7 +152,7 @@
     {
       "id": "0199a474-65d5-7f95-a1f3-290976326ecd",
       "submission_id": "ddc07f4f-563d-434d-bc6e-8e07577c7811",
-      "status": "READY_TO_PROCESS",
+      "status": "VOID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 2,
       "case_reference_number": "EF/4439/2017/3078011",
@@ -300,7 +300,7 @@
     {
       "id": "0199a474-6834-72db-866d-d540e41b0a99",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VOID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 4,
       "case_reference_number": "DM/4604/2019/4334501",
@@ -448,7 +448,7 @@
     {
       "id": "0199a474-6987-7233-a749-85f14de24111",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 5,
       "case_reference_number": "SJ/4546/18/3481072",
@@ -596,7 +596,7 @@
     {
       "id": "0199a474-6a80-7b13-aeb5-5e2108a48044",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 8,
       "case_reference_number": "EC/4570/2019/4114714",
@@ -744,7 +744,7 @@
     {
       "id": "0199a474-6b5b-7603-ad16-3b7fadad1071",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 10,
       "case_reference_number": "EC/4571/2018/4016343",
@@ -854,7 +854,7 @@
     {
       "id": "0199a474-6c1b-74eb-8f7a-0c9d4b649e71",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 12,
       "case_reference_number": "NB/4549/19/4620803",
@@ -964,7 +964,7 @@
     {
       "id": "0199a474-6cdc-7d10-83ca-c762803e7a48",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 13,
       "case_reference_number": "NT/4563/2019/4238506",
@@ -1074,7 +1074,7 @@
     {
       "id": "0199a474-6833-79f1-be13-03992c636c1d",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 3,
       "case_reference_number": "DM/4557/2019/4648695",
@@ -1184,7 +1184,7 @@
     {
       "id": "0199a474-6973-7355-85ce-8b04fa45ee17",
       "submission_id": "0199a474-518d-7794-97e0-65ccabfe692f",
-      "status": "READY_TO_PROCESS",
+      "status": "VALID",
       "schedule_reference": "0U733A/2018/02",
       "line_number": 6,
       "case_reference_number": "SJ/4512/18/3310795",


### PR DESCRIPTION
## What is this PR?

Wires up the feature flag to the Void claim button and removes role check from it so we can see the button before roles are setup

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

