### PR TITLE
Move Snyk app scan to standalone workflow to fix code scanning analysis key mismatch.

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -65,7 +65,7 @@ jobs:
   security:
     name: Security
     needs: build
-    uses: ./.github/workflows/security.yml
+    uses: ./.github/workflows/snyk-docker-scan.yml
     with:
       branch: ${{ github.ref_name }}
       image_tag: ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
   security:
     name: Security
     needs: [ build, test ]
-    uses: ./.github/workflows/security.yml
+    uses: ./.github/workflows/snyk-docker-scan.yml
     with:
       branch: ${{ github.ref_name }}
       image_tag: ${{ needs.build.outputs.image_tag }}

--- a/.github/workflows/snyk-app-scan.yml
+++ b/.github/workflows/snyk-app-scan.yml
@@ -1,0 +1,46 @@
+name: Security Scan
+
+on:
+  push:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  vulnerability-scan-app:
+    name: Vulnerability Scan - Application
+    runs-on: ubuntu-latest
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      SNYK_TEST_EXCLUDE: build,generated
+      SNYK_TARGET_REFERENCE: main
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout Source Code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: 25
+          distribution: corretto
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+
+      - name: Install Snyk CLI
+        run: npm install -g snyk
+
+      - name: Run Snyk app vulnerability scan
+        run: snyk test --severity-threshold=low --sarif-file-output=snyk-app.sarif
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+      - name: Upload result to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@a899987af240c0578ed84ce13c02319a693e168f
+        with:
+          sarif_file: snyk-app.sarif
+          category: snyk-app

--- a/.github/workflows/snyk-docker-scan.yml
+++ b/.github/workflows/snyk-docker-scan.yml
@@ -23,45 +23,6 @@ permissions:
   id-token: write
 
 jobs:
-  vulnerability-scan-app:
-    name: Vulnerability Scan - Application
-    runs-on: ubuntu-latest
-    env:
-      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      SNYK_TEST_EXCLUDE: build,generated
-      SNYK_TARGET_REFERENCE: main
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - name: Checkout Source Code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ inputs.branch }}
-
-      - name: Set up JDK 25
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
-        with:
-          java-version: 25
-          distribution: corretto
-
-      - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
-
-      - name: Install Snyk CLI
-        run: npm install -g snyk
-
-      - name: Run Snyk app vulnerability scan
-        run: snyk test --severity-threshold=low --sarif-file-output=snyk-app.sarif
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-
-      - name: Upload result to GitHub Code Scanning
-        if: always()
-        uses: github/codeql-action/upload-sarif@a899987af240c0578ed84ce13c02319a693e168f
-        with:
-          sarif_file: snyk-app.sarif
-          category: snyk-app
-
   vulnerability-scan-docker:
     name: Vulnerability Scan - Docker
     runs-on: ubuntu-latest


### PR DESCRIPTION
…

## What is this PR?
## Summary 
- Moved the Snyk app vulnerability scan from the reusable `security.yml` workflow into a standalone `snyk-app-scan.yml` workflow that triggers on push to all branches.

GitHub code scanning was showing a "configuration not found" warning on PRs. This happened because the Snyk app scan was called from different parent workflows (`main.yml` for main, `feature.yml` for feature branches), resulting in different analysis keys. GitHub couldn't match PR results against the main baseline for comparison.


## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

