### PR TITLE
BC-515: Remove liable for VAT question from assessment outcome flow

### DIFF
--- a/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/AssessmentOutcomePage.java
+++ b/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/AssessmentOutcomePage.java
@@ -4,7 +4,6 @@ import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertTha
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
-import com.microsoft.playwright.options.AriaRole;
 
 public class AssessmentOutcomePage extends LaaInputPage {
 
@@ -12,11 +11,6 @@ public class AssessmentOutcomePage extends LaaInputPage {
     private final Locator reducedStillEscapedRadio;
     private final Locator reducedToFixedFeeRadio;
     private final Locator nilledRadio;
-
-    private final Locator vatGroup;
-    private final Locator vatLegend;
-    private final Locator vatYesRadio;
-    private final Locator vatNoRadio;
 
     private final Locator errorSummaryTitle;
     private final Locator errorSummaryLink;
@@ -31,12 +25,6 @@ public class AssessmentOutcomePage extends LaaInputPage {
                 page.getByLabel("Reduced to fixed fee (assessed)", new Page.GetByLabelOptions().setExact(true));
         this.nilledRadio = page.getByLabel("Nilled", new Page.GetByLabelOptions().setExact(true));
 
-        this.vatGroup =
-                page.getByRole(AriaRole.GROUP, new Page.GetByRoleOptions().setName("Is this claim liable for VAT?"));
-        this.vatLegend = page.getByText("Is this claim liable for VAT?");
-        this.vatYesRadio = vatGroup.getByLabel("Yes", new Locator.GetByLabelOptions().setExact(true));
-        this.vatNoRadio = vatGroup.getByLabel("No", new Locator.GetByLabelOptions().setExact(true));
-
         this.errorSummaryTitle = page.locator(".govuk-error-summary__title");
         this.errorSummaryLink = page.locator(".govuk-error-summary__list a");
     }
@@ -46,10 +34,6 @@ public class AssessmentOutcomePage extends LaaInputPage {
         assertThat(reducedStillEscapedRadio).isVisible();
         assertThat(reducedToFixedFeeRadio).isVisible();
         assertThat(nilledRadio).isVisible();
-
-        assertThat(vatLegend).isVisible();
-        assertThat(vatYesRadio).isVisible();
-        assertThat(vatNoRadio).isVisible();
 
         assertThat(saveButton).isVisible();
     }
@@ -88,17 +72,8 @@ public class AssessmentOutcomePage extends LaaInputPage {
         }
     }
 
-    public void selectVatLiable(boolean isLiable) {
-        if (isLiable) {
-            vatYesRadio.check();
-        } else {
-            vatNoRadio.check();
-        }
-    }
-
-    public void completeAssessment(String outcome, boolean vat) {
+    public void completeAssessment(String outcome) {
         selectAssessmentOutcome(outcome);
-        selectVatLiable(vat);
         saveChanges();
     }
 }

--- a/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/ReviewAndAmendPage.java
+++ b/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/ReviewAndAmendPage.java
@@ -69,10 +69,6 @@ public class ReviewAndAmendPage extends LaaErrorSummaryPage {
         clickChangeInRow("Assessment outcome", assessmentTable);
     }
 
-    public void clickLiableForVat() {
-        clickChangeInRow("Is this claim liable for VAT?", assessmentTable);
-    }
-
     public void clickChangeProfitCosts() {
         clickChangeInRow("Profit costs", claimCostsTable);
     }
@@ -136,15 +132,9 @@ public class ReviewAndAmendPage extends LaaErrorSummaryPage {
         assertTableHasHeaders(totalClaimValueTable, "Item", "Calculated", "Requested", "Assessed");
         assertTableHasHeaders(totalAllowedValueTable, "Item", "Calculated", "Requested", "Allowed");
 
-        assertAssessmentHasItems("Assessment outcome", "Is this claim liable for VAT?");
+        assertAssessmentHasItems("Assessment outcome");
         assertClaimCostsHasItems(
-                "Fixed fee",
-                "Profit costs",
-                "Disbursements",
-                "Disbursement VAT",
-                "Travel costs",
-                "Waiting costs",
-                "VAT");
+                "Fixed fee", "Profit costs", "Disbursements", "Disbursement VAT", "Travel costs", "Waiting costs");
         assertClaimCostsNotHasItems("Total");
         assertThat(saveButton).isVisible();
         assertThat(cancelButton).isVisible();
@@ -155,7 +145,7 @@ public class ReviewAndAmendPage extends LaaErrorSummaryPage {
         assertTableHasHeaders(totalClaimValueTable, "Item", "Calculated", "Requested", "Assessed");
         assertTableHasHeaders(totalAllowedValueTable, "Item", "Calculated", "Requested", "Allowed");
 
-        assertAssessmentHasItems("Assessment outcome", "Is this claim liable for VAT?");
+        assertAssessmentHasItems("Assessment outcome");
         assertClaimCostsHasItems(
                 "Fixed fee",
                 "Profit costs",
@@ -163,8 +153,7 @@ public class ReviewAndAmendPage extends LaaErrorSummaryPage {
                 "Disbursement VAT",
                 "Detention travel and waiting costs",
                 "JR and form filling",
-                "Counsel costs",
-                "VAT");
+                "Counsel costs");
         assertClaimCostsNotHasItems("Total");
 
         assertThat(saveButton).isVisible();

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessmentFlowE2ETest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/AssessmentFlowE2ETest.java
@@ -86,7 +86,6 @@ public class AssessmentFlowE2ETest extends BaseTest {
 
         AssessmentOutcomePage outcome = new AssessmentOutcomePage(page);
         outcome.selectAssessmentOutcome("assessed in full");
-        outcome.selectVatLiable(true);
         outcome.saveChanges();
 
         ReviewAndAmendPage review = new ReviewAndAmendPage(page);

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/DiscardAssessmentTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/DiscardAssessmentTest.java
@@ -154,7 +154,7 @@ public class DiscardAssessmentTest extends BaseTest {
         details.clickAddUpdateAssessmentOutcome();
 
         AssessmentOutcomePage outcome = new AssessmentOutcomePage(page);
-        outcome.completeAssessment("assessed in full", true);
+        outcome.completeAssessment("assessed in full");
 
         return new ReviewAndAmendPage(page);
     }

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/E2eBaseTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/E2eBaseTest.java
@@ -115,7 +115,6 @@ public abstract class E2eBaseTest extends BaseTest {
 
         AssessmentOutcomePage outcome = new AssessmentOutcomePage(page);
         outcome.selectAssessmentOutcome(assessmentOutcome);
-        outcome.selectVatLiable(true);
         outcome.saveChanges();
     }
 

--- a/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/ReviewAndAmendTest.java
+++ b/src/e2e/test/java/uk/gov/justice/laa/amend/claim/tests/ReviewAndAmendTest.java
@@ -116,11 +116,6 @@ public class ReviewAndAmendTest extends BaseTest {
 
         // Minimal inputs to proceed
         outcome.selectAssessmentOutcome(outcomeValue);
-
-        // VAT is defaulted on your HTML (often "No" checked), and not needed for these tests.
-        // If your app requires VAT explicitly, uncomment one line:
-        // outcome.selectVatLiable(false);
-
         outcome.saveChanges();
     }
 
@@ -208,18 +203,6 @@ public class ReviewAndAmendTest extends BaseTest {
     }
 
     @Test
-    @DisplayName("Review & amend (Crime) change VAT liability – navigates correctly")
-    void crimeChangeVatLiability() {
-        navigateToReviewAndAmend(CRIME_OFFICE_CODE, CRIME_MONTH, CRIME_YEAR, CRIME_UFN);
-
-        ReviewAndAmendPage review = new ReviewAndAmendPage(page);
-
-        review.clickLiableForVat();
-
-        assertTrue(page.url().contains("/assessment-outcome"));
-    }
-
-    @Test
     @DisplayName("Review & amend (Civil) change assessment outcome – navigates correctly")
     void civilChangeAssessmentOutcome() {
         navigateToReviewAndAmend(CIVIL_OFFICE_CODE, CIVIL_MONTH, CIVIL_YEAR, CIVIL_UFN);
@@ -227,18 +210,6 @@ public class ReviewAndAmendTest extends BaseTest {
         ReviewAndAmendPage review = new ReviewAndAmendPage(page);
 
         review.clickAssessmentOutcome();
-
-        assertTrue(page.url().contains("/assessment-outcome"));
-    }
-
-    @Test
-    @DisplayName("Review & amend (Civil) change VAT liability – navigates correctly")
-    void civilChangeVatLiability() {
-        navigateToReviewAndAmend(CIVIL_OFFICE_CODE, CIVIL_MONTH, CIVIL_YEAR, CIVIL_UFN);
-
-        ReviewAndAmendPage review = new ReviewAndAmendPage(page);
-
-        review.clickLiableForVat();
 
         assertTrue(page.url().contains("/assessment-outcome"));
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/constants/AmendClaimConstants.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/constants/AmendClaimConstants.java
@@ -24,7 +24,6 @@ public class AmendClaimConstants {
     public static final String ASSESSMENT_REASON_VOID = "Void";
 
     public static final String ASSESSMENT_OUTCOME_REQUIRED_ERROR = "{assessmentOutcome.assessmentOutcomeRequiredError}";
-    public static final String LIABILITY_FOR_VAT_REQUIRED_ERROR = "{assessmentOutcome.liabilityForVatRequiredError}";
 
     public static class Label {
         public static final String FIXED_FEE = "fixedFee";

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeController.java
@@ -37,11 +37,6 @@ public class AssessmentOutcomeController {
         AssessmentOutcomeForm form = new AssessmentOutcomeForm();
         form.setAssessmentOutcome(claim.getAssessmentOutcome());
 
-        // Load VAT liability from vatClaimed
-        if (claim.getVatClaimed() != null && claim.getVatClaimed().getAssessed() != null) {
-            form.setLiabilityForVat((Boolean) claim.getVatClaimed().getAssessed());
-        }
-
         return renderView(model, form, submissionId, claimId, claim);
     }
 
@@ -68,11 +63,6 @@ public class AssessmentOutcomeController {
 
         // Set the assessment outcome
         claim.setAssessmentOutcome(newOutcome);
-
-        // Update VAT liability in vatClaimed
-        if (claim.getVatClaimed() != null) {
-            claim.getVatClaimed().setAssessed(form.getLiabilityForVat());
-        }
 
         // Save updated Claim back to session
         session.setAttribute(claimId.toString(), claim);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/AssessmentOutcomeForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/AssessmentOutcomeForm.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.laa.amend.claim.forms;
 
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_OUTCOME_REQUIRED_ERROR;
-import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.LIABILITY_FOR_VAT_REQUIRED_ERROR;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -14,7 +13,4 @@ public class AssessmentOutcomeForm {
 
     @NotNull(message = ASSESSMENT_OUTCOME_REQUIRED_ERROR)
     private OutcomeType assessmentOutcome;
-
-    @NotNull(message = LIABILITY_FOR_VAT_REQUIRED_ERROR)
-    private Boolean liabilityForVat;
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/errors/AssessmentOutcomeFormError.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/errors/AssessmentOutcomeFormError.java
@@ -15,8 +15,6 @@ public class AssessmentOutcomeFormError extends FormError {
 
     @Override
     protected Map<String, Integer> getFieldOrderMap() {
-        return Map.of(
-                "assessmentOutcome", 1,
-                "liabilityForVAT", 2);
+        return Map.of("assessmentOutcome", 1);
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/handlers/ClaimStatusHandler.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/handlers/ClaimStatusHandler.java
@@ -6,7 +6,6 @@ import uk.gov.justice.laa.amend.claim.models.AssessedClaimField;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimField;
 import uk.gov.justice.laa.amend.claim.models.OutcomeType;
-import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 
 /**
  * Handles the mapping between different outcome types and their corresponding field assessment statuses.
@@ -36,7 +35,7 @@ public class ClaimStatusHandler {
     }
 
     private void handleNilledStatus(ClaimField field) {
-        field.setAssessable(field instanceof VatLiabilityClaimField);
+        field.setAssessable(false);
     }
 
     /**

--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapper.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.amend.claim.mappers;
 
+import static java.util.Objects.nonNull;
+
 import java.math.BigDecimal;
 import java.util.function.Function;
 import org.mapstruct.AfterMapping;
@@ -38,7 +40,7 @@ public interface AssessmentMapper {
             target = "assessmentReason",
             expression =
                     "java(uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_ESCAPE_CASE)")
-    @Mapping(target = "isVatApplicable", source = "vatApplicable")
+    @Mapping(target = "isVatApplicable", expression = "java(deriveVatApplicable(claim))")
     @Mapping(target = "boltOnAdjournedHearingFee", ignore = true)
     @Mapping(target = "jrFormFillingAmount", ignore = true)
     @Mapping(target = "boltOnCmrhOralFee", ignore = true)
@@ -266,6 +268,11 @@ public interface AssessmentMapper {
      */
     default BigDecimal mapAssessedTotalInclVat(ClaimDetails claim) {
         return mapToBigDecimal(claim.getAssessedTotalInclVat());
+    }
+
+    default Boolean deriveVatApplicable(ClaimDetails claim) {
+        BigDecimal allowedVat = mapAllowedTotalVat(claim);
+        return nonNull(allowedVat) && allowedVat.compareTo(BigDecimal.ZERO) > 0;
     }
 
     default BigDecimal mapAllowedTotalVat(ClaimDetails claim) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/VatLiabilityClaimField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/VatLiabilityClaimField.java
@@ -27,7 +27,7 @@ public class VatLiabilityClaimField extends ClaimField {
 
     @Override
     public void setAssessableToDefault() {
-        this.assessable = true;
+        this.assessable = false;
     }
 
     @Override

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -75,8 +75,7 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
 
     // 'Claim costs' rows for the 'Review and amend' page
     default List<ClaimFieldRow> getReviewClaimFieldRows() {
-        Stream<ClaimField> rows = Stream.concat(claimFields(), Stream.of(claim().getVatClaimed()));
-        return toClaimFieldRows(rows).toList();
+        return toClaimFieldRows(claimFields()).toList();
     }
 
     // 'Total claim value' rows for the 'Review and amend' page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -86,13 +86,11 @@ maintenance.default.message=We are performing scheduled maintenance.
 
 assessmentOutcome.mainHeading=Assessment outcome
 assessmentOutcome.title=Assessment outcome
-assessmentOutcome.vatLiabilitySubHeading=Is this claim liable for VAT?
 assessmentOutcome.paidInFull=Assessed in full
 assessmentOutcome.nilled=Nilled
 assessmentOutcome.reducedStillEscaped=Reduced (still escaped)
 assessmentOutcome.reducedAssessed=Reduced to fixed fee (assessed)
 assessmentOutcome.assessmentOutcomeRequiredError=Select the assessment outcome
-assessmentOutcome.liabilityForVatRequiredError=Select if this claim is liable for VAT
 assessmentOutcome.saveChanges=Save changes
 assessmentOutcome.cancel=Cancel
 
@@ -158,7 +156,6 @@ claimSummary.rows.allowedTotalInclVat=Allowed total incl VAT
 
 
 claimSummary.rows.assessmentOutcome=Assessment outcome
-claimSummary.rows.vatLiability=Is this claim liable for VAT?
 
 
 claimSummary.rows.profitCost.error=The submission must include profit costs

--- a/src/main/resources/templates/assessment-outcome.html
+++ b/src/main/resources/templates/assessment-outcome.html
@@ -60,34 +60,6 @@
                                 </fieldset>
                             </div>
 
-                            <div class="govuk-form-group">
-                                <fieldset class="govuk-fieldset">
-                                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m" th:text="#{assessmentOutcome.vatLiabilitySubHeading}"></legend>
-
-                                    <div th:classappend="${#fields.hasErrors('liabilityForVat')} ? 'govuk-form-group--error'">
-                                        <p th:if="${#fields.hasErrors('liabilityForVat')}" class="govuk-error-message">
-                                            <span class="govuk-visually-hidden" th:text="#{form.error}"></span>
-                                            <th:block th:errors=" *{liabilityForVat}"></th:block>
-                                        </p>
-
-                                        <div class="govuk-radios govuk-radios--inline govuk-radios--small" data-module="govuk-radios">
-                                            <div class="govuk-radios__item">
-                                                <input class="govuk-radios__input" id="liability-for-vat" name="liabilityForVat" type="radio" value="yes"
-                                                       th:checked="${form.liabilityForVat != null && form.liabilityForVat}">
-                                                <label class="govuk-label govuk-radios__label" for="liability-for-vat" th:text="#{service.yes}">
-                                                </label>
-                                            </div>
-                                            <div class="govuk-radios__item">
-                                                <input class="govuk-radios__input" id="liability-for-vat-2" name="liabilityForVat" type="radio" value="no"
-                                                       th:checked="${form.liabilityForVat != null && !form.liabilityForVat}">
-                                                <label class="govuk-label govuk-radios__label" for="liability-for-vat-2" th:text="#{service.no}">
-                                                </label>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </fieldset>
-                            </div>
-
                             <th:block th:if="${form.getAssessmentOutcome() != null }">
                                 <div class="govuk-button-group">
                                     <button class="govuk-button" type="submit" th:text="#{assessmentOutcome.saveChanges}"></button>

--- a/src/main/resources/templates/review-and-amend.html
+++ b/src/main/resources/templates/review-and-amend.html
@@ -57,24 +57,6 @@
                     </td>
                 </tr>
 
-                <tr class="govuk-table__row">
-
-                    <td class="govuk-table__cell govuk-!-font-weight-bold" th:text="#{claimSummary.rows.vatLiability}"></td>
-
-                    <td class="govuk-table__cell" colspan="3"
-                        th:text="${@ThymeleafUtils.getFormattedValue(claim.vatClaimed.getAssessed()).resolve(#messages)}"/>
-
-                    <td class="govuk-table__cell">
-                        <a
-                           th:href="${viewModel.reviewAssessmentChangeUrl(submissionId, claimId, 'liability-for-vat')}"
-                           th:data-testid="claim-field-vat-liability"
-                           class="govuk-link govuk-link--no-visited-state">
-                            <th:block th:text="#{service.change}"></th:block>
-                            <span class="govuk-visually-hidden" th:text="| #{claimSummary.rows.vatLiability}|"></span>
-                        </a>
-                    </td>
-
-                </tr>
                 </tbody>
             </table>
         </div>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/AssessmentOutcomeControllerTest.java
@@ -47,11 +47,7 @@ public class AssessmentOutcomeControllerTest extends BaseControllerTest {
 
     @Test
     public void testOnSubmitReturnsBadRequestWithViewForInvalidForm() throws Exception {
-        mockMvc.perform(post(buildPath())
-                        .session(session)
-                        .with(csrf())
-                        .param("assessmentOutcome", "")
-                        .param("liabilityForVat", ""))
+        mockMvc.perform(post(buildPath()).session(session).with(csrf()).param("assessmentOutcome", ""))
                 .andExpect(status().isBadRequest())
                 .andExpect(view().name("assessment-outcome"));
     }
@@ -60,11 +56,7 @@ public class AssessmentOutcomeControllerTest extends BaseControllerTest {
     public void testOnSubmitRedirects() throws Exception {
         String redirectUrl = String.format("/submissions/%s/claims/%s/review", submissionId, claimId);
 
-        mockMvc.perform(post(buildPath())
-                        .session(session)
-                        .with(csrf())
-                        .param("assessmentOutcome", "paid-in-full")
-                        .param("liabilityForVat", "true"))
+        mockMvc.perform(post(buildPath()).session(session).with(csrf()).param("assessmentOutcome", "paid-in-full"))
                 .andExpect(status().is3xxRedirection())
                 .andExpect(redirectedUrl(redirectUrl));
     }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapperTest.java
@@ -40,7 +40,6 @@ class AssessmentMapperTest {
         String userId = UUID.randomUUID().toString();
 
         CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
-        claim.setVatApplicable(true);
 
         AssessmentPost assessment = mapper.mapCivilClaimToAssessment(claim, userId);
 
@@ -73,7 +72,6 @@ class AssessmentMapperTest {
         String userId = UUID.randomUUID().toString();
 
         CrimeClaimDetails claim = MockClaimsFunctions.createMockCrimeClaim();
-        claim.setVatApplicable(true);
 
         AssessmentPost assessment = mapper.mapCrimeClaimToAssessment(claim, userId);
 
@@ -93,6 +91,34 @@ class AssessmentMapperTest {
         assertEquals(true, assessment.getIsVatApplicable());
         assertEquals(ASSESSMENT_REASON_ESCAPE_CASE, assessment.getAssessmentReason());
         assertEquals(userId, assessment.getCreatedByUserId());
+    }
+
+    @Test
+    void testVatApplicableIsFalseWhenAllowedTotalVatIsZero() {
+        String userId = UUID.randomUUID().toString();
+
+        CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        claim.setAllowedTotalVat(AllowedClaimField.builder()
+                .key(ALLOWED_TOTAL_VAT)
+                .assessed(BigDecimal.ZERO)
+                .build());
+
+        AssessmentPost assessment = mapper.mapCivilClaimToAssessment(claim, userId);
+
+        assertEquals(false, assessment.getIsVatApplicable());
+    }
+
+    @Test
+    void testVatApplicableIsFalseWhenAllowedTotalVatIsNull() {
+        String userId = UUID.randomUUID().toString();
+
+        CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+        claim.setAllowedTotalVat(
+                AllowedClaimField.builder().key(ALLOWED_TOTAL_VAT).build());
+
+        AssessmentPost assessment = mapper.mapCivilClaimToAssessment(claim, userId);
+
+        assertEquals(false, assessment.getIsVatApplicable());
     }
 
     @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimStatusHandlerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimStatusHandlerTest.java
@@ -118,14 +118,14 @@ class ClaimStatusHandlerTest {
         }
 
         @Test
-        void shouldSetVatClaimedFieldToModifiable() {
+        void shouldSetVatClaimedFieldToNotModifiable() {
             ClaimField vatClaimedField = MockClaimsFunctions.createVatClaimedField();
             ClaimDetails civilClaimDetails = new CivilClaimDetails();
             civilClaimDetails.setVatClaimed(vatClaimedField);
 
             claimStatusHandler.updateFieldStatuses(civilClaimDetails, OutcomeType.NILLED);
 
-            assertThat(vatClaimedField.isAssessable()).isTrue();
+            assertThat(vatClaimedField.isAssessable()).isFalse();
         }
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
@@ -480,7 +480,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             claim.setSubstantiveHearing(updateClaimFieldSubmittedValue(claim.getSubstantiveHearing(), true));
             List<ClaimFieldRow> result = viewModel.getReviewClaimFieldRows();
 
-            Assertions.assertEquals(13, result.size());
+            Assertions.assertEquals(12, result.size());
 
             Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
 
@@ -538,13 +538,6 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             Assertions.assertEquals(ADJOURNED_FEE, result.get(11).getKey());
             Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).getSubmitted());
             Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).getCalculated());
-
-            Assertions.assertEquals(VAT, result.get(12).getKey());
-            Assertions.assertEquals(true, result.get(12).getSubmitted());
-            Assertions.assertEquals(false, result.get(12).getCalculated());
-            Assertions.assertEquals(
-                    "/submissions/%s/claims/%s/assessment-outcome",
-                    result.get(12).getChangeUrl());
         }
 
         @Test
@@ -559,7 +552,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimFieldRow> result = viewModel.getReviewClaimFieldRows();
 
-            Assertions.assertEquals(8, result.size());
+            Assertions.assertEquals(7, result.size());
 
             Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
 
@@ -597,13 +590,6 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
             Assertions.assertEquals(
                     "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
-
-            Assertions.assertEquals(VAT, result.get(7).getKey());
-            Assertions.assertEquals(true, result.get(7).getSubmitted());
-            Assertions.assertEquals(false, result.get(7).getCalculated());
-            Assertions.assertEquals(
-                    "/submissions/%s/claims/%s/assessment-outcome",
-                    result.get(7).getChangeUrl());
         }
 
         @Test
@@ -618,7 +604,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             CivilClaimDetailsView viewModel = createView(claim);
             List<ClaimFieldRow> result = viewModel.getReviewClaimFieldRows();
 
-            Assertions.assertEquals(8, result.size());
+            Assertions.assertEquals(7, result.size());
 
             Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
 
@@ -656,10 +642,6 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
             Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
             Assertions.assertEquals(
                     "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
-
-            Assertions.assertEquals(VAT, result.get(7).getKey());
-            Assertions.assertEquals(true, result.get(7).getSubmitted());
-            Assertions.assertEquals(false, result.get(7).getCalculated());
         }
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRowTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRowTest.java
@@ -233,7 +233,7 @@ public class ClaimFieldRowTest {
         Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
         Assertions.assertEquals(field.getCalculated(), result.getCalculated());
         Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-        Assertions.assertTrue(result.isAssessable());
+        Assertions.assertFalse(result.isAssessable());
         Assertions.assertEquals("/submissions/%s/claims/%s/assessment-outcome", result.getChangeUrl());
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
@@ -174,7 +174,7 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
             CrimeClaimDetailsView viewModel = createView(claim);
             List<ClaimFieldRow> result = viewModel.getReviewClaimFieldRows();
 
-            Assertions.assertEquals(7, result.size());
+            Assertions.assertEquals(6, result.size());
 
             Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
 
@@ -197,8 +197,6 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
             Assertions.assertEquals(WAITING_COSTS, result.get(5).getKey());
             Assertions.assertEquals(
                     "/submissions/%s/claims/%s/waiting-costs", result.get(5).getChangeUrl());
-
-            Assertions.assertEquals(VAT, result.get(6).getKey());
         }
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/AssessmentOutcomeViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/AssessmentOutcomeViewTest.java
@@ -32,7 +32,6 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
         assertPageHasSecondaryLink(doc, "Cancel");
         assertPageHasNoActiveServiceNavigationItems(doc);
         assertPageHasRadioButtons(doc);
-        assertPageHasInlineRadioButtons(doc);
         assertPageDoesNotHaveBackLink(doc);
     }
 
@@ -40,7 +39,6 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
     void testPageErrors() throws Exception {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("assessmentOutcome", "");
-        params.add("liabilityForVat", "");
 
         Document doc = renderDocumentWithErrors(params);
 
@@ -51,9 +49,8 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
         assertPageHasSecondaryLink(doc, "Cancel");
         assertPageHasNoActiveServiceNavigationItems(doc);
         assertPageHasRadioButtons(doc);
-        assertPageHasInlineRadioButtons(doc);
 
-        assertPageHasErrorSummary(doc, "assessment-outcome", "liability-for-vat");
+        assertPageHasErrorSummary(doc, "assessment-outcome");
     }
 
     @Test
@@ -69,7 +66,6 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
                 doc, "Cancel", String.format("/submissions/%s/claims/%s/review", submissionId, claimId));
         assertPageHasNoActiveServiceNavigationItems(doc);
         assertPageHasRadioButtons(doc);
-        assertPageHasInlineRadioButtons(doc);
         assertPageDoesNotHaveBackLink(doc);
     }
 
@@ -86,7 +82,6 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
                 doc, "Cancel", String.format("/submissions/%s/claims/%s/review", submissionId, claimId));
         assertPageHasNoActiveServiceNavigationItems(doc);
         assertPageHasRadioButtons(doc);
-        assertPageHasInlineRadioButtons(doc);
         assertPageDoesNotHaveBackLink(doc);
     }
 
@@ -102,7 +97,6 @@ class AssessmentOutcomeViewTest extends ViewTestBase {
         assertPageCancelLinkValue(doc, "Cancel", String.format("/submissions/%s/claims/%s", submissionId, claimId));
         assertPageHasNoActiveServiceNavigationItems(doc);
         assertPageHasRadioButtons(doc);
-        assertPageHasInlineRadioButtons(doc);
         assertPageDoesNotHaveBackLink(doc);
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ReviewAndAmendViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ReviewAndAmendViewTest.java
@@ -57,12 +57,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "Assessed in full",
                 String.format(
                         "/submissions/%s/claims/%s/assessment-outcome#assessment-outcome", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                assessmentTable.get(1),
-                "Is this claim liable for VAT?",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome#liability-for-vat", submissionId, claimId));
-
         List<List<Element>> claimCostsTable = getTable(doc, "Claim costs");
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.getFirst(), "Fixed fee", "£200.00", "Not applicable", "£300.00");
@@ -118,13 +112,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 claimCostsTable.get(10), "Substantive hearing", "£200.00", "£100.00", "£300.00");
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.get(11), "Adjourned hearing fee", "£200.00", "£100.00", "£300.00");
-        assertTableRowContainsValuesWithChangeLink(
-                claimCostsTable.get(12),
-                "VAT",
-                "No",
-                "Yes",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId));
 
         List<List<Element>> totalClaimValueTable = getTable(doc, "Total claim value");
         assertTableRowContainsValuesWithNoChangeLink(
@@ -172,14 +159,8 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "Assessed in full",
                 String.format(
                         "/submissions/%s/claims/%s/assessment-outcome#assessment-outcome", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                assessmentTable.get(1),
-                "Is this claim liable for VAT?",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome#liability-for-vat", submissionId, claimId));
-
         List<List<Element>> claimCostsTable = getTable(doc, "Claim costs");
-        Assertions.assertEquals(7, claimCostsTable.size());
+        Assertions.assertEquals(6, claimCostsTable.size());
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.getFirst(), "Fixed fee", "£200.00", "Not applicable", "£300.00");
         assertTableRowContainsValuesWithChangeLink(
@@ -217,13 +198,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "£100.00",
                 "£300.00",
                 String.format("/submissions/%s/claims/%s/waiting-costs", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                claimCostsTable.get(6),
-                "VAT",
-                "No",
-                "Yes",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId));
 
         List<List<Element>> totalClaimValueTable = getTable(doc, "Total claim value");
         Assertions.assertEquals(2, totalClaimValueTable.size());
@@ -296,14 +270,8 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "Reduced (still escaped)",
                 String.format(
                         "/submissions/%s/claims/%s/assessment-outcome#assessment-outcome", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                assessmentTable.get(1),
-                "Is this claim liable for VAT?",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome#liability-for-vat", submissionId, claimId));
-
         List<List<Element>> claimCostsTable = getTable(doc, "Claim costs");
-        Assertions.assertEquals(7, claimCostsTable.size());
+        Assertions.assertEquals(6, claimCostsTable.size());
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.getFirst(), "Fixed fee", "£200.00", "Not applicable", "£300.00");
         assertTableRowContainsValuesWithAddLink(
@@ -340,13 +308,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "£100.00",
                 "£300.00",
                 String.format("/submissions/%s/claims/%s/waiting-costs", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                claimCostsTable.get(6),
-                "VAT",
-                "No",
-                "Yes",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId));
 
         List<List<Element>> totalClaimValueTable = getTable(doc, "Total claim value");
         Assertions.assertEquals(2, totalClaimValueTable.size());
@@ -414,14 +375,8 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "Reduced (still escaped)",
                 String.format(
                         "/submissions/%s/claims/%s/assessment-outcome#assessment-outcome", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                assessmentTable.get(1),
-                "Is this claim liable for VAT?",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome#liability-for-vat", submissionId, claimId));
-
         List<List<Element>> claimCostsTable = getTable(doc, "Claim costs");
-        Assertions.assertEquals(13, claimCostsTable.size());
+        Assertions.assertEquals(12, claimCostsTable.size());
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.getFirst(), "Fixed fee", "£200.00", "Not applicable", "£300.00");
         assertTableRowContainsValuesWithChangeLink(
@@ -476,13 +431,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 claimCostsTable.get(10), "Substantive hearing", "£200.00", "£100.00", "£300.00");
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.get(11), "Adjourned hearing fee", "£200.00", "£100.00", "£300.00");
-        assertTableRowContainsValuesWithChangeLink(
-                claimCostsTable.get(12),
-                "VAT",
-                "No",
-                "Yes",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId));
 
         List<List<Element>> totalClaimValueTable = getTable(doc, "Total claim value");
         Assertions.assertEquals(2, totalClaimValueTable.size());
@@ -591,14 +539,8 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "Assessed in full",
                 String.format(
                         "/submissions/%s/claims/%s/assessment-outcome#assessment-outcome", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                assessmentTable.get(1),
-                "Is this claim liable for VAT?",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome#liability-for-vat", submissionId, claimId));
-
         List<List<Element>> claimCostsTable = getTable(doc, "Claim costs");
-        Assertions.assertEquals(13, claimCostsTable.size());
+        Assertions.assertEquals(12, claimCostsTable.size());
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.getFirst(), "Fixed fee", "£200.00", "Not applicable", "£300.00");
         assertTableRowContainsValuesWithChangeLink(
@@ -653,13 +595,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 claimCostsTable.get(10), "Substantive hearing", "Not applicable", "£100.00", "Not applicable");
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.get(11), "Adjourned hearing fee", "Not applicable", "£100.00", "Not applicable");
-        assertTableRowContainsValuesWithChangeLink(
-                claimCostsTable.get(12),
-                "VAT",
-                "No",
-                "Yes",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId));
 
         List<List<Element>> totalClaimValueTable = getTable(doc, "Total claim value");
         Assertions.assertEquals(2, totalClaimValueTable.size());
@@ -732,14 +667,8 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "Assessed in full",
                 String.format(
                         "/submissions/%s/claims/%s/assessment-outcome#assessment-outcome", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                assessmentTable.get(1),
-                "Is this claim liable for VAT?",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome#liability-for-vat", submissionId, claimId));
-
         List<List<Element>> claimCostsTable = getTable(doc, "Claim costs");
-        Assertions.assertEquals(8, claimCostsTable.size());
+        Assertions.assertEquals(7, claimCostsTable.size());
         assertTableRowContainsValuesWithNoChangeLink(
                 claimCostsTable.getFirst(), "Fixed fee", "£200.00", "Not applicable", "£300.00");
         assertTableRowContainsValuesWithChangeLink(
@@ -784,13 +713,6 @@ class ReviewAndAmendViewTest extends ViewTestBase {
                 "£100.00",
                 "£300.00",
                 String.format("/submissions/%s/claims/%s/counsel-costs", submissionId, claimId));
-        assertTableRowContainsValuesWithChangeLink(
-                claimCostsTable.get(7),
-                "VAT",
-                "No",
-                "Yes",
-                "Yes",
-                String.format("/submissions/%s/claims/%s/assessment-outcome", submissionId, claimId));
 
         List<List<Element>> totalClaimValueTable = getTable(doc, "Total claim value");
         Assertions.assertEquals(2, totalClaimValueTable.size());


### PR DESCRIPTION
## What is this PR?

[BC-515](https://dsdmoj.atlassian.net/browse/BC-515)

Removed the "Is this claim liable for VAT?" question from the assessment outcome flow. 
The liable for VAT question was redundant - VAT applicability can be derived automatically from allowedTotalVat > 0

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.



[BC-515]: https://dsdmoj.atlassian.net/browse/BC-515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ