### PR TITLE
fix: upgrade Spring Security to 7.0.5 for Access Control Bypass and User Impersonation CVEs.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,10 @@ configurations.configureEach {
             details.useVersion '7.0.7'
             details.because 'Fixes HTTP Request Smuggling (SNYK-JAVA-ORGSPRINGFRAMEWORK-16109603, SNYK-JAVA-ORGSPRINGFRAMEWORK-16109604)'
         }
+        if (details.requested.group == 'org.springframework.security' && details.requested.name.startsWith('spring-security-')) {
+            details.useVersion '7.0.5'
+            details.because 'Fixes Access Control Bypass (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-16120588, 16121326) and User Impersonation (SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-16121020)'
+        }
     }
 }
 


### PR DESCRIPTION
- Add Spring Security 7.0.5 resolution override to fix pipeline Snyk failures.
