### PR TITLE
BC-551: Update pact to send assessment_type instead of null.

### DIFF
--- a/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentPactTest.java
+++ b/src/pactTest/java/uk/gov/justice/laa/amend/claim/CreateAssessmentPactTest.java
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 import uk.gov.justice.laa.amend.claim.client.ClaimsApiClient;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentOutcome;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentPost;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.AssessmentType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.CreateAssessment201Response;
 
 @SpringBootTest(
@@ -112,7 +113,7 @@ public final class CreateAssessmentPactTest extends AbstractPactTest {
         body.stringType("assessment_outcome", "PAID_IN_FULL");
         body.uuid("created_by_user_id");
         body.stringType("assessment_reason", ASSESSMENT_REASON_ESCAPE_CASE);
-        body.nullValue("assessment_type");
+        body.stringType("assessment_type", "ESCAPE_CASE_ASSESSMENT");
         body.booleanType("is_vat_applicable", true);
         body.decimalType("fixed_fee_amount", 100.00);
         body.decimalType("net_profit_costs_amount", 200.00);
@@ -150,6 +151,7 @@ public final class CreateAssessmentPactTest extends AbstractPactTest {
         assessment.setAllowedTotalVat(new BigDecimal("60.00"));
         assessment.setAllowedTotalInclVat(new BigDecimal("360.00"));
         assessment.setAssessmentReason(ASSESSMENT_REASON_ESCAPE_CASE);
+        assessment.setAssessmentType(AssessmentType.ESCAPE_CASE_ASSESSMENT);
         return assessment;
     }
 }


### PR DESCRIPTION
## What is this PR?

[BC-551](https://dsdmoj.atlassian.net/browse/BC-551)

The data-claims-api is being updated to require `assessmentType` in the create assessment request - instead of defaulting to `ESCAPE_CASE_ASSESSMENT`. 
This pact change is backward compatible with the current API and unblocks the data-claims-api PR. 

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
