### PR TITLE
Fix Docker Hub rate limit by authenticating before pulling images.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,11 +7,6 @@ on:
         required: false
         type: string
         default: 'main'
-    secrets:
-      ECR_ROLE_TO_ASSUME:
-        required: true
-      PAT_TOKEN:
-        required: true
     outputs:
       image_tag:
         description: "The Docker image tag (commit SHA) - Cache test"
@@ -72,12 +67,20 @@ jobs:
           ecr_role: ${{ secrets.ECR_ROLE_TO_ASSUME }}
           role-session-name: ${{ github.run_id }}-build
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
       - name: Build and Push Docker Image
-        env:
-          ECR_REGISTRY: ${{ steps.ecr-auth.outputs.image_registry }}
-          ECR_REPOSITORY: ${{ vars.ECR_REPOSITORY }}
-          IMAGE_TAG: ${{ steps.get_sha.outputs.sha }}
-        run: |
-          docker build --pull --tag app .
-          docker tag app $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:${{ steps.get_sha.outputs.sha }}
+          cache-from: type=registry,ref=${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:buildcache
+          cache-to: type=registry,ref=${{ steps.ecr-auth.outputs.image_registry }}/${{ vars.ECR_REPOSITORY }}:buildcache,mode=max

--- a/.github/workflows/deploy-ephemeral.yml
+++ b/.github/workflows/deploy-ephemeral.yml
@@ -13,17 +13,6 @@ on:
         required: false
         type: string
         default: 'eu-west-2'
-    secrets:
-      ECR_ROLE_TO_ASSUME:
-        required: true
-      KUBE_NAMESPACE:
-        required: true
-      KUBE_CLUSTER:
-        required: true
-      KUBE_TOKEN:
-        required: true
-      KUBE_CERT:
-        required: true
     outputs:
       sanitized_release_name:
         description: "The Docker image tag (commit SHA) - Cache test"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,21 +31,6 @@ on:
         required: true
         type: string
         description: 'Claims API environment name for Pact broker (e.g., main, stg, prod)'
-    secrets:
-      ECR_ROLE_TO_ASSUME:
-        required: true
-      KUBE_NAMESPACE:
-        required: true
-      KUBE_CLUSTER:
-        required: true
-      KUBE_TOKEN:
-        required: true
-      KUBE_CERT:
-        required: true
-      PACT_BROKER_USERNAME:
-        required: true
-      PACT_BROKER_PASSWORD:
-        required: true
 
 jobs:
   deploy:
@@ -97,6 +82,12 @@ jobs:
           kube-cluster: ${{ secrets.KUBE_CLUSTER }}
           kube-namespace: ${{ secrets.KUBE_NAMESPACE }}
           kube-sa: deploy-user
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Can I deploy?
         uses: ministryofjustice/laa-ccms-common-workflows/.github/actions/pact-can-i-deploy@90aa22bf1f55a39b4f10c4f7168356f0669eed77 # v1

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,23 +22,6 @@ on:
         type: string
         default: 'data-claims-api-1.0.17'
         description: 'data-claims-api image tag, retrieved from github build logs (needs to update with latest version)'
-    secrets:
-      ECR_ROLE_TO_ASSUME:
-        required: true
-      DATA_CLAIMS_API_IMAGE:
-        required: true
-      KUBE_NAMESPACE:
-        required: true
-      KUBE_CLUSTER:
-        required: true
-      KUBE_TOKEN:
-        required: true
-      KUBE_CERT:
-        required: true
-      E2E_DB_PASSWORD:
-        required: true
-      E2E_DB_USER:
-         required: true
 
 permissions:
   id-token: write

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -18,9 +18,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       branch: ${{ github.ref_name }}
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    secrets: inherit
 
   pact-test:
     name: Pact Test
@@ -49,12 +47,7 @@ jobs:
       branch: ${{ github.ref_name }}
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
+    secrets: inherit
 
   test:
     name: Test
@@ -65,19 +58,7 @@ jobs:
       environment: dev
       amend_a_claim_image_tag: ${{ needs.build.outputs.image_tag }}
       sanitized_release_name: ${{ needs.deploy-ephemeral.outputs.sanitized_release_name }}
-    secrets:
-      P_USERNAME: ${{ secrets.P_USERNAME }}
-      P_PASSWORD: ${{ secrets.P_PASSWORD }}
-      P_MFA_SECRET: ${{ secrets.P_MFA_SECRET }}
-      E2E_DB_PASSWORD: ${{ secrets.E2E_DB_PASSWORD }}
-      E2E_DB_USER: ${{ secrets.E2E_DB_USER }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      DATA_CLAIMS_API_IMAGE: ${{ secrets.DATA_CLAIMS_API_IMAGE }}
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    secrets: inherit
 
   security:
     name: Security
@@ -87,9 +68,7 @@ jobs:
       branch: ${{ github.ref_name }}
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+    secrets: inherit
 
   deploy-dev:
     name: Deploy to Dev
@@ -103,11 +82,4 @@ jobs:
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/dev.yaml
       claim_api_environment_name: dev
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
-      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+    secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       branch: ${{ github.ref_name }}
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    secrets: inherit
 
   test:
     name: Test
@@ -30,19 +28,7 @@ jobs:
       environment: dev
       amend_a_claim_image_tag: ${{ needs.build.outputs.image_tag }}
       sanitized_release_name: 'main'
-    secrets:
-      P_USERNAME: ${{ secrets.P_USERNAME }}
-      P_PASSWORD: ${{ secrets.P_PASSWORD }}
-      P_MFA_SECRET: ${{ secrets.P_MFA_SECRET }}
-      E2E_DB_PASSWORD: ${{ secrets.E2E_DB_PASSWORD }}
-      E2E_DB_USER: ${{ secrets.E2E_DB_USER }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      DATA_CLAIMS_API_IMAGE: ${{ secrets.DATA_CLAIMS_API_IMAGE }}
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    secrets: inherit
 
   pact-test:
     name: Pact Test
@@ -69,9 +55,7 @@ jobs:
       branch: ${{ github.ref_name }}
       image_tag: ${{ needs.build.outputs.image_tag }}
       aws_region: ${{ vars.ECR_REGION }}
-    secrets:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+    secrets: inherit
 
   deploy-dev:
     name: Deploy to Dev
@@ -85,14 +69,7 @@ jobs:
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/dev.yaml
       claim_api_environment_name: dev
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
-      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+    secrets: inherit
 
   deploy-uat:
     name: Deploy to UAT
@@ -106,14 +83,7 @@ jobs:
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/uat.yaml
       claim_api_environment_name: main
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
-      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+    secrets: inherit
 
   deploy-staging:
     name: Deploy to Staging
@@ -127,14 +97,7 @@ jobs:
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/staging.yaml
       claim_api_environment_name: stg
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
-      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+    secrets: inherit
 
   deploy-production:
     name: Deploy to Production
@@ -148,11 +111,4 @@ jobs:
       aws_region: ${{ vars.ECR_REGION }}
       values_file: values/production.yaml
       claim_api_environment_name: prod
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      PACT_BROKER_USERNAME: ${{ secrets.PACT_BROKER_USERNAME }}
-      PACT_BROKER_PASSWORD: ${{ secrets.PACT_BROKER_PASSWORD }}
+    secrets: inherit

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,11 +16,6 @@ on:
         type: string
         default: 'eu-west-2'
         description: 'AWS region for the ECR'
-    secrets:
-      SNYK_TOKEN:
-        required: true
-      ECR_ROLE_TO_ASSUME:
-        required: true
 
 permissions:
   contents: read
@@ -53,6 +48,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@55252c7a3a47fea1e0fdd923b269f4be8a5ad9a0
         with:
           sarif_file: snyk-app.sarif
+          category: snyk-app
 
   vulnerability-scan-docker:
     name: Vulnerability Scan - Docker

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,31 +17,6 @@ on:
         required: false
         type: string
         description: 'Sanitized release name from ephemeral deployment'
-    secrets:
-      P_USERNAME:
-        required: true
-      P_PASSWORD:
-        required: true
-      P_MFA_SECRET:
-        required: true
-      E2E_DB_PASSWORD:
-        required: true
-      E2E_DB_USER:
-        required: true
-      KUBE_NAMESPACE:
-        required: true
-      KUBE_CLUSTER:
-        required: true
-      KUBE_TOKEN:
-        required: true
-      KUBE_CERT:
-        required: true
-      ECR_ROLE_TO_ASSUME:
-        required: true
-      DATA_CLAIMS_API_IMAGE:
-        required: true
-      PAT_TOKEN:
-        required: true
 
 
 permissions:
@@ -129,12 +104,4 @@ jobs:
       environment: ${{ inputs.environment }}
       amend_a_claim_image_tag: ${{ inputs.amend_a_claim_image_tag }}
       sanitized_release_name: ${{ inputs.sanitized_release_name }}
-    secrets:
-      ECR_ROLE_TO_ASSUME: ${{ secrets.ECR_ROLE_TO_ASSUME }}
-      DATA_CLAIMS_API_IMAGE: ${{ secrets.DATA_CLAIMS_API_IMAGE }}
-      KUBE_NAMESPACE: ${{ secrets.KUBE_NAMESPACE }}
-      KUBE_CLUSTER: ${{ secrets.KUBE_CLUSTER }}
-      KUBE_TOKEN: ${{ secrets.KUBE_TOKEN }}
-      KUBE_CERT: ${{ secrets.KUBE_CERT }}
-      E2E_DB_PASSWORD: ${{ secrets.E2E_DB_PASSWORD }}
-      E2E_DB_USER: ${{ secrets.E2E_DB_USER }}
+    secrets: inherit


### PR DESCRIPTION
## What is this PR?

- Authenticate with Docker Hub before pulling images in the build and deploy pipelines. 
-  Restores docker/build-push-action and docker/setup-buildx-action in build.yml. Previously removed as a workaround for the same issue, which brings back ECR layer caching for faster builds.   
- Switches internal reusable workflow calls to secrets: inherit to avoid repeating secrets across every job.


## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

