### PR TITLE
BC-522: Fix E2E cleanup to only run on success, allowing failed job rerun

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -296,7 +296,7 @@ jobs:
   cleanup-e2e-environment:
     name: Cleanup E2E Environment
     needs: run-e2e-tests
-    if: always()
+    if: success()
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
     env:


### PR DESCRIPTION


## What is this PR?

[BC-522](https://dsdmoj.atlassian.net/browse/BC-522)

Describe what you did and why.

Previously, the E2E environment was torn down regardless of test outcome. When tests failed, the environment was destroyed, meaning developers couldn't simply rerun the failed job. This change preserves the environment on failure, allowing quick reruns of just the failed E2E test job.                                                                                       

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

