### PR TITLE
chore: bump netty to 4.2.13.Final to fix HTTP Request Smuggling.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ repositories {
     mavenCentral()
 }
 
+// Upgrade to fix HTTP Request Smuggling (SNYK-JAVA-IONETTY-16425695)
+ext['netty.version'] = '4.2.13.Final'
+
 configurations.configureEach {
     resolutionStrategy.eachDependency { DependencyResolveDetails details ->
         if (details.requested.group == 'org.codehaus.plexus' && details.requested.name == 'plexus-utils') {


### PR DESCRIPTION
## Summary
Fixes Snyk-flagged HTTP Request Smuggling vulnerability.
Adds a Gradle resolution-strategy clause forcing any `io.netty:*:4.2.12.Final` to `4.2.13.Final`

