### PR TITLE
Revert "Add CRN hint text to clarify only exact matches work (#296)"

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -55,7 +55,6 @@ index.uniqueFileNumber.hint=For example, 120223/001
 index.uniqueFileNumber.error.invalid=The UFN must only include numbers 0 to 9 and forward slashes
 index.uniqueFileNumber.error.format=The UFN must match the required format
 index.caseReferenceNumber=Case reference number (CRN)
-index.caseReferenceNumber.hint=The CRN must match exactly to show results
 index.caseReferenceNumber.error.invalid=The CRN must only include letters a to z, numbers 0 to 9, and special characters such as hyphens, spaces, full stops and forward slashes
 index.caseReferenceNumber.error.format=The CRN must match the required format
 index.areaOfLaw=Area of law

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -61,7 +61,7 @@
 
                                 <div th:replace="~{partials/text-input :: textInput('uniqueFileNumber', 'unique-file-number', 'index.uniqueFileNumber', 'govuk-!-width-one-half', 'text', true, 'govuk-label--s', true)}"></div>
 
-                                <div th:replace="~{partials/text-input :: textInput('caseReferenceNumber', 'case-reference-number', 'index.caseReferenceNumber', 'govuk-!-width-one-half', 'text', true, 'govuk-label--s', true)}"></div>
+                                <div th:replace="~{partials/text-input :: textInput('caseReferenceNumber', 'case-reference-number', 'index.caseReferenceNumber', 'govuk-!-width-one-half', 'text', true, 'govuk-label--s', false)}"></div>
 
                                 <div class="govuk-grid-row">
                                     <div class="govuk-form-group govuk-grid-column-one-quarter">


### PR DESCRIPTION
This reverts commit 3bc740cca665ea13fe47c2b2a7a71e2b3308dc48.

## What is this PR?

To be merged and deployed after https://github.com/ministryofjustice/laa-data-claims-api/pull/300

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

