### PR TITLE
BC-497: Setting 5 second timeout for requests to provider details API.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/config/ProviderApiProperties.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/config/ProviderApiProperties.java
@@ -14,8 +14,12 @@ public class ProviderApiProperties {
     @NotBlank
     private final String accessToken;
 
-    public ProviderApiProperties(String url, String accessToken) {
+    @NotBlank
+    private final long timeout;
+
+    public ProviderApiProperties(String url, String accessToken, long timeout) {
         this.url = url;
         this.accessToken = accessToken;
+        this.timeout = timeout;
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/client/config/WebClientConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/client/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.client.config;
 
+import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -58,6 +59,7 @@ public class WebClientConfig {
                 .build();
 
         WebClientAdapter webClientAdapter = WebClientAdapter.create(webClient);
+        webClientAdapter.setBlockTimeout(Duration.ofMillis(properties.getTimeout()));
         HttpServiceProxyFactory factory =
                 HttpServiceProxyFactory.builderFor(webClientAdapter).build();
         return factory.createClient(ProviderApiClient.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,7 @@ microsoft-graph-api:
 provider-api:
   url: ${PROVIDER_API}
   access-token: ${PROVIDER_TOKEN}
+  timeout: 5000
 search:
   sort-enabled: true
 submission:


### PR DESCRIPTION
## BC-497

[Link to story](https://dsdmoj.atlassian.net/browse/BC-497)

Configuring a 5 second request timeout for the provider details API client.

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

