### PR TITLE
Added config to attach to remote JVM. Also work to standardize locally running ports.

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -4,7 +4,7 @@ AZURE_CLIENT_SECRET=
 AZURE_TENANT_ID=
 
 # Localhost
-BASE_URL_HOMEPAGE=http://localhost:8080
+BASE_URL_HOMEPAGE=http://localhost:8090
 FEEDBACK_URL=https://www.smartsurvey.co.uk/s/AaBC_Beta_DevTest
 LAA_URL=https://dev.your-legal-aid-services.service.justice.gov.uk
 
@@ -32,7 +32,7 @@ IS_BULK_UPLOAD_ENABLED=true
 IS_CLAIM_HISTORY_ENABLED=true
 
 # E2E tests
-UI_BASE_URL=http://localhost:8080
+UI_BASE_URL=http://localhost:8090
 P_USERNAME=
 P_PASSWORD=
 P_MFA_SECRET=

--- a/.helm/laa-amend-a-claim/templates/NOTES.txt
+++ b/.helm/laa-amend-a-claim/templates/NOTES.txt
@@ -17,6 +17,6 @@
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "laa-amend-a-claim.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
-  echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+  echo "Visit http://127.0.0.1:8090 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8090:$CONTAINER_PORT
 {{- end }}

--- a/Dockerfile_internal
+++ b/Dockerfile_internal
@@ -32,7 +32,7 @@ RUN addgroup -S appgroup && adduser -u 1001 -S appuser -G appgroup
 USER 1001
 
 # Expose the port that the application will run on
-EXPOSE 8080
+EXPOSE 8090
 
 # Run the JAR file
 CMD ["java", "-jar", "application.jar"]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ We use Snyk to help identify security vulnerabilities in our code and dependenci
    2. `./run.sh dev` to run the service with:
       1. An integration with the claims API in UAT
       2. A security configuration that enforces Entra login with CSRF enabled (note you will need a test developer account to log in through Entra)
-2. Navigate to the landing page at [http://localhost:8080/](http://localhost:8080/)
+2. Navigate to the landing page at [http://localhost:8090/](http://localhost:8090/)
 
 ### Build application
 `./gradlew clean build`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,9 @@ services:
         - github_actor
         - github_token
     ports:
-      - "8090:8080"
+      - "8090:8090"
+      - "8190:8190"
+      - "5090:5005"
     environment:
       AZURE_CLIENT_ID: ${AMEND_SILAS_CLIENT_ID}
       AZURE_CLIENT_SECRET: ${AMEND_SILAS_CLIENT_SECRET}
@@ -31,6 +33,7 @@ services:
       SPRING_PROFILES_ACTIVE: docker
       IS_BULK_UPLOAD_ENABLED: true
       IS_STAGE_DISBURSEMENT_ENABLED: true
+      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
   amend-redis:
     image: redis:8-alpine
     container_name: amend-redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
     container_name: amend-redis
     restart: always
     ports:
-      - "6380:6379" #Updated to 6380 to avoid conflict with SaBC Redis instance
+      - "6390:6379" #Updated to 6390 to avoid conflict with SaBC Redis instance
     command: redis-server --appendonly yes
     volumes:
       - amend_redis_data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       secrets:
         - github_actor
         - github_token
+    # Information on why these ports here: https://github.com/ministryofjustice/laa-data-claims-parent#exposed-ports
     ports:
       - "8090:8090"
       - "8190:8190"

--- a/src/e2e/README.md
+++ b/src/e2e/README.md
@@ -23,7 +23,7 @@ It uses Playwright (Java), JUnit 5 and Allure. The E2E project is isolated under
 
 Example .env contents:
 
-* UI_BASE_URL=http://localhost:8080
+* UI_BASE_URL=http://localhost:8090
 * P_USERNAME=<your test@devl.justice.gov.uk email>
 * P_PASSWORD=<your test@devl.justice.gov.uk password>
 * MFA_SECRET=<see below instructions>

--- a/src/e2e/main/java/uk/gov/justice/laa/amend/claim/config/EnvConfig.java
+++ b/src/e2e/main/java/uk/gov/justice/laa/amend/claim/config/EnvConfig.java
@@ -10,7 +10,7 @@ public class EnvConfig {
   }
 
   public static String baseUrl() {
-    return getOrDefault("UI_BASE_URL", "http://localhost:8080/");
+    return getOrDefault("UI_BASE_URL", "http://localhost:8090/");
   }
 
   public static String username() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,6 +107,12 @@ spring:
     activate:
       on-profile: local | e2e | docker
 
+server:
+  port: 8090
+management:
+  server:
+    port: 8190
+
 logging:
   structured:
     format:


### PR DESCRIPTION
## What is this PR?
Added flag to docker-compose.yml to able able to debug the application through intelliJ whilst it's running in a Docker container. Also standardizing ports across applications, so amend will use 8090 going forward meaning E2E tests are updated to go along side this.

Info regarding port convention can be found here:
https://github.com/ministryofjustice/laa-data-claims-parent#exposed-ports 

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

