### PR TITLE
refactor: convert MicrosoftApiUser from Lombok POJO to Java record

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/amend/claim/client/MicrosoftGraphApiClientIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/amend/claim/client/MicrosoftGraphApiClientIntegrationTest.java
@@ -40,10 +40,10 @@ public class MicrosoftGraphApiClientIntegrationTest extends WireMockSetup {
         MicrosoftApiUser user = microsoftGraphApiClient.getUser("abc", "123").block();
 
         Assertions.assertNotNull(user);
-        Assertions.assertEquals("dummy-id", user.getId());
-        Assertions.assertEquals("User, Dummy", user.getDisplayName());
-        Assertions.assertEquals("Dummy", user.getGivenName());
-        Assertions.assertEquals("User", user.getSurname());
+        Assertions.assertEquals("dummy-id", user.id());
+        Assertions.assertEquals("User, Dummy", user.displayName());
+        Assertions.assertEquals("Dummy", user.givenName());
+        Assertions.assertEquals("User", user.surname());
     }
 
     @Test
@@ -64,8 +64,8 @@ public class MicrosoftGraphApiClientIntegrationTest extends WireMockSetup {
         MicrosoftApiUser user = microsoftGraphApiClient.getUser("abc", "123").block();
 
         Assertions.assertNotNull(user);
-        Assertions.assertNull(user.getId());
-        Assertions.assertNull(user.getDisplayName());
+        Assertions.assertNull(user.id());
+        Assertions.assertNull(user.displayName());
     }
 
     @Test

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/MicrosoftApiUser.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/MicrosoftApiUser.java
@@ -1,18 +1,11 @@
 package uk.gov.justice.laa.amend.claim.models;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import static java.util.Objects.nonNull;
 
-@Data
-@AllArgsConstructor
-public class MicrosoftApiUser {
-    private String id;
-    private String displayName;
-    private String givenName;
-    private String surname;
+public record MicrosoftApiUser(String id, String displayName, String givenName, String surname) {
 
-    public String getName() {
-        if (givenName != null && surname != null) {
+    public String name() {
+        if (nonNull(givenName) && nonNull(surname)) {
             return String.format("%s %s", givenName, surname);
         }
         return displayName;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsView.java
@@ -5,6 +5,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import uk.gov.justice.laa.amend.claim.forms.errors.ReviewAndAmendFormError;
@@ -120,12 +121,11 @@ public interface ClaimDetailsView<T extends ClaimDetails> extends BaseClaimView<
         String time = DateUtils.displayDateTimeTimeValue(claim().getLastUpdatedDateTime());
 
         List<Object> args = new ArrayList<>();
-        String editMessageKey;
-        if (user != null && user.getName() != null) {
-            args.add(user.getName());
+        String editMessageKey = "claimSummary.lastAssessmentText.noUser";
+        Optional<String> userName = Optional.ofNullable(user).map(MicrosoftApiUser::name);
+        if (userName.isPresent()) {
+            args.add(userName.get());
             editMessageKey = "claimSummary.lastAssessmentText";
-        } else {
-            editMessageKey = "claimSummary.lastAssessmentText.noUser";
         }
         args.add(date);
         args.add(time);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryControllerTest.java
@@ -167,10 +167,10 @@ public class ClaimSummaryControllerTest extends BaseControllerTest {
         var user = MockClaimsFunctions.createUser();
         var claim = MockClaimsFunctions.createMockCivilClaim();
         claim.setStatus(ClaimStatus.VOID);
-        claim.setLastUpdatedUser(user.getId());
+        claim.setLastUpdatedUser(user.id());
         claim.setLastUpdatedDateTime(OffsetDateTime.now());
 
-        when(userRetrievalService.getMicrosoftApiUser(user.getId())).thenReturn(user);
+        when(userRetrievalService.getMicrosoftApiUser(user.id())).thenReturn(user);
         when(claimService.getClaimDetails(submissionId, claimId)).thenReturn(claim);
 
         mockMvc.perform(get(buildPath()).session(session))
@@ -228,10 +228,10 @@ public class ClaimSummaryControllerTest extends BaseControllerTest {
         var user = MockClaimsFunctions.createUser();
         var claim = MockClaimsFunctions.createMockCivilClaim();
         claim.setStatus(ClaimStatus.VOID);
-        claim.setLastUpdatedUser(user.getId());
+        claim.setLastUpdatedUser(user.id());
         claim.setLastUpdatedDateTime(OffsetDateTime.now());
 
-        when(userRetrievalService.getMicrosoftApiUser(user.getId())).thenReturn(user);
+        when(userRetrievalService.getMicrosoftApiUser(user.id())).thenReturn(user);
         when(claimService.getClaimDetails(submissionId, claimId)).thenReturn(claim);
 
         mockMvc.perform(get(buildPath()).session(session))
@@ -246,10 +246,10 @@ public class ClaimSummaryControllerTest extends BaseControllerTest {
         var user = MockClaimsFunctions.createUser();
         var claim = MockClaimsFunctions.createMockCivilClaim();
         claim.setStatus(ClaimStatus.VALID);
-        claim.setLastUpdatedUser(user.getId());
+        claim.setLastUpdatedUser(user.id());
         claim.setLastUpdatedDateTime(OffsetDateTime.now());
 
-        when(userRetrievalService.getMicrosoftApiUser(user.getId())).thenReturn(user);
+        when(userRetrievalService.getMicrosoftApiUser(user.id())).thenReturn(user);
         when(claimService.getClaimDetails(submissionId, claimId)).thenReturn(claim);
 
         mockMvc.perform(get(buildPath()).session(session))

--- a/src/test/java/uk/gov/justice/laa/amend/claim/models/MicrosoftApiUserTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/models/MicrosoftApiUserTest.java
@@ -7,26 +7,26 @@ import org.junit.jupiter.api.Test;
 public class MicrosoftApiUserTest {
 
     @Nested
-    class GetNameTests {
+    class NameTests {
 
         @Test
         void whenGivenNameAndSurnameAreNull() {
             MicrosoftApiUser user = new MicrosoftApiUser("test-id", "Bloggs, Joe", null, null);
-            String result = user.getName();
+            String result = user.name();
             Assertions.assertEquals("Bloggs, Joe", result);
         }
 
         @Test
         void whenGivenNameAndSurnameAreNotNull() {
             MicrosoftApiUser user = new MicrosoftApiUser("test-id", "Bloggs, Joe", "Joe", "Bloggs");
-            String result = user.getName();
+            String result = user.name();
             Assertions.assertEquals("Joe Bloggs", result);
         }
 
         @Test
         void whenAllValuesAreNull() {
             MicrosoftApiUser user = new MicrosoftApiUser("test-id", null, null, null);
-            String result = user.getName();
+            String result = user.name();
             Assertions.assertNull(result);
         }
     }


### PR DESCRIPTION
- Convert `MicrosoftApiUser` from Lombok `@Data`/`@AllArgsConstructor` class to a Java record                                                                                                          
- Rename `getName()` to `name()` to follow record conventions                                                                                                                      
- Update method call sites to use record accessors