### PR TITLE
BC-550: Set security headers globally

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/security/CommonSecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/security/CommonSecurityConfig.java
@@ -32,7 +32,7 @@ public abstract class CommonSecurityConfig {
         return source;
     }
 
-    public OncePerRequestFilter securityHeadersFilter() {
+    public OncePerRequestFilter createSecurityHeadersFilter() {
         return new OncePerRequestFilter() {
             @Override
             protected void doFilterInternal(

--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/security/LocalSecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/security/LocalSecurityConfig.java
@@ -2,14 +2,16 @@ package uk.gov.justice.laa.amend.claim.config.security;
 
 import static uk.gov.justice.laa.amend.claim.config.security.SecurityConstants.PUBLIC_PATHS;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.AnonymousAuthenticationFilter;
-import org.springframework.security.web.header.HeaderWriterFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.justice.laa.amend.claim.service.DummyUserSecurityService;
 
 @Profile({"local", "ephemeral"})
@@ -25,8 +27,15 @@ public class LocalSecurityConfig extends CommonSecurityConfig {
                         .permitAll()
                         .anyRequest()
                         .authenticated())
-                .addFilterBefore(dummyUserSecurityService, AnonymousAuthenticationFilter.class)
-                .addFilterAfter(securityHeadersFilter(), HeaderWriterFilter.class);
+                .addFilterBefore(dummyUserSecurityService, AnonymousAuthenticationFilter.class);
         return http.build();
+    }
+
+    @Bean
+    public FilterRegistrationBean<OncePerRequestFilter> securityHeadersFilter() {
+        FilterRegistrationBean<OncePerRequestFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(createSecurityHeadersFilter());
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
     }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/security/SecurityConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/security/SecurityConfig.java
@@ -7,9 +7,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.core.Ordered;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -27,7 +29,7 @@ import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
-import org.springframework.security.web.header.HeaderWriterFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
 import uk.gov.justice.laa.amend.claim.models.Role;
 
 @Profile("!local & !ephemeral & !e2e")
@@ -57,10 +59,17 @@ public class SecurityConfig extends CommonSecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)
                         .invalidSessionUrl("/logout-success?message=expired")
                         .sessionConcurrency(concurrency ->
-                                concurrency.maximumSessions(1).expiredUrl("/logout-success?message=expired")))
-                .addFilterAfter(securityHeadersFilter(), HeaderWriterFilter.class);
+                                concurrency.maximumSessions(1).expiredUrl("/logout-success?message=expired")));
 
         return http.build();
+    }
+
+    @Bean
+    public FilterRegistrationBean<OncePerRequestFilter> securityHeadersFilter() {
+        FilterRegistrationBean<OncePerRequestFilter> registration = new FilterRegistrationBean<>();
+        registration.setFilter(createSecurityHeadersFilter());
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE);
+        return registration;
     }
 
     private OidcUserService oidcUserService() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,6 +78,7 @@ server:
     session:
       cookie:
         same-site: lax
+      tracking-modes: cookie
 
 ---
 spring:


### PR DESCRIPTION
## What is this PR?

WARN-NEW: Content Security Policy (CSP) Header Not Set [10038] x 6 
WARN-NEW: Relative Path Confusion [10051] x 6 
WARN-NEW: Permissions Policy Header Not Set [10063] x 6 
WARN-NEW: Session ID in URL Rewrite [3] x 12 
https://github.com/ministryofjustice/laa-amend-a-claim/actions/runs/23842149225/job/69500219597

These started occurring due to introduction of ErrorConfig.errorPageRegistrar(). This forwards exceptions to our error controller which was bypassing the part of our security filter chain that we'd attached the headers. Moving them into a bean means that they're applied to every request as expected

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

