### PR TITLE
remove is-stage-disbursement-enabled feature flag.

### DIFF
--- a/.helm/laa-amend-a-claim/values.yaml
+++ b/.helm/laa-amend-a-claim/values.yaml
@@ -181,11 +181,6 @@ env:
       configMapKeyRef:
         name: feature-flags
         key: is-bulk-upload-enabled
-  - name: IS_STAGE_DISBURSEMENT_ENABLED
-    valueFrom:
-      configMapKeyRef:
-        name: feature-flags
-        key: is-stage-disbursement-enabled
   - name: IS_CLAIM_HISTORY_ENABLED
     valueFrom:
       configMapKeyRef:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
       PROVIDER_TOKEN: ${PROVIDER_DETAILS_API_ACCESS_TOKEN}
       SPRING_PROFILES_ACTIVE: docker
       IS_BULK_UPLOAD_ENABLED: true
-      IS_STAGE_DISBURSEMENT_ENABLED: true
       JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
   amend-redis:
     image: redis:8-alpine

--- a/src/main/java/uk/gov/justice/laa/amend/claim/config/FeatureFlagsConfig.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/config/FeatureFlagsConfig.java
@@ -10,6 +10,5 @@ import org.springframework.context.annotation.Configuration;
 public class FeatureFlagsConfig {
   private Boolean isBulkUploadEnabled;
   private Boolean isClaimHistoryEnabled;
-  private Boolean isStageDisbursementEnabled;
   private Boolean isRequestedAndCalculatedSwapEnabled;
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimDetailsBaseController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/ClaimDetailsBaseController.java
@@ -29,9 +29,7 @@ public abstract class ClaimDetailsBaseController {
     model.addAttribute("claim", claim.toViewModel());
 
     boolean isEscapedCase = claim.isEscapedCase();
-    boolean isStageDisbursement =
-        claim.isStageDisbursement()
-            && TRUE.equals(featureFlagsConfig.getIsStageDisbursementEnabled());
+    boolean isStageDisbursement = claim.isStageDisbursement();
     boolean isAssessmentButtonPresent =
         request.isUserInRole(ROLE_ESCAPE_CASE_CASEWORKER.name())
             && claim.isValid()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,7 +64,6 @@ app:
 feature-flags:
   is-bulk-upload-enabled: ${IS_BULK_UPLOAD_ENABLED:false}
   is-claim-history-enabled: ${IS_CLAIM_HISTORY_ENABLED:false}
-  is-stage-disbursement-enabled: ${IS_STAGE_DISBURSEMENT_ENABLED:false}
   is-requested-and-calculated-swap-enabled: ${IS_REQUESTED_AND_CALCULATED_SWAP_ENABLED:false}
 
 management:

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/ClaimSummaryControllerTest.java
@@ -216,9 +216,8 @@ public class ClaimSummaryControllerTest extends BaseControllerTest {
   }
 
   @Test
-  void testIsAssessmentButtonPresentTrueForStageDisbursementClaimWhenEnabled() throws Exception {
+  void testIsAssessmentButtonPresentTrueForStageDisbursementClaim() throws Exception {
     dummyUserSecurityService.setRoles(Set.of(ROLE_ESCAPE_CASE_CASEWORKER));
-    when(featureFlagsConfig.getIsStageDisbursementEnabled()).thenReturn(true);
 
     CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
     claim.setEscaped(false);
@@ -230,23 +229,6 @@ public class ClaimSummaryControllerTest extends BaseControllerTest {
         .perform(get(buildPath()).session(session))
         .andExpect(status().isOk())
         .andExpect(model().attribute("isAssessmentButtonPresent", true));
-  }
-
-  @Test
-  void testIsAssessmentButtonPresentFalseForStageDisbursementClaimWhenDisabled() throws Exception {
-    dummyUserSecurityService.setRoles(Set.of(ROLE_ESCAPE_CASE_CASEWORKER));
-    when(featureFlagsConfig.getIsStageDisbursementEnabled()).thenReturn(false);
-
-    CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
-    claim.setEscaped(false);
-    claim.setFeeCode("ILHSD");
-    claim.setHasAssessment(false);
-    when(claimService.getClaimDetails(any(), any())).thenReturn(claim);
-
-    mockMvc
-        .perform(get(buildPath()).session(session))
-        .andExpect(status().isOk())
-        .andExpect(model().attribute("isAssessmentButtonPresent", false));
   }
 
   @Test


### PR DESCRIPTION
## Summary
Removes the `is-stage-disbursement-enabled` feature flag. 
Stage disbursement assessment is live in production and permanently on - the flag is no longer a toggle.         

