### PR TITLE
BC-515: Add assessment reason to escape case and void API submissions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,14 +72,12 @@ jobs:
           ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}-build
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
-
       - name: Build and Push Docker Image
-        uses: docker/build-push-action@v7.0.0
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.get_sha.outputs.sha }}
-          cache-from: type=registry,ref=${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:buildcache
-          cache-to: type=registry,ref=${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:buildcache,mode=max
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-auth.outputs.image_registry }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: ${{ steps.get_sha.outputs.sha }}
+        run: |
+          docker build --pull --tag app .
+          docker tag app $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -99,13 +99,14 @@ jobs:
       - name: Build and Push Runner Image
         if: steps.check-runner.outputs.deploy-runner == 'true'
         id: build
-        uses: docker/build-push-action@v7.0.0
-        with:
-          context: ./scripts
-          file: ./scripts/Dockerfile.e2e-runner
-          push: true
-          tags: |
-            ${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:github-runner-${{ github.run_id }}
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-auth.outputs.image_registry }}
+          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
+          IMAGE_TAG: github-runner-${{ github.run_id }}
+        run: |
+          docker build --pull -f ./scripts/Dockerfile.e2e-runner --tag runner ./scripts
+          docker tag runner $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
       - name: Deploy Runner
         if: steps.check-runner.outputs.deploy-runner == 'true'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.1.6'
+    id 'uk.gov.laa.springboot.laa-spring-boot-gradle-plugin' version '2.1.9'
     id "com.diffplug.spotless" version "8.2.1"
     id "com.palantir.java-format-spotless" version "2.89.0"
     id "io.sentry.jvm.gradle" version "6.0.0"

--- a/src/main/java/uk/gov/justice/laa/amend/claim/constants/AmendClaimConstants.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/constants/AmendClaimConstants.java
@@ -20,6 +20,9 @@ public class AmendClaimConstants {
     public static final String DEFAULT_PERIOD_FORMAT = "MMM yyyy";
     public static final String DEFAULT_TIME_FORMAT = "HH:mm:ss";
 
+    public static final String ASSESSMENT_REASON_ESCAPE_CASE = "Escape Fee Case Assessment";
+    public static final String ASSESSMENT_REASON_VOID = "Void";
+
     public static final String ASSESSMENT_OUTCOME_REQUIRED_ERROR = "{assessmentOutcome.assessmentOutcomeRequiredError}";
     public static final String LIABILITY_FOR_VAT_REQUIRED_ERROR = "{assessmentOutcome.liabilityForVatRequiredError}";
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapper.java
@@ -24,8 +24,6 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
 @Mapper(componentModel = "spring")
 public interface AssessmentMapper {
 
-    String ESCAPE_FEE_CASE_ASSESSMENT = "Escape Fee Case Assessment";
-
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "assessmentOutcome", expression = "java(mapAssessmentOutcome(claim))")
     @Mapping(target = "fixedFeeAmount", expression = "java(mapFixedFeeAmount(claim))")
@@ -36,6 +34,10 @@ public interface AssessmentMapper {
     @Mapping(target = "disbursementVatAmount", expression = "java(mapDisbursementVatAmount(claim))")
     @Mapping(target = "netCostOfCounselAmount", ignore = true)
     @Mapping(target = "detentionTravelAndWaitingCostsAmount", ignore = true)
+    @Mapping(
+            target = "assessmentReason",
+            expression =
+                    "java(uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_ESCAPE_CASE)")
     @Mapping(target = "isVatApplicable", source = "vatApplicable")
     @Mapping(target = "boltOnAdjournedHearingFee", ignore = true)
     @Mapping(target = "jrFormFillingAmount", ignore = true)
@@ -49,7 +51,6 @@ public interface AssessmentMapper {
     @Mapping(target = "allowedTotalVat", expression = "java(mapAllowedTotalVat(claim))")
     @Mapping(target = "allowedTotalInclVat", expression = "java(mapAllowedTotalInclVat(claim))")
     @Mapping(target = "assessmentType", constant = "ESCAPE_CASE_ASSESSMENT")
-    @Mapping(target = "assessmentReason", constant = ESCAPE_FEE_CASE_ASSESSMENT)
     AssessmentPost mapClaimToAssessment(ClaimDetails claim, @Context String userId);
 
     @InheritConfiguration(name = "mapClaimToAssessment")

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/ClaimService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/ClaimService.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.amend.claim.service;
 
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_VOID;
+
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.util.List;
@@ -25,8 +27,6 @@ import uk.gov.justice.laadata.providers.model.ProviderFirmOfficeDto;
 @Service
 @Slf4j
 public class ClaimService {
-
-    private static final String VOID_ASSESSMENT_REASON = "Void assessment";
 
     private final ClaimsApiClient claimsApiClient;
     private final ClaimMapper claimMapper;
@@ -105,7 +105,7 @@ public class ClaimService {
 
     public VoidClaim201Response voidClaim(UUID claimId, UUID userId) {
         try {
-            var request = new VoidClaimRequest(userId, VOID_ASSESSMENT_REASON);
+            var request = new VoidClaimRequest(userId, ASSESSMENT_REASON_VOID);
             var response = claimsApiClient.voidClaim(claimId, request).block();
             voidClaimCounter.increment();
             return response;

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentPactTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.amend.claim;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_ESCAPE_CASE;
 
 import au.com.dius.pact.consumer.dsl.LambdaDsl;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
@@ -110,7 +111,7 @@ public final class CreateAssessmentPactTest extends AbstractPactTest {
         body.uuid("claim_summary_fee_id");
         body.stringType("assessment_outcome", "PAID_IN_FULL");
         body.uuid("created_by_user_id");
-        body.nullValue("assessment_reason");
+        body.stringType("assessment_reason", ASSESSMENT_REASON_ESCAPE_CASE);
         body.nullValue("assessment_type");
         body.booleanType("is_vat_applicable", true);
         body.decimalType("fixed_fee_amount", 100.00);
@@ -148,6 +149,7 @@ public final class CreateAssessmentPactTest extends AbstractPactTest {
         assessment.setAssessedTotalInclVat(new BigDecimal("360.00"));
         assessment.setAllowedTotalVat(new BigDecimal("60.00"));
         assessment.setAllowedTotalInclVat(new BigDecimal("360.00"));
+        assessment.setAssessmentReason(ASSESSMENT_REASON_ESCAPE_CASE);
         return assessment;
     }
 }

--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/VoidClaimPactTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.amend.claim;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_VOID;
 
 import au.com.dius.pact.consumer.dsl.LambdaDsl;
 import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
@@ -74,7 +75,7 @@ public final class VoidClaimPactTest extends AbstractPactTest {
     @DisplayName("Verify 201 response - claim voided successfully")
     @PactTestFor(pactMethod = "voidClaim201")
     void verify201Response() {
-        VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), "Void reason");
+        VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), ASSESSMENT_REASON_VOID);
         VoidClaim201Response response =
                 claimsApiClient.voidClaim(CLAIM_ID, request).block();
 
@@ -86,7 +87,7 @@ public final class VoidClaimPactTest extends AbstractPactTest {
     @DisplayName("Verify 404 response - claim does not exist")
     @PactTestFor(pactMethod = "voidClaim404")
     void verify404Response() {
-        VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), "Void reason");
+        VoidClaimRequest request = new VoidClaimRequest(UUID.randomUUID(), ASSESSMENT_REASON_VOID);
         assertThrows(
                 NotFound.class,
                 () -> claimsApiClient.voidClaim(CLAIM_ID, request).block());
@@ -94,6 +95,6 @@ public final class VoidClaimPactTest extends AbstractPactTest {
 
     private static void buildVoidClaimRequestBody(au.com.dius.pact.consumer.dsl.LambdaDslJsonBody body) {
         body.uuid("created_by_user_id");
-        body.stringType("assessment_reason", "Void reason");
+        body.stringType("assessment_reason", ASSESSMENT_REASON_VOID);
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/AssessmentMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.amend.claim.mappers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_ESCAPE_CASE;
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.ALLOWED_TOTAL_INCL_VAT;
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.ALLOWED_TOTAL_VAT;
 
@@ -63,6 +64,7 @@ class AssessmentMapperTest {
         assertEquals(BigDecimal.valueOf(300), assessment.getAllowedTotalVat());
         assertEquals(BigDecimal.valueOf(300), assessment.getAllowedTotalInclVat());
         assertEquals(true, assessment.getIsVatApplicable());
+        assertEquals(ASSESSMENT_REASON_ESCAPE_CASE, assessment.getAssessmentReason());
         assertEquals(userId, assessment.getCreatedByUserId());
     }
 
@@ -89,6 +91,7 @@ class AssessmentMapperTest {
         assertEquals(BigDecimal.valueOf(300), assessment.getAllowedTotalVat());
         assertEquals(BigDecimal.valueOf(300), assessment.getAllowedTotalInclVat());
         assertEquals(true, assessment.getIsVatApplicable());
+        assertEquals(ASSESSMENT_REASON_ESCAPE_CASE, assessment.getAssessmentReason());
         assertEquals(userId, assessment.getCreatedByUserId());
     }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/ClaimServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.ASSESSMENT_REASON_VOID;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.List;
@@ -282,7 +283,7 @@ class ClaimServiceTest {
     @Test
     @DisplayName("Should return void response and increment success counter")
     void voidClaim() {
-        var request = new VoidClaimRequest(userId, "Void assessment");
+        var request = new VoidClaimRequest(userId, ASSESSMENT_REASON_VOID);
         var expectedResponse = new VoidClaim201Response(UUID.randomUUID());
         when(claimsApiClient.voidClaim(claimId, request)).thenReturn(Mono.just(expectedResponse));
 
@@ -296,7 +297,7 @@ class ClaimServiceTest {
     @Test
     @DisplayName("Should increment failure counter when void claim throws an exception")
     void voidClaim_failure() {
-        var request = new VoidClaimRequest(userId, "Void assessment");
+        var request = new VoidClaimRequest(userId, ASSESSMENT_REASON_VOID);
         when(claimsApiClient.voidClaim(claimId, request)).thenThrow(new RuntimeException("API Error"));
 
         assertThrows(RuntimeException.class, () -> claimService.voidClaim(claimId, userId));


### PR DESCRIPTION
## What is this PR?

[BC-378](https://dsdmoj.atlassian.net/browse/BC-378)

Added assessmentReason to the Data Claims API payloads for both escape case assessments and void submissions.
Stakeholders in the reconciliation & assurance team need to know why a claim was amended, voided, or assessed.

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.



[BC-378]: https://dsdmoj.atlassian.net/browse/BC-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ