### PR TITLE
Sort bulk upload errors

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadServiceParsingErrorTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadServiceParsingErrorTest.java
@@ -32,10 +32,10 @@ class BulkUploadServiceParsingErrorTest extends WireMockSetup {
         UUID userId = UUID.randomUUID();
         BulkUploadResult result = bulkUploadService.upload(file, userId);
         assertThat(result.status()).isEqualTo(BulkUploadStatus.PARSING_FAILURE);
-        List<String> errors = result.reasons();
+        List<BulkUploadError> errors = result.errors();
         assertThat(errors).isNotEmpty();
         // Should contain header error
-        assertThat(errors.stream().anyMatch(e -> e.toLowerCase().contains("header")))
+        assertThat(errors.stream().anyMatch(e -> e.message().toLowerCase().contains("header")))
                 .isTrue();
     }
 
@@ -62,12 +62,11 @@ class BulkUploadServiceParsingErrorTest extends WireMockSetup {
         UUID userId = UUID.randomUUID();
         BulkUploadResult result = bulkUploadService.upload(file, userId);
         assertThat(result.status()).isEqualTo(BulkUploadStatus.PARSING_FAILURE);
-        List<String> errors = result.reasons();
+        List<BulkUploadError> errors = result.errors();
         assertThat(errors).isNotEmpty();
         assertThat(errors.size()).isEqualTo(9);
         // Should contain row errors
-        assertThat(errors.stream().anyMatch(e -> e.toLowerCase().contains("row")))
-                .isTrue();
+        assertThat(errors.stream().anyMatch(e -> e.rowNumber() != null)).isTrue();
     }
 
     @Test
@@ -93,7 +92,7 @@ class BulkUploadServiceParsingErrorTest extends WireMockSetup {
 
         assertThat(result.status()).isEqualTo(BulkUploadStatus.VALIDATION_FAILURE);
 
-        List<String> errors = result.reasons();
+        List<BulkUploadError> errors = result.errors();
 
         assertThat(errors).isNotEmpty();
 
@@ -101,11 +100,10 @@ class BulkUploadServiceParsingErrorTest extends WireMockSetup {
         assertThat(errors.size()).isGreaterThan(5);
 
         // Contains row-level validation errors
-        assertThat(errors.stream().anyMatch(e -> e.toLowerCase().contains("row")))
-                .isTrue();
+        assertThat(errors.stream().anyMatch(e -> e.rowNumber() != null)).isTrue();
 
         // Contains duplicate detection errors
-        assertThat(errors.stream().anyMatch(e -> e.toLowerCase().contains("duplicate")))
+        assertThat(errors.stream().anyMatch(e -> e.message().toLowerCase().contains("duplicate")))
                 .isTrue();
     }
 }

--- a/src/integrationTest/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadServiceTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadServiceTest.java
@@ -164,7 +164,8 @@ class BulkUploadServiceTest extends WireMockSetup {
 
         assertThat(result).isNotNull();
         assertThat(result.status()).isEqualTo(BulkUploadStatus.VALIDATION_FAILURE);
-        assertThat(result.reasons())
-                .anyMatch(reason -> reason.contains("Claim not found for UFN 010101/001999 and officeCode 0p0001"));
+        assertThat(result.errors())
+                .anyMatch(error ->
+                        error.message().contains("Claim not found for UFN 010101/001999 and officeCode 0p0001"));
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadError.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadError.java
@@ -1,0 +1,5 @@
+package uk.gov.justice.laa.amend.claim.bulkupload;
+
+import java.io.Serializable;
+
+public record BulkUploadError(Integer rowNumber, String message) implements Serializable {}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
@@ -45,7 +45,7 @@ public class BulkUploadHelper {
         return claims;
     }
 
-    public List<ClaimResponseV2> getAllClaims(List<BulkUploadCivilClaim> rows, List<String> errors) {
+    public List<ClaimResponseV2> getAllClaims(List<BulkUploadCivilClaim> rows, List<BulkUploadError> errors) {
         var officeCodes = rows.stream().map(BulkUploadCivilClaim::getOfficeCode).collect(Collectors.toSet());
         var officeCodeUfnRows = getOfficeCodeUfnRows(rows, errors);
         return officeCodes.stream()
@@ -58,7 +58,7 @@ public class BulkUploadHelper {
      * Map officeCode with UFN and row index from given rows of csv
      */
     public Map<Pair<String, String>, BulkUploadCivilClaim> getOfficeCodeUfnRows(
-            List<BulkUploadCivilClaim> rows, List<String> errors) {
+            List<BulkUploadCivilClaim> rows, List<BulkUploadError> errors) {
 
         var officeUfnToClaim = new HashMap<Pair<String, String>, BulkUploadCivilClaim>();
         Set<Pair<String, String>> appearedKeys = new HashSet<>();
@@ -71,8 +71,8 @@ public class BulkUploadHelper {
             Pair<String, String> key = Pair.of(office, ufn);
             // Duplicate Rows (officeCode + UFN)
             if (!appearedKeys.add(key)) {
-                errors.add(String.format(
-                        "Row %d: Duplicate row for office code %s and UFN %s", row.getRowNumber(), office, ufn));
+                errors.add(new BulkUploadError(
+                        row.getRowNumber(), String.format("Duplicate row for office code %s and UFN %s", office, ufn)));
             }
             officeUfnToClaim.put(key, row);
         });

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/civil/BulkUploadCivilClaim.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/civil/BulkUploadCivilClaim.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 import uk.gov.justice.laa.amend.claim.models.OutcomeType;
 
 @Data
@@ -30,21 +31,22 @@ public class BulkUploadCivilClaim {
         this.officeCode = officeCode == null ? null : officeCode.toUpperCase();
     }
 
-    public List<String> validate() {
-        List<String> errors = new ArrayList<>();
+    public List<BulkUploadError> validate() {
+        List<BulkUploadError> errors = new ArrayList<>();
 
         if (StringUtils.isBlank(officeCode) || officeCode.length() != 6 || !officeCode.matches(OFFICE_CODE_REGEX)) {
-            errors.add(String.format("Row %d: Invalid office code %s", rowNumber, officeCode));
+            errors.add(new BulkUploadError(rowNumber, String.format("Invalid office code %s", officeCode)));
         }
 
         if (StringUtils.isBlank(ufn)
                 || !ufn.matches(UNIQUE_FILE_NUMBER_CHARACTER_REGEX)
                 || !ufn.matches(UNIQUE_FILE_NUMBER_FORMAT_REGEX)) {
-            errors.add(String.format("Row %d: Invalid UFN %s", rowNumber, ufn));
+            errors.add(new BulkUploadError(rowNumber, String.format("Invalid UFN %s", ufn)));
         }
 
         if (OutcomeType.fromCsvLabel(assessmentOutcome) == null) {
-            errors.add(String.format("Row %d: Invalid Assessment Outcome %s", rowNumber, assessmentOutcome));
+            errors.add(
+                    new BulkUploadError(rowNumber, String.format("Invalid Assessment Outcome %s", assessmentOutcome)));
         }
 
         validateCurrency(profitCost, "Profit Cost", errors);
@@ -57,24 +59,25 @@ public class BulkUploadCivilClaim {
         return errors;
     }
 
-    private void validateCurrency(BigDecimal value, String fieldName, List<String> errors) {
-        String prefix = String.format("Row %d: Invalid %s", rowNumber, fieldName);
+    private void validateCurrency(BigDecimal value, String fieldName, List<BulkUploadError> errors) {
+        String prefix = String.format("Invalid %s", fieldName);
 
         if (value == null) {
-            errors.add(prefix);
+            errors.add(new BulkUploadError(rowNumber, prefix));
             return;
         }
 
         if (value.scale() > 2) {
-            errors.add(String.format("%s must be a number with up to 2 decimal places", prefix));
+            errors.add(new BulkUploadError(
+                    rowNumber, String.format("%s must be a number with up to 2 decimal places", prefix)));
         }
 
         if (value.compareTo(MIN_CURRENCY) < 0) {
-            errors.add(String.format("%s must not be negative", prefix));
+            errors.add(new BulkUploadError(rowNumber, String.format("%s must not be negative", prefix)));
         }
 
         if (value.compareTo(MAX_CURRENCY) >= 0) {
-            errors.add(String.format("%s must be less than %s", prefix, MAX_CURRENCY));
+            errors.add(new BulkUploadError(rowNumber, String.format("%s must be less than %s", prefix, MAX_CURRENCY)));
         }
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/civil/BulkUploadCivilClaimCsvMapper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/civil/BulkUploadCivilClaimCsvMapper.java
@@ -38,7 +38,7 @@ public class BulkUploadCivilClaimCsvMapper implements CsvRowMapper<BulkUploadCiv
     private String getRequiredString(CSVRecord record, String header, int rowNumber) {
         String value = record.get(header);
         if (value == null || value.isBlank()) {
-            throw new IllegalArgumentException("Row " + rowNumber + ": " + header + " is required.");
+            throw new IllegalArgumentException(header + " is required.");
         }
         return value.trim();
     }
@@ -55,7 +55,7 @@ public class BulkUploadCivilClaimCsvMapper implements CsvRowMapper<BulkUploadCiv
 
             return NumberUtils.parse(normalized);
         } catch (Exception ex) {
-            throw new IllegalArgumentException("Row " + rowNumber + ": Invalid number in " + header);
+            throw new IllegalArgumentException("Invalid number in " + header);
         }
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/BulkUploadResult.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/BulkUploadResult.java
@@ -7,8 +7,9 @@ import static uk.gov.justice.laa.amend.claim.models.BulkUploadResult.BulkUploadS
 import java.io.Serializable;
 import java.util.EnumSet;
 import java.util.List;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 
-public record BulkUploadResult(BulkUploadStatus status, List<String> reasons) implements Serializable {
+public record BulkUploadResult(BulkUploadStatus status, List<BulkUploadError> errors) implements Serializable {
 
     public enum BulkUploadStatus {
         SUCCESS,

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilService.java
@@ -84,8 +84,8 @@ public class BulkUploadCivilService extends BulkUploadService<BulkUploadCivilCla
         }
         if (!errors.isEmpty()) {
             log.info("Failed validation with {} errors", errors.size());
-            sortByRowNumber(errors);
-            return new BulkUploadValidationOutcome(new BulkUploadResult(VALIDATION_FAILURE, errors), List.of());
+            return new BulkUploadValidationOutcome(
+                    new BulkUploadResult(VALIDATION_FAILURE, sortedByRowNumber(errors)), List.of());
         } else {
             String message = String.format("Successfully validated %d rows", rows.size());
             log.info(message);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Service;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadHelper;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvHeaderValidator;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvRowMapper;
@@ -45,7 +46,7 @@ public class BulkUploadCivilService extends BulkUploadService<BulkUploadCivilCla
      */
     @Override
     protected BulkUploadValidationOutcome validateRows(List<BulkUploadCivilClaim> rows) {
-        List<String> errors = new ArrayList<>();
+        List<BulkUploadError> errors = new ArrayList<>();
         List<ClaimDetails> claimsData = new ArrayList<>();
 
         var apiClaimResponseObjects = bulkUploadHelper.getAllClaims(rows, errors);
@@ -55,21 +56,25 @@ public class BulkUploadCivilService extends BulkUploadService<BulkUploadCivilCla
             var claimResponsesForRow = claimsByOfficeCodeAndUfn.get(Pair.of(row.getOfficeCode(), row.getUfn()));
 
             // Row validation
-            List<String> rowErrors = row.validate();
+            List<BulkUploadError> rowErrors = row.validate();
             if (!rowErrors.isEmpty()) {
                 errors.addAll(rowErrors);
             }
 
             if (claimResponsesForRow == null) {
-                errors.add(String.format(
-                        "Row %d: Escaped Civil Claim not found for UFN %s and officeCode %s",
-                        row.getRowNumber(), row.getUfn(), row.getOfficeCode()));
+                errors.add(new BulkUploadError(
+                        row.getRowNumber(),
+                        String.format(
+                                "Escaped Civil Claim not found for UFN %s and officeCode %s",
+                                row.getUfn(), row.getOfficeCode())));
                 continue;
             }
             if (claimResponsesForRow.size() > 1) {
-                errors.add(String.format(
-                        "Row %d: Duplicate Escaped Civil Claim found for UFN %s and officeCode %s",
-                        row.getRowNumber(), row.getUfn(), row.getOfficeCode()));
+                errors.add(new BulkUploadError(
+                        row.getRowNumber(),
+                        String.format(
+                                "Duplicate Escaped Civil Claim found for UFN %s and officeCode %s",
+                                row.getUfn(), row.getOfficeCode())));
                 continue;
             }
 
@@ -79,11 +84,13 @@ public class BulkUploadCivilService extends BulkUploadService<BulkUploadCivilCla
         }
         if (!errors.isEmpty()) {
             log.info("Failed validation with {} errors", errors.size());
+            sortByRowNumber(errors);
             return new BulkUploadValidationOutcome(new BulkUploadResult(VALIDATION_FAILURE, errors), List.of());
         } else {
             String message = String.format("Successfully validated %d rows", rows.size());
             log.info(message);
-            return new BulkUploadValidationOutcome(new BulkUploadResult(SUCCESS, List.of(message)), claimsData);
+            return new BulkUploadValidationOutcome(
+                    new BulkUploadResult(SUCCESS, List.of(new BulkUploadError(null, message))), claimsData);
         }
     }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
@@ -85,7 +85,10 @@ public abstract class BulkUploadService<T> {
             try {
                 csvHeaderValidator.validate(schemaProvider.getSchema(), parser.getHeaderNames());
             } catch (Exception ex) {
-                errors.add(new BulkUploadError(null, ex.getMessage()));
+                String message = StringUtils.isBlank(ex.getMessage())
+                        ? "Failed to validate CSV header."
+                        : ex.getMessage();
+                errors.add(new BulkUploadError(null, message));
                 return;
             }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.amend.claim.service;
 
+import static java.util.Comparator.naturalOrder;
+import static java.util.Comparator.nullsFirst;
 import static uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadHelper.MAX_ROWS;
 import static uk.gov.justice.laa.amend.claim.models.BulkUploadResult.BulkUploadStatus.PARSING_FAILURE;
 import static uk.gov.justice.laa.amend.claim.models.BulkUploadResult.BulkUploadStatus.SUBMISSION_FAILURE;
@@ -50,8 +52,7 @@ public abstract class BulkUploadService<T> {
                     null, StringUtils.isNotBlank(ex.getMessage()) ? ex.getMessage() : "Error parsing file"));
         }
         if (!errors.isEmpty()) {
-            sortByRowNumber(errors);
-            return new BulkUploadResult(PARSING_FAILURE, errors);
+            return new BulkUploadResult(PARSING_FAILURE, sortedByRowNumber(errors));
         }
         log.info("Parsed {} rows from file", rows.size());
 
@@ -85,9 +86,8 @@ public abstract class BulkUploadService<T> {
             try {
                 csvHeaderValidator.validate(schemaProvider.getSchema(), parser.getHeaderNames());
             } catch (Exception ex) {
-                String message = StringUtils.isBlank(ex.getMessage())
-                        ? "Failed to validate CSV header."
-                        : ex.getMessage();
+                String message =
+                        StringUtils.isBlank(ex.getMessage()) ? "Failed to validate CSV header." : ex.getMessage();
                 errors.add(new BulkUploadError(null, message));
                 return;
             }
@@ -131,7 +131,9 @@ public abstract class BulkUploadService<T> {
         return new BulkUploadResult(SUCCESS, List.of(new BulkUploadError(null, successMessage)));
     }
 
-    protected static void sortByRowNumber(List<BulkUploadError> errors) {
-        errors.sort(Comparator.comparing(BulkUploadError::rowNumber, Comparator.nullsFirst(Comparator.naturalOrder())));
+    protected static List<BulkUploadError> sortedByRowNumber(List<BulkUploadError> errors) {
+        return errors.stream()
+                .sorted(Comparator.comparing(BulkUploadError::rowNumber, nullsFirst(naturalOrder())))
+                .toList();
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +20,7 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvHeaderValidator;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvRowMapper;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvSchemaProvider;
@@ -39,21 +41,24 @@ public abstract class BulkUploadService<T> {
 
     public BulkUploadResult upload(MultipartFile file, UUID userId) {
         List<T> rows = new ArrayList<>();
-        List<String> errors = new ArrayList<>();
+        List<BulkUploadError> errors = new ArrayList<>();
         try {
             parseFile(file, rows, errors);
         } catch (Exception ex) {
             log.error("Error parsing file", ex);
-            errors.add(StringUtils.isNotBlank(ex.getMessage()) ? ex.getMessage() : "Error parsing file");
+            errors.add(new BulkUploadError(
+                    null, StringUtils.isNotBlank(ex.getMessage()) ? ex.getMessage() : "Error parsing file"));
         }
         if (!errors.isEmpty()) {
+            sortByRowNumber(errors);
             return new BulkUploadResult(PARSING_FAILURE, errors);
         }
         log.info("Parsed {} rows from file", rows.size());
 
         if (rows.size() > MAX_ROWS) {
             return new BulkUploadResult(
-                    PARSING_FAILURE, List.of("File contains too many rows. Maximum allowed is " + MAX_ROWS));
+                    PARSING_FAILURE,
+                    List.of(new BulkUploadError(null, "File contains too many rows. Maximum allowed is " + MAX_ROWS)));
         }
 
         var validationOutcome = validateRows(rows);
@@ -64,7 +69,7 @@ public abstract class BulkUploadService<T> {
         return submit(validationOutcome.claimDetailsList(), userId);
     }
 
-    private void parseFile(MultipartFile file, List<T> rows, List<String> errors) throws IOException {
+    private void parseFile(MultipartFile file, List<T> rows, List<BulkUploadError> errors) throws IOException {
         try (BufferedReader reader =
                         new BufferedReader(new InputStreamReader(file.getInputStream(), StandardCharsets.UTF_8));
                 CSVParser parser = CSVFormat.DEFAULT
@@ -80,7 +85,7 @@ public abstract class BulkUploadService<T> {
             try {
                 csvHeaderValidator.validate(schemaProvider.getSchema(), parser.getHeaderNames());
             } catch (Exception ex) {
-                errors.add(ex.getMessage());
+                errors.add(new BulkUploadError(null, ex.getMessage()));
                 return;
             }
 
@@ -90,7 +95,7 @@ public abstract class BulkUploadService<T> {
                 try {
                     rows.add(rowMapper.mapRow(record, row));
                 } catch (Exception ex) {
-                    errors.add(ex.getMessage());
+                    errors.add(new BulkUploadError(row, ex.getMessage()));
                 }
             }
         }
@@ -110,15 +115,20 @@ public abstract class BulkUploadService<T> {
                 assessmentService.submitAssessment(claim, userId.toString());
             } catch (Exception ex) {
                 var message = String.format(
-                        "Row %s: Failed to submit assessment. %s prior rows in the file have already been"
+                        "Failed to submit assessment. %s prior rows in the file have already been"
                                 + " processed and do not need to be reuploaded.",
-                        row + ROW_OFFSET, row);
+                        row);
                 log.error(message, ex);
-                return new BulkUploadResult(SUBMISSION_FAILURE, List.of(message));
+                return new BulkUploadResult(
+                        SUBMISSION_FAILURE, List.of(new BulkUploadError(row + ROW_OFFSET, message)));
             }
         }
         var successMessage = String.format("Successfully uploaded %s assessments", claimDetails.size());
         log.info(successMessage);
-        return new BulkUploadResult(SUCCESS, List.of(successMessage));
+        return new BulkUploadResult(SUCCESS, List.of(new BulkUploadError(null, successMessage)));
+    }
+
+    protected static void sortByRowNumber(List<BulkUploadError> errors) {
+        errors.sort(Comparator.comparing(BulkUploadError::rowNumber, Comparator.nullsFirst(Comparator.naturalOrder())));
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadService.java
@@ -118,7 +118,7 @@ public abstract class BulkUploadService<T> {
                         "Failed to submit assessment. %s prior rows in the file have already been"
                                 + " processed and do not need to be reuploaded.",
                         row);
-                log.error(message, ex);
+                log.error(String.format("Row %s: %s", row + ROW_OFFSET, message), ex);
                 return new BulkUploadResult(
                         SUBMISSION_FAILURE, List.of(new BulkUploadError(row + ROW_OFFSET, message)));
             }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -372,3 +372,6 @@ bulkUploadResult.errorHeading=Your file could not be processed
 bulkUploadResult.errorSummary=Please address the following issues and try again
 bulkUploadResult.uploadAnotherFile=Upload another file
 bulkUploadResult.backToSearch=Back to search
+bulkUploadResult.errorTable.rowHeader=Row
+bulkUploadResult.errorTable.errorHeader=Error
+bulkUploadResult.errorTable.noRow=—

--- a/src/main/resources/templates/bulk-upload-result.html
+++ b/src/main/resources/templates/bulk-upload-result.html
@@ -15,8 +15,8 @@
                         <th:block th:if="${result.isSuccess()}">
                             <div class="govuk-panel govuk-panel--confirmation">
                                 <h1 class="govuk-panel__title" th:text="#{bulkUploadResult.success}"></h1>
-                                <th:block th:each="reason : ${result.reasons}">
-                                    <div class="govuk-panel__body" th:text="${reason}"></div>
+                                <th:block th:each="error : ${result.errors}">
+                                    <div class="govuk-panel__body" th:text="${error.message}"></div>
                                 </th:block>
                             </div>
                         </th:block>
@@ -35,11 +35,20 @@
                                 </div>
                             </div>
 
-                            <dl class="govuk-summary-list" id="error-summary-list">
-                                <div class="govuk-summary-list__row" th:each="reason : ${result.reasons}">
-                                    <dd class="govuk-summary-list__value" th:text="${reason}"></dd>
-                                </div>
-                            </dl>
+                            <table class="govuk-table" id="error-summary-list">
+                                <thead class="govuk-table__head">
+                                    <tr class="govuk-table__row">
+                                        <th scope="col" class="govuk-table__header">Row</th>
+                                        <th scope="col" class="govuk-table__header">Error</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="govuk-table__body">
+                                    <tr class="govuk-table__row" th:each="error : ${result.errors}">
+                                        <td class="govuk-table__cell" th:text="${error.rowNumber} ?: 'N/A'"></td>
+                                        <td class="govuk-table__cell" th:text="${error.message}"></td>
+                                    </tr>
+                                </tbody>
+                            </table>
                         </th:block>
                     </th:block>
 

--- a/src/main/resources/templates/bulk-upload-result.html
+++ b/src/main/resources/templates/bulk-upload-result.html
@@ -38,13 +38,13 @@
                             <table class="govuk-table" id="error-summary-list">
                                 <thead class="govuk-table__head">
                                     <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Row</th>
-                                        <th scope="col" class="govuk-table__header">Error</th>
+                                        <th scope="col" class="govuk-table__header" th:text="#{bulkUploadResult.errorTable.rowHeader}"></th>
+                                        <th scope="col" class="govuk-table__header" th:text="#{bulkUploadResult.errorTable.errorHeader}"></th>
                                     </tr>
                                 </thead>
                                 <tbody class="govuk-table__body">
                                     <tr class="govuk-table__row" th:each="error : ${result.errors}">
-                                        <td class="govuk-table__cell" th:text="${error.rowNumber} ?: 'N/A'"></td>
+                                        <td class="govuk-table__cell" th:text="${error.rowNumber} ?: #{bulkUploadResult.errorTable.noRow}"></td>
                                         <td class="govuk-table__cell" th:text="${error.message}"></td>
                                     </tr>
                                 </tbody>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadCivilClaimTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadCivilClaimTest.java
@@ -29,7 +29,7 @@ class BulkUploadCivilClaimTest {
     void validateShouldReturnNoErrorsForValidRow() {
         BulkUploadCivilClaim row = newValidRow();
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertTrue(errors.isEmpty(), "Expected no validation errors");
     }
@@ -39,10 +39,10 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setOfficeCode("");
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertEquals(1, errors.size());
-        assertTrue(errors.getFirst().contains("Invalid office code"));
+        assertTrue(errors.getFirst().message().contains("Invalid office code"));
     }
 
     @Test
@@ -50,10 +50,10 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setOfficeCode("ABC12"); // only 5 chars
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertEquals(1, errors.size());
-        assertTrue(errors.getFirst().contains("Invalid office code"));
+        assertTrue(errors.getFirst().message().contains("Invalid office code"));
     }
 
     @Test
@@ -61,10 +61,10 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setOfficeCode("###123"); // invalid regex
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertEquals(1, errors.size());
-        assertTrue(errors.getFirst().contains("Invalid office code"));
+        assertTrue(errors.getFirst().message().contains("Invalid office code"));
     }
 
     @Test
@@ -72,10 +72,10 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setUfn("");
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertEquals(1, errors.size());
-        assertTrue(errors.getFirst().contains("Invalid UFN"));
+        assertTrue(errors.getFirst().message().contains("Invalid UFN"));
     }
 
     @Test
@@ -83,10 +83,10 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setUfn("BAD_UFN");
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertEquals(1, errors.size());
-        assertTrue(errors.getFirst().contains("Invalid UFN"));
+        assertTrue(errors.getFirst().message().contains("Invalid UFN"));
     }
 
     @Test
@@ -94,9 +94,9 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setProfitCost(null);
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
-        assertTrue(errors.stream().anyMatch(e -> e.contains("Invalid Profit Cost")));
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("Invalid Profit Cost")));
     }
 
     @Test
@@ -104,9 +104,9 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setProfitCost(new BigDecimal("10.999"));
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
-        assertTrue(errors.stream().anyMatch(e -> e.contains("must be a number with up to 2 decimal places")));
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("must be a number with up to 2 decimal places")));
     }
 
     @Test
@@ -114,9 +114,9 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setProfitCost(new BigDecimal("-1.00"));
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
-        assertTrue(errors.stream().anyMatch(e -> e.contains("must not be negative")));
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("must not be negative")));
     }
 
     @Test
@@ -124,9 +124,9 @@ class BulkUploadCivilClaimTest {
         BulkUploadCivilClaim row = newValidRow();
         row.setProfitCost(new BigDecimal("100000000")); // MAX or above
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
-        assertTrue(errors.stream().anyMatch(e -> e.contains("must be less than")));
+        assertTrue(errors.stream().anyMatch(e -> e.message().contains("must be less than")));
     }
 
     @Test
@@ -137,8 +137,19 @@ class BulkUploadCivilClaimTest {
         row.setProfitCost(new BigDecimal("-1")); // invalid
         row.setDisbursements(null); // invalid
 
-        List<String> errors = row.validate();
+        List<BulkUploadError> errors = row.validate();
 
         assertTrue(errors.size() >= 4, "Should contain multiple errors");
+    }
+
+    @Test
+    void validateShouldIncludeRowNumberOnAllErrors() {
+        BulkUploadCivilClaim row = newValidRow();
+        row.setRowNumber(7);
+        row.setOfficeCode("BAD");
+
+        List<BulkUploadError> errors = row.validate();
+
+        assertTrue(errors.stream().allMatch(e -> e.rowNumber() == 7));
     }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
@@ -36,7 +36,7 @@ class BulkUploadHelperTest {
     @Test
     void getOfficeCodeToUfnIdxValidRowsShouldMapRowsCorrectly() {
         List<BulkUploadCivilClaim> rows = new ArrayList<>();
-        List<String> errors = new ArrayList<>();
+        List<BulkUploadError> errors = new ArrayList<>();
 
         BulkUploadCivilClaim row1 = row("123456", "131019/020", 1);
         BulkUploadCivilClaim row2 = row("123456", "131019/024", 2);
@@ -83,7 +83,7 @@ class BulkUploadHelperTest {
                         null))
                 .thenReturn(emptyList());
 
-        List<String> errors = new ArrayList<>();
+        List<BulkUploadError> errors = new ArrayList<>();
         BulkUploadCivilClaim row = row(officeCode, "20220101/020244", 1);
         List<BulkUploadCivilClaim> rows = List.of(row);
         var response = helper.getAllClaims(rows, errors);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/BulkUploadControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/BulkUploadControllerTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 import uk.gov.justice.laa.amend.claim.models.BulkUploadResult;
 import uk.gov.justice.laa.amend.claim.service.BulkUploadService;
 import uk.gov.justice.laa.amend.claim.service.DummyUserSecurityService;
@@ -78,7 +79,7 @@ public class BulkUploadControllerTest extends BaseControllerTest {
 
     @Test
     void testResultOnPageLoadReturnsViewIfResultSet() throws Exception {
-        var result = new BulkUploadResult(SUCCESS, List.of("all is good"));
+        var result = new BulkUploadResult(SUCCESS, List.of(new BulkUploadError(null, "all is good")));
         mockMvc.perform(get(RESULT_PATH).flashAttr("result", result))
                 .andExpect(status().isOk())
                 .andExpect(view().name("bulk-upload-result"));

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilServiceTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadHelper;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvHeaderValidator;
 import uk.gov.justice.laa.amend.claim.bulkupload.CsvRowMapper;
@@ -150,8 +151,37 @@ class BulkUploadCivilServiceTest {
 
         // --- assert ---
         assertEquals(VALIDATION_FAILURE, outcome.result().status());
-        String error = outcome.result().reasons().getFirst();
-        assertTrue(error.contains("Duplicate Escaped Civil Claim"));
+        BulkUploadError error = outcome.result().errors().getFirst();
+        assertTrue(error.message().contains("Duplicate Escaped Civil Claim"));
+    }
+
+    @Test
+    void validateRowsShouldReturnErrorsSortedByRowNumber() {
+        // --- arrange: two rows with invalid office codes, row 5 before row 2 in iteration ---
+        BulkUploadCivilClaim row2 = mock(BulkUploadCivilClaim.class);
+        BulkUploadCivilClaim row5 = mock(BulkUploadCivilClaim.class);
+
+        when(row2.getRowNumber()).thenReturn(2);
+        when(row2.getOfficeCode()).thenReturn(OFFICE_CODE);
+        when(row2.getUfn()).thenReturn(UNIQUE_FILE_NUMBER);
+        when(row2.validate()).thenReturn(List.of(new BulkUploadError(2, "error on row 2")));
+
+        when(row5.getRowNumber()).thenReturn(5);
+        when(row5.getOfficeCode()).thenReturn(OFFICE_CODE);
+        when(row5.getUfn()).thenReturn("999999/999");
+        when(row5.validate()).thenReturn(List.of(new BulkUploadError(5, "error on row 5")));
+
+        when(bulkUploadHelper.getAllClaims(anyList(), anyList())).thenReturn(List.of());
+
+        // --- act: pass row5 first, then row2 ---
+        BulkUploadValidationOutcome outcome = service.validateRows(List.of(row5, row2));
+
+        // --- assert: errors sorted ascending by row number ---
+        assertEquals(VALIDATION_FAILURE, outcome.result().status());
+        List<BulkUploadError> errors = outcome.result().errors();
+        assertTrue(
+                errors.get(0).rowNumber() <= errors.get(1).rowNumber(),
+                "Errors should be sorted by row number ascending");
     }
 
     private CivilClaimDetails buildEmptyDetails() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilServiceTest.java
@@ -179,9 +179,11 @@ class BulkUploadCivilServiceTest {
         // --- assert: errors sorted ascending by row number ---
         assertEquals(VALIDATION_FAILURE, outcome.result().status());
         List<BulkUploadError> errors = outcome.result().errors();
-        assertTrue(
-                errors.get(0).rowNumber() <= errors.get(1).rowNumber(),
-                "Errors should be sorted by row number ascending");
+        for (int i = 1; i < errors.size(); i++) {
+            assertTrue(
+                    errors.get(i - 1).rowNumber() <= errors.get(i).rowNumber(),
+                    "Errors should be sorted by row number ascending");
+        }
     }
 
     private CivilClaimDetails buildEmptyDetails() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/BulkUploadResultViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/BulkUploadResultViewTest.java
@@ -7,11 +7,12 @@ import static uk.gov.justice.laa.amend.claim.models.BulkUploadResult.BulkUploadS
 import java.util.List;
 import java.util.Map;
 import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import uk.gov.justice.laa.amend.claim.bulkupload.BulkUploadError;
 import uk.gov.justice.laa.amend.claim.controllers.BulkUploadController;
 import uk.gov.justice.laa.amend.claim.models.BulkUploadResult;
 import uk.gov.justice.laa.amend.claim.service.BulkUploadService;
@@ -31,7 +32,7 @@ public class BulkUploadResultViewTest extends ViewTestBase {
         when(featureFlagsConfig.getIsBulkUploadEnabled()).thenReturn(true);
 
         var successReason = "success reason";
-        var result = new BulkUploadResult(SUCCESS, List.of(successReason));
+        var result = new BulkUploadResult(SUCCESS, List.of(new BulkUploadError(null, successReason)));
 
         Document doc = renderDocument(Map.of("result", result));
 
@@ -55,14 +56,16 @@ public class BulkUploadResultViewTest extends ViewTestBase {
 
         var errorReason1 = "error reason 1";
         var errorReason2 = "error reason 2";
-        var result = new BulkUploadResult(PARSING_FAILURE, List.of(errorReason1, errorReason2));
+        var result = new BulkUploadResult(
+                PARSING_FAILURE,
+                List.of(new BulkUploadError(null, errorReason1), new BulkUploadError(3, errorReason2)));
 
         Document doc = renderDocument(Map.of("result", result));
 
-        List<List<Element>> summaryList = getFirstSummaryList(doc);
-        Assertions.assertEquals(2, summaryList.size());
-        assertCellContainsText(summaryList.get(0).get(1), errorReason1);
-        assertCellContainsText(summaryList.get(1).get(1), errorReason2);
+        Elements rows = doc.select("#error-summary-list tbody tr");
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals(errorReason1, rows.get(0).select("td").get(1).text());
+        Assertions.assertEquals(errorReason2, rows.get(1).select("td").get(1).text());
 
         assertPageHasLink(doc, "upload-another-file", "Upload another file", "/bulk-upload");
         assertPageHasLink(doc, "back-to-search", "Back to search", "/");


### PR DESCRIPTION
## What is this PR?

- Sort bulk upload errors by storing them as `BulkUploadError`'s which have an optional row number.
- Display these errors in a table of Row Number/ Error Message

<img width="1110" height="879" alt="Screenshot 2026-03-31 at 16 14 57" src="https://github.com/user-attachments/assets/7b1529dd-39b0-4d66-ab67-bb9def6044ab" />

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

