### PR TITLE
BC-543: Fix timestamps not displaying in London time

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapper.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.amend.claim.mappers;
 
-import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -39,7 +38,7 @@ public interface ClaimMapper {
     @Mapping(target = "hasAssessment", source = "hasAssessment")
     @Mapping(target = "areaOfLaw", expression = "java(mapAreaOfLaw(claimResponse))")
     @Mapping(target = "providerName", ignore = true)
-    @Mapping(target = "submittedDate", expression = "java(mapSubmittedDate(claimResponse))")
+    @Mapping(target = "submittedDate", source = "dateSubmitted")
     @Mapping(target = "assessmentOutcome", ignore = true)
     @Mapping(target = "lastAssessment", ignore = true)
     @Mapping(target = "claimFields", ignore = true)
@@ -140,12 +139,5 @@ public interface ClaimMapper {
             case LEGAL_HELP -> AreaOfLaw.LEGAL_HELP;
             case MEDIATION -> AreaOfLaw.MEDIATION;
         };
-    }
-
-    default LocalDateTime mapSubmittedDate(ClaimResponseV2 claimResponse) {
-        if (claimResponse.getDateSubmitted() != null) {
-            return claimResponse.getDateSubmitted().toLocalDateTime();
-        }
-        return null;
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimDetails.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/ClaimDetails.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.laa.amend.claim.models;
 
 import jakarta.validation.constraints.NotNull;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.function.Function;
@@ -32,7 +31,7 @@ public abstract class ClaimDetails extends Claim {
     private ClaimField allowedTotalInclVat;
 
     private OutcomeType assessmentOutcome;
-    private LocalDateTime submittedDate;
+    private OffsetDateTime submittedDate;
     private String feeCode;
     private String feeCodeDescription;
     private boolean hasAssessment;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/DateUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/DateUtils.java
@@ -5,21 +5,29 @@ import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.DEFAU
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 public class DateUtils {
+
+    static final ZoneId LONDON_TIMEZONE = ZoneId.of("Europe/London");
 
     public static String displayDateValue(LocalDate value) {
         return value != null ? value.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT)) : null;
     }
 
-    public static String displayDateTimeDateValue(LocalDateTime value) {
-        return displayDateTimeValue(value, DEFAULT_DATE_FORMAT);
+    public static String displayDateTimeDateValue(OffsetDateTime value) {
+        return value != null ? displayDateTimeValue(toLondonLocalDateTime(value), DEFAULT_DATE_FORMAT) : null;
     }
 
-    public static String displayDateTimeTimeValue(LocalDateTime value) {
-        return displayDateTimeValue(value, DEFAULT_TIME_FORMAT);
+    public static String displayDateTimeTimeValue(OffsetDateTime value) {
+        return value != null ? displayDateTimeValue(toLondonLocalDateTime(value), DEFAULT_TIME_FORMAT) : null;
+    }
+
+    private static LocalDateTime toLondonLocalDateTime(OffsetDateTime value) {
+        return value.atZoneSameInstant(LONDON_TIMEZONE).toLocalDateTime();
     }
 
     private static String displayDateTimeValue(LocalDateTime value, String format) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/DateUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/DateUtils.java
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter;
 
 public class DateUtils {
 
-    static final ZoneId LONDON_TIMEZONE = ZoneId.of("Europe/London");
+    private static final ZoneId LONDON_TIMEZONE = ZoneId.of("Europe/London");
 
     public static String displayDateValue(LocalDate value) {
         return value != null ? value.format(DateTimeFormatter.ofPattern(DEFAULT_DATE_FORMAT)) : null;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtils.java
@@ -7,7 +7,6 @@ import static uk.gov.justice.laa.amend.claim.utils.DateUtils.displayDateValue;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -65,10 +64,9 @@ public class ThymeleafUtils {
             case Boolean b -> getFormattedBoolean(b);
             case String s -> new ThymeleafLiteralString(s);
             case ThymeleafMessage s -> s;
-            case OffsetDateTime o -> getFormattedValue(o.toLocalDateTime());
+            case OffsetDateTime o ->
+                new ThymeleafMessage("fulldate.format", displayDateTimeDateValue(o), displayDateTimeTimeValue(o));
             case LocalDate d -> new ThymeleafLiteralString(displayDateValue(d));
-            case LocalDateTime d ->
-                new ThymeleafMessage("fulldate.format", displayDateTimeDateValue(d), displayDateTimeTimeValue(d));
             default -> new ThymeleafLiteralString(value.toString());
         };
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -1,6 +1,5 @@
 package uk.gov.justice.laa.amend.claim.viewmodels;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -118,9 +117,8 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
     }
 
     default ThymeleafMessage lastEditedBy(MicrosoftApiUser user) {
-        LocalDateTime dateTime = claim().getLastUpdatedDateTime().toLocalDateTime();
-        String date = DateUtils.displayDateTimeDateValue(dateTime);
-        String time = DateUtils.displayDateTimeTimeValue(dateTime);
+        String date = DateUtils.displayDateTimeDateValue(claim().getLastUpdatedDateTime());
+        String time = DateUtils.displayDateTimeTimeValue(claim().getLastUpdatedDateTime());
 
         List<Object> args = new ArrayList<>();
         String editMessageKey;

--- a/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/mappers/ClaimMapperTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
-import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
@@ -546,7 +545,7 @@ class ClaimMapperTest {
         assertEquals(uk.gov.justice.laa.amend.claim.models.AreaOfLaw.LEGAL_HELP, claim.getAreaOfLaw());
         assertEquals("0P322F", claim.getOfficeCode());
         assertNull(claim.getProviderName());
-        assertEquals(LocalDateTime.of(2025, 1, 10, 14, 30, 0), claim.getSubmittedDate());
+        assertEquals(OffsetDateTime.parse("2025-01-10T14:30:00+02:00"), claim.getSubmittedDate());
         assertEquals(ClaimStatus.VALID, claim.getStatus());
     }
 
@@ -591,7 +590,7 @@ class ClaimMapperTest {
         assertEquals(ClaimStatus.VALID, claim.getStatus());
         assertEquals("0P322F", claim.getOfficeCode());
 
-        assertEquals(LocalDateTime.of(2025, 1, 10, 14, 30, 0), claim.getSubmittedDate());
+        assertEquals(OffsetDateTime.parse("2025-01-10T14:30:00+02:00"), claim.getSubmittedDate());
     }
 
     private static ClaimResponseV2 createClaimResponse(AreaOfLaw areaOfLaw) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/utils/DateUtilsTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/utils/DateUtilsTest.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.laa.amend.claim.utils;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,6 +48,66 @@ public class DateUtilsTest {
             String year = "2007";
             String result = DateUtils.toSubmissionPeriod(month, year);
             Assertions.assertEquals("MAR-2007", result);
+        }
+    }
+
+    @Nested
+    class DisplayDateTimeDateValueTests {
+
+        @Test
+        void returnsNullWhenOffsetDateTimeIsNull() {
+            Assertions.assertNull(DateUtils.displayDateTimeDateValue(null));
+        }
+
+        @Test
+        void formatsDateInGmtDuringWinter() {
+            // December is GMT (UTC+0), so London time == UTC time
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 12, 18, 16, 11, 27), ZoneOffset.UTC);
+            Assertions.assertEquals("18 December 2025", DateUtils.displayDateTimeDateValue(utcDateTime));
+        }
+
+        @Test
+        void formatsDateInBstDuringBstSameDay() {
+            // June is BST (UTC+1): UTC 14:30 = London 15:30 — same calendar day
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 6, 15, 14, 30, 0), ZoneOffset.UTC);
+            Assertions.assertEquals("15 June 2025", DateUtils.displayDateTimeDateValue(utcDateTime));
+        }
+
+        @Test
+        void formatsDateInBstDuringBstCrossingMidnight() {
+            // June is BST (UTC+1): UTC 23:30 on the 15th = London 00:30 on the 16th
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 6, 15, 23, 30, 0), ZoneOffset.UTC);
+            Assertions.assertEquals("16 June 2025", DateUtils.displayDateTimeDateValue(utcDateTime));
+        }
+    }
+
+    @Nested
+    class DisplayDateTimeTimeValueTests {
+
+        @Test
+        void returnsNullWhenOffsetDateTimeIsNull() {
+            Assertions.assertNull(DateUtils.displayDateTimeTimeValue(null));
+        }
+
+        @Test
+        void formatsTimeInGmtDuringWinter() {
+            // December is GMT (UTC+0), so London time == UTC time
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 12, 18, 16, 11, 27), ZoneOffset.UTC);
+            Assertions.assertEquals("16:11:27", DateUtils.displayDateTimeTimeValue(utcDateTime));
+        }
+
+        @Test
+        void formatsTimeInBstDuringBst() {
+            // June is BST (UTC+1): UTC 14:30:00 = London 15:30:00
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 6, 15, 14, 30, 0), ZoneOffset.UTC);
+            Assertions.assertEquals("15:30:00", DateUtils.displayDateTimeTimeValue(utcDateTime));
+        }
+
+        @Test
+        void formatsTimeInBstCrossingMidnight() {
+            // June is BST (UTC+1): UTC 23:30:00 on the 15th = London 00:30:00 on the 16th
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 6, 15, 23, 30, 0), ZoneOffset.UTC);
+            Assertions.assertEquals("00:30:00", DateUtils.displayDateTimeTimeValue(utcDateTime));
         }
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtilsTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/utils/ThymeleafUtilsTest.java
@@ -1,5 +1,8 @@
 package uk.gov.justice.laa.amend.claim.utils;
 
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Assertions;
@@ -9,6 +12,8 @@ import org.thymeleaf.spring6.util.DetailedError;
 import uk.gov.justice.laa.amend.claim.forms.errors.AssessedTotalFormError;
 import uk.gov.justice.laa.amend.claim.forms.errors.AssessmentOutcomeFormError;
 import uk.gov.justice.laa.amend.claim.forms.errors.SearchFormError;
+import uk.gov.justice.laa.amend.claim.viewmodels.ThymeleafMessage;
+import uk.gov.justice.laa.amend.claim.viewmodels.ThymeleafString;
 
 public class ThymeleafUtilsTest {
 
@@ -104,6 +109,40 @@ public class ThymeleafUtilsTest {
                     new AssessedTotalFormError("assessedTotalInclVat", "foo"));
 
             Assertions.assertEquals(expectedResult, result);
+        }
+    }
+
+    @Nested
+    class GetFormattedValueTests {
+
+        @Test
+        void formatsOffsetDateTimeInLondonTimeZoneDuringGmt() {
+            // December is GMT (UTC+0), so London time == UTC time
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 12, 18, 16, 11, 27), ZoneOffset.UTC);
+            ThymeleafUtils sut = new ThymeleafUtils();
+
+            ThymeleafString result = sut.getFormattedValue(utcDateTime);
+
+            Assertions.assertInstanceOf(ThymeleafMessage.class, result);
+            ThymeleafMessage message = (ThymeleafMessage) result;
+            Assertions.assertEquals("fulldate.format", message.getKey());
+            Assertions.assertEquals("18 December 2025", message.getParams()[0]);
+            Assertions.assertEquals("16:11:27", message.getParams()[1]);
+        }
+
+        @Test
+        void formatsOffsetDateTimeInLondonTimeZoneDuringBst() {
+            // June is BST (UTC+1): UTC 14:30:00 = London 15:30:00
+            OffsetDateTime utcDateTime = OffsetDateTime.of(LocalDateTime.of(2025, 6, 15, 14, 30, 0), ZoneOffset.UTC);
+            ThymeleafUtils sut = new ThymeleafUtils();
+
+            ThymeleafString result = sut.getFormattedValue(utcDateTime);
+
+            Assertions.assertInstanceOf(ThymeleafMessage.class, result);
+            ThymeleafMessage message = (ThymeleafMessage) result;
+            Assertions.assertEquals("fulldate.format", message.getKey());
+            Assertions.assertEquals("15 June 2025", message.getParams()[0]);
+            Assertions.assertEquals("15:30:00", message.getParams()[1]);
         }
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
@@ -18,7 +18,8 @@ import static uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions.updat
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,7 +134,7 @@ public class CivilClaimDetailsViewTest extends ClaimDetailsViewTest<CivilClaimDe
     class GetSummaryRowsTests {
         @Test
         void createMapOfKeyValuePairs() {
-            LocalDateTime submittedDate = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+            OffsetDateTime submittedDate = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
             LocalDate caseStartDate = LocalDate.of(2001, 1, 1);
             LocalDate caseEndDate = LocalDate.of(2002, 1, 1);
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
@@ -191,7 +191,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
         void displayLastEditedTextWhenUserValuesAreNonNull() {
             C claim = createClaim();
             AssessmentInfo assessmentInfo = new AssessmentInfo();
-            LocalDateTime localDateTime = LocalDateTime.of(2025, 12, 18, 16, 11, 27);
+            // UTC 14:30:00 on a BST day (June) = London 15:30:00
+            LocalDateTime localDateTime = LocalDateTime.of(2025, 6, 15, 14, 30, 0);
             assessmentInfo.setLastAssessmentDate(OffsetDateTime.of(localDateTime, ZoneOffset.UTC));
             assessmentInfo.setLastAssessmentOutcome(OutcomeType.NILLED);
             claim.setLastAssessment(assessmentInfo);
@@ -204,8 +205,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
 
             Assertions.assertEquals("claimSummary.lastAssessmentText", result.getKey());
             Assertions.assertEquals("Joe Bloggs", result.getParams()[0]);
-            Assertions.assertEquals("18 December 2025", result.getParams()[1]);
-            Assertions.assertEquals("16:11:27", result.getParams()[2]);
+            Assertions.assertEquals("15 June 2025", result.getParams()[1]);
+            Assertions.assertEquals("15:30:00", result.getParams()[2]);
             ThymeleafMessage param = (ThymeleafMessage) result.getParams()[3];
             Assertions.assertEquals("outcome.nilled", param.getKey());
             Assertions.assertEquals(0, param.getParams().length);
@@ -215,7 +216,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
         void displayLastEditedTextWhenUserValuesAreNull() {
             C claim = createClaim();
             AssessmentInfo assessmentInfo = new AssessmentInfo();
-            LocalDateTime localDateTime = LocalDateTime.of(2025, 12, 18, 16, 11, 27);
+            // UTC 14:30:00 on a BST day (June) = London 15:30:00
+            LocalDateTime localDateTime = LocalDateTime.of(2025, 6, 15, 14, 30, 0);
             assessmentInfo.setLastAssessmentDate(OffsetDateTime.of(localDateTime, ZoneOffset.UTC));
             assessmentInfo.setLastAssessmentOutcome(OutcomeType.NILLED);
             claim.setLastAssessment(assessmentInfo);
@@ -227,8 +229,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
             ThymeleafMessage result = viewModel.lastEditedBy(user);
 
             Assertions.assertEquals("claimSummary.lastAssessmentText.noUser", result.getKey());
-            Assertions.assertEquals("18 December 2025", result.getParams()[0]);
-            Assertions.assertEquals("16:11:27", result.getParams()[1]);
+            Assertions.assertEquals("15 June 2025", result.getParams()[0]);
+            Assertions.assertEquals("15:30:00", result.getParams()[1]);
             ThymeleafMessage param = (ThymeleafMessage) result.getParams()[2];
             Assertions.assertEquals("outcome.nilled", param.getKey());
             Assertions.assertEquals(0, param.getParams().length);
@@ -238,7 +240,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
         void displayLastEditedTextWhenUserIsNull() {
             C claim = createClaim();
             AssessmentInfo assessmentInfo = new AssessmentInfo();
-            LocalDateTime localDateTime = LocalDateTime.of(2025, 12, 18, 16, 11, 27);
+            // UTC 14:30:00 on a BST day (June) = London 15:30:00
+            LocalDateTime localDateTime = LocalDateTime.of(2025, 6, 15, 14, 30, 0);
             assessmentInfo.setLastAssessmentDate(OffsetDateTime.of(localDateTime, ZoneOffset.UTC));
             assessmentInfo.setLastAssessmentOutcome(OutcomeType.NILLED);
             claim.setLastAssessment(assessmentInfo);
@@ -250,8 +253,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
             ThymeleafMessage result = viewModel.lastEditedBy(null);
 
             Assertions.assertEquals("claimSummary.lastAssessmentText.noUser", result.getKey());
-            Assertions.assertEquals("18 December 2025", result.getParams()[0]);
-            Assertions.assertEquals("16:11:27", result.getParams()[1]);
+            Assertions.assertEquals("15 June 2025", result.getParams()[0]);
+            Assertions.assertEquals("15:30:00", result.getParams()[1]);
             ThymeleafMessage param = (ThymeleafMessage) result.getParams()[2];
             Assertions.assertEquals("outcome.nilled", param.getKey());
             Assertions.assertEquals(0, param.getParams().length);
@@ -261,7 +264,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
         void displayLastEditedTextWhenClaimVoided() {
             C claim = createClaim();
             AssessmentInfo assessmentInfo = new AssessmentInfo();
-            LocalDateTime localDateTime = LocalDateTime.of(2025, 12, 18, 16, 11, 27);
+            // UTC 14:30:00 on a BST day (June) = London 15:30:00
+            LocalDateTime localDateTime = LocalDateTime.of(2025, 6, 15, 14, 30, 0);
             assessmentInfo.setLastAssessmentDate(OffsetDateTime.of(localDateTime, ZoneOffset.UTC));
             assessmentInfo.setLastAssessmentOutcome(OutcomeType.NILLED);
             claim.setLastAssessment(assessmentInfo);
@@ -274,8 +278,8 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
             ThymeleafMessage result = viewModel.lastEditedBy(user);
 
             Assertions.assertEquals("claimSummary.lastAssessmentText.noUser", result.getKey());
-            Assertions.assertEquals("18 December 2025", result.getParams()[0]);
-            Assertions.assertEquals("16:11:27", result.getParams()[1]);
+            Assertions.assertEquals("15 June 2025", result.getParams()[0]);
+            Assertions.assertEquals("15:30:00", result.getParams()[1]);
             ThymeleafMessage param = (ThymeleafMessage) result.getParams()[2];
             Assertions.assertEquals("claimSummary.void.message", param.getKey());
         }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
@@ -10,7 +10,8 @@ import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label
 import static uk.gov.justice.laa.amend.claim.constants.AmendClaimConstants.Label.WAITING_COSTS;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,7 +41,7 @@ public class CrimeClaimDetailsViewTest extends ClaimDetailsViewTest<CrimeClaimDe
     class GetSummaryRowsTests {
         @Test
         void createMapOfKeyValuePairs() {
-            LocalDateTime submittedDate = LocalDateTime.of(2000, 1, 1, 0, 0, 0);
+            OffsetDateTime submittedDate = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
             LocalDate caseStartDate = LocalDate.of(2001, 1, 1);
             LocalDate caseEndDate = LocalDate.of(2002, 1, 1);
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/ClaimSummaryViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/ClaimSummaryViewTest.java
@@ -94,7 +94,7 @@ class ClaimSummaryViewTest extends ViewTestBase {
         assertSummaryListRowContainsValues(summaryList1.get(2), "Unique client number (UCN)", "Not applicable");
         assertSummaryListRowContainsValues(summaryList1.get(3), "Provider name", "Currently not available");
         assertSummaryListRowContainsValues(summaryList1.get(4), "Office code", "0P322F");
-        assertSummaryListRowContainsValues(summaryList1.get(5), "Date submitted", "15 June 2020 at 09:30:00");
+        assertSummaryListRowContainsValues(summaryList1.get(5), "Date submitted", "15 June 2020 at 10:30:00");
         assertSummaryListRowContainsValues(summaryList1.get(6), "Area of law", "Legal help");
         assertSummaryListRowContainsValues(summaryList1.get(7), "Category of law", "TEST");
         assertSummaryListRowContainsValues(summaryList1.get(8), "Fee code", "FC");
@@ -223,7 +223,7 @@ class ClaimSummaryViewTest extends ViewTestBase {
         assertSummaryListRowContainsValues(summaryList1.get(1), "Unique file number (UFN)", "Not applicable");
         assertSummaryListRowContainsValues(summaryList1.get(2), "Provider name", "Currently not available");
         assertSummaryListRowContainsValues(summaryList1.get(3), "Office code", "0P322F");
-        assertSummaryListRowContainsValues(summaryList1.get(4), "Date submitted", "15 June 2020 at 09:30:00");
+        assertSummaryListRowContainsValues(summaryList1.get(4), "Date submitted", "15 June 2020 at 10:30:00");
         assertSummaryListRowContainsValues(summaryList1.get(5), "Area of law", "Crime lower");
         assertSummaryListRowContainsValues(summaryList1.get(6), "Category of law", "Not applicable");
         assertSummaryListRowContainsValues(summaryList1.get(7), "Fee code", "FC");
@@ -354,6 +354,6 @@ class ClaimSummaryViewTest extends ViewTestBase {
         claim.setClientSurname("Doe");
         claim.setCaseStartDate(LocalDate.of(2020, 1, 1));
         claim.setCaseEndDate(LocalDate.of(2020, 12, 31));
-        claim.setSubmittedDate(LocalDateTime.of(2020, 6, 15, 9, 30, 0));
+        claim.setSubmittedDate(OffsetDateTime.of(2020, 6, 15, 9, 30, 0, 0, ZoneOffset.UTC));
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/VoidConfirmationViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/VoidConfirmationViewTest.java
@@ -2,7 +2,8 @@ package uk.gov.justice.laa.amend.claim.views;
 
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import org.jsoup.nodes.Document;
@@ -44,7 +45,7 @@ class VoidConfirmationViewTest extends ViewTestBase {
         claim.setProviderName("Provider Name");
         claim.setClientForename("John");
         claim.setClientSurname("Doe");
-        claim.setSubmittedDate(LocalDateTime.of(2020, 6, 15, 9, 30, 0));
+        claim.setSubmittedDate(OffsetDateTime.of(2020, 6, 15, 9, 30, 0, 0, ZoneOffset.UTC));
         claim.setCategoryOfLaw("TEST");
 
         when(claimService.voidClaim(claimId, USER_ID)).thenReturn(new VoidClaim201Response(UUID.randomUUID()));
@@ -64,7 +65,7 @@ class VoidConfirmationViewTest extends ViewTestBase {
         assertSummaryListRowContainsValues(summaryList.get(2), "Unique client number (UCN)", "UCN");
         assertSummaryListRowContainsValues(summaryList.get(3), "Provider name", "Provider Name");
         assertSummaryListRowContainsValues(summaryList.get(4), "Office code", "0P322F");
-        assertSummaryListRowContainsValues(summaryList.get(5), "Date submitted", "15 June 2020 at 09:30:00");
+        assertSummaryListRowContainsValues(summaryList.get(5), "Date submitted", "15 June 2020 at 10:30:00");
         assertSummaryListRowContainsValues(summaryList.get(6), "Category of law", "TEST");
         assertSummaryListRowContainsValues(summaryList.get(7), "Fee code description", "FCD");
     }
@@ -83,7 +84,7 @@ class VoidConfirmationViewTest extends ViewTestBase {
         claim.setProviderName("Provider Name");
         claim.setClientForename("John");
         claim.setClientSurname("Doe");
-        claim.setSubmittedDate(LocalDateTime.of(2020, 6, 15, 9, 30, 0));
+        claim.setSubmittedDate(OffsetDateTime.of(2020, 6, 15, 9, 30, 0, 0, ZoneOffset.UTC));
         claim.setCategoryOfLaw("TEST");
 
         when(claimService.voidClaim(claimId, USER_ID)).thenReturn(new VoidClaim201Response(UUID.randomUUID()));
@@ -102,7 +103,7 @@ class VoidConfirmationViewTest extends ViewTestBase {
         assertSummaryListRowContainsValues(summaryList.get(1), "Unique file number (UFN)", "UFN");
         assertSummaryListRowContainsValues(summaryList.get(2), "Provider name", "Provider Name");
         assertSummaryListRowContainsValues(summaryList.get(3), "Office code", "0P322F");
-        assertSummaryListRowContainsValues(summaryList.get(4), "Date submitted", "15 June 2020 at 09:30:00");
+        assertSummaryListRowContainsValues(summaryList.get(4), "Date submitted", "15 June 2020 at 10:30:00");
         assertSummaryListRowContainsValues(summaryList.get(5), "Category of law", "TEST");
         assertSummaryListRowContainsValues(summaryList.get(6), "Fee code description", "FCD");
     }


### PR DESCRIPTION
## What is this PR?

Timestamps displayed on the "This claim has been assessed" banner and the "Date submitted" field were not being localised to London time. They were showing UTC time, meaning during BST (late March to late October) they appeared one hour behind.

The root cause was `OffsetDateTime.toLocalDateTime()`, which strips the UTC offset without converting the clock value. This affected three places:

  - `ClaimDetailsView.lastEditedBy()` - the assessed-at time shown in the information alert
  - `ThymeleafUtils.getFormattedValue()` - the general datetime formatter used across summary rows, including "Date submitted"
  - `ClaimMapper.mapSubmittedDate()` - was converting OffsetDateTime to LocalDateTime at the mapping layer, permanently discarding timezone information

In general we now keep dateTimes' as `OffsetDateTime` until they are formatted and displayed to the user.

### Changes

  - DateUtils - Changed `displayDateTimeDateValue` and `displayDateTimeTimeValue` to accept OffsetDateTime and convert to `Europe/London` before formatting. LocalDateTime is now only used internally as a formatting intermediary.
  - ClaimDetailsView - Passes `OffsetDateTime` directly to `DateUtils`, removing the `toLocalDateTime()` call.
  - ThymeleafUtils - Fixed the OffsetDateTime switch case to call DateUtils directly (with London conversion) rather than delegating via toLocalDateTime(). Removed the now-dead LocalDateTime case.
  - ClaimDetails - Changed `submittedDate` from `LocalDateTime` to `OffsetDateTime` so timezone information is preserved through the mapping layer.
   - ClaimMapper - Removed the `mapSubmittedDate` helper and replaced it with a direct source = "dateSubmitted" mapping, since the types now match.

### Tests

   - Updated existing `LastEditedByTests` in `ClaimDetailsViewTest` to use BST timestamps (UTC 14:30 -> London 15:30), so they would have failed against the old code.
   - Added `DisplayDateTimeDateValueTests` and `DisplayDateTimeTimeValueTests` to `DateUtilsTest` covering GMT, BST same-day, and BST crossing midnight
  - Added `GetFormattedValueTests` to `ThymeleafUtilsTest` covering GMT and BST `OffsetDateTime` formatting
  - Updated `ClaimMapperTest`, `CivilClaimDetailsViewTest`, `CrimeClaimDetailsViewTest`, `ClaimSummaryViewTest`, and `VoidConfirmationViewTest` to use `OffsetDateTime` and corrected BST assertions (e.g. 09:30 UTC -> 10:30 London)

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.