### PR TITLE
BC-583: redirect to clean URL on invalid sort param to recover legacy bookmarks.

### DIFF
--- a/src/integrationTest/java/uk/gov/justice/laa/amend/claim/controllers/HomePageControllerIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/justice/laa/amend/claim/controllers/HomePageControllerIntegrationTest.java
@@ -112,6 +112,14 @@ class HomePageControllerIntegrationTest extends ControllerIntegrationTest {
   }
 
   @Test
+  void testGetWithLegacyCamelCaseSortRedirectsToCleanUrl() throws Exception {
+    mockMvc
+        .perform(get("/").param("officeCode", "0P322F").param("sort", "uniqueFileNumber,asc"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/?officeCode=0P322F&page=1"));
+  }
+
+  @Test
   void testSearchWithValidSubmissionDate() throws Exception {
     mockMvc
         .perform(

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/HomePageController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/HomePageController.java
@@ -9,15 +9,19 @@ import jakarta.validation.Valid;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
 import org.springframework.validation.Validator;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.amend.claim.client.config.SearchProperties;
 import uk.gov.justice.laa.amend.claim.forms.SearchForm;
 import uk.gov.justice.laa.amend.claim.mappers.ClaimMapper;
@@ -115,5 +119,15 @@ public class HomePageController {
     SearchQuery query = new SearchQuery(form, sort);
     String redirectUrl = query.getRedirectUrl();
     return "redirect:" + redirectUrl;
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public String handleSearchQueryBindingError(MethodArgumentNotValidException ex) {
+    if (ex.getBindingResult().getTarget() instanceof SearchQuery query
+        && ex.getBindingResult().getFieldErrors().stream()
+            .anyMatch(fe -> "sort".equals(fe.getField()))) {
+      return "redirect:" + query.getRedirectUrl(null);
+    }
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid request parameters");
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/HomePageControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/HomePageControllerTest.java
@@ -127,19 +127,35 @@ public class HomePageControllerTest extends BaseControllerTest {
   }
 
   @Test
-  public void testOnPageLoadWithInvalidSortFieldReturnsBadRequest() throws Exception {
+  public void testOnPageLoadWithInvalidSortFieldRedirectsToCleanUrl() throws Exception {
     when(searchProperties.isSortEnabled()).thenReturn(true);
 
-    mockMvc.perform(get("/?officeCode=123&page=1&sort=foo,asc")).andExpect(status().isBadRequest());
+    mockMvc
+        .perform(get("/?officeCode=123&page=1&sort=foo,asc"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/?officeCode=123&page=1"));
   }
 
   @Test
-  public void testOnPageLoadWithInvalidSortDirectionReturnsBadRequest() throws Exception {
+  public void testOnPageLoadWithInvalidSortDirectionRedirectsToCleanUrl() throws Exception {
     when(searchProperties.isSortEnabled()).thenReturn(true);
 
     mockMvc
         .perform(get("/?officeCode=123&page=1&sort=unique_file_number,foo"))
-        .andExpect(status().isBadRequest());
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/?officeCode=123&page=1"));
+  }
+
+  @Test
+  public void testOnPageLoadWithLegacyCamelCaseSortRedirectsPreservingOtherParams()
+      throws Exception {
+    when(searchProperties.isSortEnabled()).thenReturn(true);
+
+    mockMvc
+        .perform(
+            get("/?officeCode=123456&uniqueFileNumber=123456/789&page=1&sort=uniqueFileNumber,asc"))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl("/?officeCode=123456&uniqueFileNumber=123456/789&page=1"));
   }
 
   @Test


### PR DESCRIPTION

[BC-583](https://dsdmoj.atlassian.net/browse/BC-583)
## Summary
Users hitting `/` with a legacy `sort=uniqueFileNumber,asc` etc query string were shown the generic 500 error.
Changes made to handle - when the page receives an unrecognised sort value, the user is silently redirected to a clean URL with search criteria preserved and the default sort applied.
 


[BC-583]: https://dsdmoj.atlassian.net/browse/BC-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ