### PR TITLE
refactor: convert ClaimFieldRow from Lombok POJO to Java record and fix Spring Framework Snyk CVEs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,10 @@ configurations.configureEach {
             details.useVersion '3.1.4.RELEASE'
             details.because 'Fixes Template Injection (SNYK-JAVA-ORGTHYMELEAF-16078370, 16078372, 16078377, 16078379)'
         }
+        if (details.requested.group == 'org.springframework' && details.requested.name.startsWith('spring-')) {
+            details.useVersion '7.0.7'
+            details.because 'Fixes HTTP Request Smuggling (SNYK-JAVA-ORGSPRINGFRAMEWORK-16109603, SNYK-JAVA-ORGSPRINGFRAMEWORK-16109604)'
+        }
     }
 }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
@@ -2,9 +2,6 @@ package uk.gov.justice.laa.amend.claim.viewmodels;
 
 import static uk.gov.justice.laa.amend.claim.utils.NumberUtils.getOrElseZero;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import uk.gov.justice.laa.amend.claim.models.AllowedClaimField;
 import uk.gov.justice.laa.amend.claim.models.AssessedClaimField;
 import uk.gov.justice.laa.amend.claim.models.BoltOnClaimField;
@@ -14,17 +11,13 @@ import uk.gov.justice.laa.amend.claim.models.FixedFeeClaimField;
 import uk.gov.justice.laa.amend.claim.models.VatLiabilityClaimField;
 import uk.gov.justice.laa.amend.claim.utils.FormUtils;
 
-@EqualsAndHashCode
-@Getter
-@AllArgsConstructor
-public class ClaimFieldRow {
-
-  private final String key;
-  private Object submitted;
-  private Object calculated;
-  private Object assessed;
-  private final boolean assessable;
-  private final String changeUrl;
+public record ClaimFieldRow(
+    String key,
+    Object submitted,
+    Object calculated,
+    Object assessed,
+    boolean assessable,
+    String changeUrl) {
 
   public static ClaimFieldRow from(AllowedClaimField claimField) {
     return new ClaimFieldRow(
@@ -135,14 +128,14 @@ public class ClaimFieldRow {
   }
 
   public boolean isAssessableAndUnassessed() {
-    return isAssessable() && !isAssessed();
+    return assessable && !hasAssessedValue();
   }
 
   public boolean isAssessableAndAssessed() {
-    return isAssessable() && isAssessed();
+    return assessable && hasAssessedValue();
   }
 
-  public boolean isAssessed() {
+  public boolean hasAssessedValue() {
     return assessed != null;
   }
 }

--- a/src/main/resources/templates/review-and-amend.html
+++ b/src/main/resources/templates/review-and-amend.html
@@ -195,7 +195,7 @@
                             <span class="govuk-visually-hidden" th:text="| #{${row.label}}|"></span>
                         </a>
 
-                        <span th:if="${row.isAssessed()}"
+                        <span th:if="${row.hasAssessedValue()}"
                               th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}"/>
                     </td>
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CivilClaimDetailsViewTest.java
@@ -194,65 +194,62 @@ public class CivilClaimDetailsViewTest
 
       Assertions.assertEquals(13, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
 
-      Assertions.assertEquals(CMRH_ORAL, result.get(7).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(7).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(7).getCalculated());
+      Assertions.assertEquals(CMRH_ORAL, result.get(7).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(7).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(7).calculated());
 
-      Assertions.assertEquals(CMRH_TELEPHONE, result.get(8).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(8).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).getCalculated());
+      Assertions.assertEquals(CMRH_TELEPHONE, result.get(8).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(8).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).calculated());
 
-      Assertions.assertEquals(HO_INTERVIEW, result.get(9).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(9).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(9).getCalculated());
+      Assertions.assertEquals(HO_INTERVIEW, result.get(9).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(9).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(9).calculated());
 
-      Assertions.assertEquals(SUBSTANTIVE_HEARING, result.get(10).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(10).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(10).getCalculated());
+      Assertions.assertEquals(SUBSTANTIVE_HEARING, result.get(10).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(10).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(10).calculated());
 
-      Assertions.assertEquals(ADJOURNED_FEE, result.get(11).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).getCalculated());
+      Assertions.assertEquals(ADJOURNED_FEE, result.get(11).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).calculated());
 
-      Assertions.assertEquals(VAT, result.get(12).getKey());
-      Assertions.assertEquals(true, result.get(12).getSubmitted());
-      Assertions.assertEquals(false, result.get(12).getCalculated());
+      Assertions.assertEquals(VAT, result.get(12).key());
+      Assertions.assertEquals(true, result.get(12).submitted());
+      Assertions.assertEquals(false, result.get(12).calculated());
     }
 
     @Test
@@ -265,69 +262,66 @@ public class CivilClaimDetailsViewTest
 
       Assertions.assertEquals(14, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
 
-      Assertions.assertEquals(CMRH_ORAL, result.get(7).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(7).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(7).getCalculated());
+      Assertions.assertEquals(CMRH_ORAL, result.get(7).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(7).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(7).calculated());
 
-      Assertions.assertEquals(CMRH_TELEPHONE, result.get(8).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(8).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).getCalculated());
+      Assertions.assertEquals(CMRH_TELEPHONE, result.get(8).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(8).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).calculated());
 
-      Assertions.assertEquals(HO_INTERVIEW, result.get(9).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(9).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(9).getCalculated());
+      Assertions.assertEquals(HO_INTERVIEW, result.get(9).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(9).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(9).calculated());
 
-      Assertions.assertEquals(SUBSTANTIVE_HEARING, result.get(10).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(10).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(10).getCalculated());
+      Assertions.assertEquals(SUBSTANTIVE_HEARING, result.get(10).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(10).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(10).calculated());
 
-      Assertions.assertEquals(ADJOURNED_FEE, result.get(11).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).getCalculated());
+      Assertions.assertEquals(ADJOURNED_FEE, result.get(11).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).calculated());
 
-      Assertions.assertEquals(VAT, result.get(12).getKey());
-      Assertions.assertEquals(true, result.get(12).getSubmitted());
-      Assertions.assertEquals(false, result.get(12).getCalculated());
+      Assertions.assertEquals(VAT, result.get(12).key());
+      Assertions.assertEquals(true, result.get(12).submitted());
+      Assertions.assertEquals(false, result.get(12).calculated());
 
-      Assertions.assertEquals(TOTAL, result.get(13).getKey());
-      Assertions.assertNull(result.get(13).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(13).getCalculated());
+      Assertions.assertEquals(TOTAL, result.get(13).key());
+      Assertions.assertNull(result.get(13).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(13).calculated());
     }
 
     @Test
@@ -346,54 +340,51 @@ public class CivilClaimDetailsViewTest
           .forEach(
               key ->
                   Assertions.assertFalse(
-                      result.stream().anyMatch(row -> key.equals(row.getKey())),
+                      result.stream().anyMatch(row -> key.equals(row.key())),
                       "Field with key '" + key + "' should not exist"));
 
       Assertions.assertEquals(9, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
 
-      Assertions.assertEquals(VAT, result.get(7).getKey());
-      Assertions.assertEquals(true, result.get(7).getSubmitted());
-      Assertions.assertEquals(false, result.get(7).getCalculated());
+      Assertions.assertEquals(VAT, result.get(7).key());
+      Assertions.assertEquals(true, result.get(7).submitted());
+      Assertions.assertEquals(false, result.get(7).calculated());
 
-      Assertions.assertEquals(TOTAL, result.get(8).getKey());
-      Assertions.assertNull(result.get(8).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).getCalculated());
+      Assertions.assertEquals(TOTAL, result.get(8).key());
+      Assertions.assertNull(result.get(8).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).calculated());
     }
 
     @Test
@@ -405,7 +396,7 @@ public class CivilClaimDetailsViewTest
           updateClaimFieldSubmittedValue(claim.getSubstantiveHearing(), false));
       List<ClaimFieldRow> result = viewModel.getSummaryClaimFieldRows();
       Assertions.assertFalse(
-          result.stream().anyMatch(row -> SUBSTANTIVE_HEARING.equals(row.getKey())),
+          result.stream().anyMatch(row -> SUBSTANTIVE_HEARING.equals(row.key())),
           "Rows should not contain substantive hearing");
     }
 
@@ -425,49 +416,46 @@ public class CivilClaimDetailsViewTest
 
       Assertions.assertEquals(9, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
 
-      Assertions.assertEquals(VAT, result.get(7).getKey());
-      Assertions.assertEquals(true, result.get(7).getSubmitted());
-      Assertions.assertEquals(false, result.get(7).getCalculated());
+      Assertions.assertEquals(VAT, result.get(7).key());
+      Assertions.assertEquals(true, result.get(7).submitted());
+      Assertions.assertEquals(false, result.get(7).calculated());
 
-      Assertions.assertEquals(TOTAL, result.get(8).getKey());
-      Assertions.assertNull(result.get(8).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).getCalculated());
+      Assertions.assertEquals(TOTAL, result.get(8).key());
+      Assertions.assertNull(result.get(8).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).calculated());
     }
   }
 
@@ -485,61 +473,58 @@ public class CivilClaimDetailsViewTest
 
       Assertions.assertEquals(12, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
 
-      Assertions.assertEquals(CMRH_ORAL, result.get(7).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(7).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(7).getCalculated());
+      Assertions.assertEquals(CMRH_ORAL, result.get(7).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(7).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(7).calculated());
 
-      Assertions.assertEquals(CMRH_TELEPHONE, result.get(8).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(8).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).getCalculated());
+      Assertions.assertEquals(CMRH_TELEPHONE, result.get(8).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(8).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(8).calculated());
 
-      Assertions.assertEquals(HO_INTERVIEW, result.get(9).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(9).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(9).getCalculated());
+      Assertions.assertEquals(HO_INTERVIEW, result.get(9).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(9).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(9).calculated());
 
-      Assertions.assertEquals(SUBSTANTIVE_HEARING, result.get(10).getKey());
-      Assertions.assertEquals(true, result.get(10).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(10).getCalculated());
+      Assertions.assertEquals(SUBSTANTIVE_HEARING, result.get(10).key());
+      Assertions.assertEquals(true, result.get(10).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(10).calculated());
 
-      Assertions.assertEquals(ADJOURNED_FEE, result.get(11).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).getCalculated());
+      Assertions.assertEquals(ADJOURNED_FEE, result.get(11).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(11).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(11).calculated());
     }
 
     @Test
@@ -556,41 +541,38 @@ public class CivilClaimDetailsViewTest
 
       Assertions.assertEquals(7, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
     }
 
     @Test
@@ -609,41 +591,38 @@ public class CivilClaimDetailsViewTest
 
       Assertions.assertEquals(7, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
-
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
-
-      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).getAssessed());
+      Assertions.assertEquals(DETENTION_TRAVEL_COST, result.get(4).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(4).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(4).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(4).assessed());
       Assertions.assertEquals(
           "/submissions/%s/claims/%s/detention-travel-and-waiting-costs",
-          result.get(4).getChangeUrl());
+          result.get(4).changeUrl());
 
-      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).getAssessed());
+      Assertions.assertEquals(JR_FORM_FILLING, result.get(5).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(5).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(5).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(5).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).getChangeUrl());
+          "/submissions/%s/claims/%s/jr-form-filling-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(COUNSELS_COST, result.get(6).getKey());
-      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).getSubmitted());
-      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).getCalculated());
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).getAssessed());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/counsel-costs", result.get(6).getChangeUrl());
+      Assertions.assertEquals(COUNSELS_COST, result.get(6).key());
+      Assertions.assertEquals(BigDecimal.valueOf(100), result.get(6).submitted());
+      Assertions.assertEquals(BigDecimal.valueOf(200), result.get(6).calculated());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(6).assessed());
+      Assertions.assertEquals("/submissions/%s/claims/%s/counsel-costs", result.get(6).changeUrl());
     }
   }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimDetailsViewTest.java
@@ -80,13 +80,13 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
 
       Assertions.assertEquals(2, result.size());
 
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(0).getAssessed());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(0).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/assessed-totals", result.get(0).getChangeUrl());
+          "/submissions/%s/claims/%s/assessed-totals", result.get(0).changeUrl());
 
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(1).getAssessed());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(1).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/assessed-totals", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/assessed-totals", result.get(1).changeUrl());
     }
   }
 
@@ -117,13 +117,13 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
 
       List<ClaimFieldRow> result = viewModel.getAllowedTotals();
 
-      Assertions.assertEquals(BigDecimal.ZERO, result.get(0).getCalculated());
+      Assertions.assertEquals(BigDecimal.ZERO, result.get(0).calculated());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/allowed-totals", result.get(0).getChangeUrl());
+          "/submissions/%s/claims/%s/allowed-totals", result.get(0).changeUrl());
 
-      Assertions.assertEquals(BigDecimal.ZERO, result.get(1).getCalculated());
+      Assertions.assertEquals(BigDecimal.ZERO, result.get(1).calculated());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/allowed-totals", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/allowed-totals", result.get(1).changeUrl());
     }
 
     @Test
@@ -140,13 +140,13 @@ public abstract class ClaimDetailsViewTest<C extends ClaimDetails, V extends Cla
 
       List<ClaimFieldRow> result = viewModel.getAllowedTotals();
 
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(0).getAssessed());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(0).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/allowed-totals", result.get(0).getChangeUrl());
+          "/submissions/%s/claims/%s/allowed-totals", result.get(0).changeUrl());
 
-      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(1).getAssessed());
+      Assertions.assertEquals(BigDecimal.valueOf(300), result.get(1).assessed());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/allowed-totals", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/allowed-totals", result.get(1).changeUrl());
     }
   }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRowTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRowTest.java
@@ -19,36 +19,36 @@ public class ClaimFieldRowTest {
   void whenProfitCostClaimField() {
     CostClaimField field = MockClaimsFunctions.createNetProfitCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.PROFIT_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.PROFIT_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenDisbursementsClaimField() {
     CostClaimField field = MockClaimsFunctions.createDisbursementCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.DISBURSEMENTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.DISBURSEMENTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenDisbursementsVatClaimField() {
     CostClaimField field = MockClaimsFunctions.createDisbursementVatCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.DISBURSEMENTS_VAT.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.DISBURSEMENTS_VAT.getChangeUrl(), result.changeUrl());
   }
 
   @Test
@@ -58,24 +58,24 @@ public class ClaimFieldRowTest {
     field.setCalculated(null);
     field.setAssessed(null);
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.TRAVEL_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(BigDecimal.ZERO, result.submitted());
+    Assertions.assertEquals(BigDecimal.ZERO, result.calculated());
+    Assertions.assertEquals(BigDecimal.ZERO, result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.TRAVEL_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenTravelCostClaimFieldWhenValuesAreNotNull() {
     CostClaimField field = MockClaimsFunctions.createTravelCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.TRAVEL_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.TRAVEL_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
@@ -85,24 +85,24 @@ public class ClaimFieldRowTest {
     field.setCalculated(null);
     field.setAssessed(null);
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.WAITING_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(BigDecimal.ZERO, result.submitted());
+    Assertions.assertEquals(BigDecimal.ZERO, result.calculated());
+    Assertions.assertEquals(BigDecimal.ZERO, result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.WAITING_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenWaitingCostClaimFieldWhenValuesAreNotNull() {
     CostClaimField field = MockClaimsFunctions.createWaitingCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.WAITING_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.WAITING_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
@@ -112,26 +112,26 @@ public class ClaimFieldRowTest {
     field.setCalculated(null);
     field.setAssessed(null);
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(BigDecimal.ZERO, result.submitted());
+    Assertions.assertEquals(BigDecimal.ZERO, result.calculated());
+    Assertions.assertEquals(BigDecimal.ZERO, result.assessed());
+    Assertions.assertTrue(result.assessable());
     Assertions.assertEquals(
-        Cost.DETENTION_TRAVEL_AND_WAITING_COSTS.getChangeUrl(), result.getChangeUrl());
+        Cost.DETENTION_TRAVEL_AND_WAITING_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenDetentionCostClaimFieldWhenValuesAreNotNull() {
     CostClaimField field = MockClaimsFunctions.createDetentionCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
     Assertions.assertEquals(
-        Cost.DETENTION_TRAVEL_AND_WAITING_COSTS.getChangeUrl(), result.getChangeUrl());
+        Cost.DETENTION_TRAVEL_AND_WAITING_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
@@ -141,24 +141,24 @@ public class ClaimFieldRowTest {
     field.setCalculated(null);
     field.setAssessed(null);
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.JR_FORM_FILLING_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(BigDecimal.ZERO, result.submitted());
+    Assertions.assertEquals(BigDecimal.ZERO, result.calculated());
+    Assertions.assertEquals(BigDecimal.ZERO, result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.JR_FORM_FILLING_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenJrFormFillingCostClaimFieldWhenValuesAreNotNull() {
     CostClaimField field = MockClaimsFunctions.createJrFormFillingCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.JR_FORM_FILLING_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.JR_FORM_FILLING_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
@@ -168,24 +168,24 @@ public class ClaimFieldRowTest {
     field.setCalculated(null);
     field.setAssessed(null);
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getSubmitted());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.COUNSEL_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(BigDecimal.ZERO, result.submitted());
+    Assertions.assertEquals(BigDecimal.ZERO, result.calculated());
+    Assertions.assertEquals(BigDecimal.ZERO, result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.COUNSEL_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
   void whenCounselCostClaimFieldWhenValuesAreNotNull() {
     CostClaimField field = MockClaimsFunctions.createCounselCostField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals(Cost.COUNSEL_COSTS.getChangeUrl(), result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals(Cost.COUNSEL_COSTS.getChangeUrl(), result.changeUrl());
   }
 
   @Test
@@ -195,60 +195,60 @@ public class ClaimFieldRowTest {
     field.setCalculated(null);
     field.setAssessed(null);
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertNull(result.getSubmitted());
-    Assertions.assertEquals(BigDecimal.ZERO, result.getCalculated());
-    Assertions.assertNull(result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals("/submissions/%s/claims/%s/allowed-totals", result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertNull(result.submitted());
+    Assertions.assertEquals(BigDecimal.ZERO, result.calculated());
+    Assertions.assertNull(result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals("/submissions/%s/claims/%s/allowed-totals", result.changeUrl());
   }
 
   @Test
   void whenAllowedClaimFieldWhenValuesAreNotNull() {
     AllowedClaimField field = MockClaimsFunctions.createAllowedTotalVatField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals("/submissions/%s/claims/%s/allowed-totals", result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals("/submissions/%s/claims/%s/allowed-totals", result.changeUrl());
   }
 
   @Test
   void whenAssessedClaimField() {
     AssessedClaimField field = MockClaimsFunctions.createAssessedTotalVatField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertTrue(result.isAssessable());
-    Assertions.assertEquals("/submissions/%s/claims/%s/assessed-totals", result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertTrue(result.assessable());
+    Assertions.assertEquals("/submissions/%s/claims/%s/assessed-totals", result.changeUrl());
   }
 
   @Test
   void whenVatLiabilityClaimField() {
     VatLiabilityClaimField field = MockClaimsFunctions.createVatClaimedField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertFalse(result.isAssessable());
-    Assertions.assertEquals("/submissions/%s/claims/%s/assessment-outcome", result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertFalse(result.assessable());
+    Assertions.assertEquals("/submissions/%s/claims/%s/assessment-outcome", result.changeUrl());
   }
 
   @Test
   void whenBoltOnClaimField() {
     BoltOnClaimField field = MockClaimsFunctions.createAdjournedHearingField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertFalse(result.isAssessable());
-    Assertions.assertNull(result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertFalse(result.assessable());
+    Assertions.assertNull(result.changeUrl());
   }
 
   @Test
@@ -279,23 +279,23 @@ public class ClaimFieldRowTest {
   void whenTotalClaimField() {
     CalculatedTotalClaimField field = MockClaimsFunctions.createTotalAmountField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertFalse(result.isAssessable());
-    Assertions.assertNull(result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertFalse(result.assessable());
+    Assertions.assertNull(result.changeUrl());
   }
 
   @Test
   void whenFixedFeeClaimField() {
     FixedFeeClaimField field = MockClaimsFunctions.createFixedFeeField();
     ClaimFieldRow result = ClaimFieldRow.from(field);
-    Assertions.assertEquals(field.getKey(), result.getKey());
-    Assertions.assertEquals(field.getSubmitted(), result.getSubmitted());
-    Assertions.assertEquals(field.getCalculated(), result.getCalculated());
-    Assertions.assertEquals(field.getAssessed(), result.getAssessed());
-    Assertions.assertFalse(result.isAssessable());
-    Assertions.assertNull(result.getChangeUrl());
+    Assertions.assertEquals(field.getKey(), result.key());
+    Assertions.assertEquals(field.getSubmitted(), result.submitted());
+    Assertions.assertEquals(field.getCalculated(), result.calculated());
+    Assertions.assertEquals(field.getAssessed(), result.assessed());
+    Assertions.assertFalse(result.assessable());
+    Assertions.assertNull(result.changeUrl());
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/CrimeClaimDetailsViewTest.java
@@ -102,29 +102,25 @@ public class CrimeClaimDetailsViewTest
 
       Assertions.assertEquals(7, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
+      Assertions.assertEquals(TRAVEL_COSTS, result.get(4).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/travel-costs", result.get(4).changeUrl());
 
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
+      Assertions.assertEquals(WAITING_COSTS, result.get(5).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/waiting-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(TRAVEL_COSTS, result.get(4).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/travel-costs", result.get(4).getChangeUrl());
-
-      Assertions.assertEquals(WAITING_COSTS, result.get(5).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/waiting-costs", result.get(5).getChangeUrl());
-
-      Assertions.assertEquals(VAT, result.get(6).getKey());
+      Assertions.assertEquals(VAT, result.get(6).key());
     }
 
     @Test
@@ -138,31 +134,27 @@ public class CrimeClaimDetailsViewTest
 
       Assertions.assertEquals(8, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
+
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
+
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
+      Assertions.assertEquals(TRAVEL_COSTS, result.get(4).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/travel-costs", result.get(4).changeUrl());
 
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
+      Assertions.assertEquals(WAITING_COSTS, result.get(5).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/waiting-costs", result.get(5).changeUrl());
 
-      Assertions.assertEquals(TRAVEL_COSTS, result.get(4).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/travel-costs", result.get(4).getChangeUrl());
+      Assertions.assertEquals(VAT, result.get(6).key());
 
-      Assertions.assertEquals(WAITING_COSTS, result.get(5).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/waiting-costs", result.get(5).getChangeUrl());
-
-      Assertions.assertEquals(VAT, result.get(6).getKey());
-
-      Assertions.assertEquals(TOTAL, result.get(7).getKey());
+      Assertions.assertEquals(TOTAL, result.get(7).key());
     }
   }
 
@@ -177,27 +169,23 @@ public class CrimeClaimDetailsViewTest
 
       Assertions.assertEquals(6, result.size());
 
-      Assertions.assertEquals(FIXED_FEE, result.get(0).getKey());
+      Assertions.assertEquals(FIXED_FEE, result.get(0).key());
 
-      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/profit-costs", result.get(1).getChangeUrl());
+      Assertions.assertEquals(NET_PROFIT_COST, result.get(1).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/profit-costs", result.get(1).changeUrl());
 
-      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements", result.get(2).getChangeUrl());
+      Assertions.assertEquals(NET_DISBURSEMENTS_COST, result.get(2).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/disbursements", result.get(2).changeUrl());
 
-      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).getKey());
+      Assertions.assertEquals(DISBURSEMENT_VAT, result.get(3).key());
       Assertions.assertEquals(
-          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).getChangeUrl());
+          "/submissions/%s/claims/%s/disbursements-vat", result.get(3).changeUrl());
 
-      Assertions.assertEquals(TRAVEL_COSTS, result.get(4).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/travel-costs", result.get(4).getChangeUrl());
+      Assertions.assertEquals(TRAVEL_COSTS, result.get(4).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/travel-costs", result.get(4).changeUrl());
 
-      Assertions.assertEquals(WAITING_COSTS, result.get(5).getKey());
-      Assertions.assertEquals(
-          "/submissions/%s/claims/%s/waiting-costs", result.get(5).getChangeUrl());
+      Assertions.assertEquals(WAITING_COSTS, result.get(5).key());
+      Assertions.assertEquals("/submissions/%s/claims/%s/waiting-costs", result.get(5).changeUrl());
     }
   }
 


### PR DESCRIPTION
- Converted ClaimFieldRow from a Lombok POJO (`@Getter, @AllArgsConstructor, @EqualsAndHashCode`) to a Java record                                                                                                                                  
- Updated test accessor calls to use record accessors (key() etc ) instead of Lombok generated getters.
- Add Spring Framework 7.0.7 resolution override to fix `SNYK-JAVA-ORGSPRINGFRAMEWORK-16109603, SNYK-JAVA-ORGSPRINGFRAMEWORK-16109604`


