### PR TITLE
[DSTEW-1259] - Loosen content type validation on pact test error responses

### DIFF
--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentPactTest.java
@@ -74,7 +74,7 @@ public final class CreateAssessmentPactTest extends AbstractPactTest {
                         .build())
                 .willRespondWith()
                 .status(404)
-                .headers(Map.of("Content-Type", "application/json"))
+                .matchHeader("Content-Type", "application/(problem\\+)?json")
                 .toPact();
     }
 

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimPactTest.java
@@ -66,7 +66,7 @@ public final class VoidClaimPactTest extends AbstractPactTest {
                         .build())
                 .willRespondWith()
                 .status(404)
-                .headers(Map.of("Content-Type", "application/json"))
+                .matchHeader("Content-Type", "application/(problem\\+)?json")
                 .toPact();
     }
 


### PR DESCRIPTION
## What is this PR?

[Link to story](https://dsdmoj.atlassian.net/browse/DSTEW-1259)

Updated the Pact test to relax content‑type validation for errors while we transition to the new error messaging.

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

