### PR TITLE
Deduplicate claims when fetching from the data claims API

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
@@ -1,11 +1,11 @@
 package uk.gov.justice.laa.amend.claim.bulkupload;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -28,6 +28,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 public class BulkUploadHelper {
   public static final int MAX_ROWS = 10000;
   public static final int PAGE_SIZE = 200;
+  private static final int MAX_FETCH_ATTEMPTS = 3;
 
   private final ClaimService claimService;
 
@@ -44,12 +45,9 @@ public class BulkUploadHelper {
 
   private List<ClaimResponseV2> getAllClaims(
       String officeCode, Map<Pair<String, String>, BulkUploadCivilClaim> officeCodeUfnRows) {
-    //  Deduplicate claims by ID, as the API may return the same claim on multiple pages
-    Map<UUID, ClaimResponseV2> claimsById = new LinkedHashMap<>();
-    fetchValidClaims(officeCode)
+    return fetchAllValidClaims(officeCode).values().stream()
         .filter(ufnExistsInRowsPredicate(officeCodeUfnRows))
-        .forEach(claim -> claimsById.putIfAbsent(UUID.fromString(claim.getId()), claim));
-    return new ArrayList<>(claimsById.values());
+        .collect(Collectors.toList());
   }
 
   /** Map officeCode with UFN and row index from given rows of csv. */
@@ -67,7 +65,6 @@ public class BulkUploadHelper {
               String ufn = row.getUfn();
 
               Pair<String, String> key = Pair.of(office, ufn);
-              // Duplicate Rows (officeCode + UFN)
               if (!appearedKeys.add(key)) {
                 errors.add(
                     new BulkUploadError(
@@ -91,24 +88,60 @@ public class BulkUploadHelper {
     };
   }
 
-  private Stream<ClaimResponseV2> fetchValidClaims(String officeCode) {
+  /**
+   * Fetches all distinct valid escaped claims for an office, keyed by claim ID.
+   *
+   * <p>The Claims API does not guarantee a stable, unique sort order across pages. As a result, a
+   * single paginated sweep may return the same claim more than once or omit claims entirely.
+   *
+   * <p>Duplicate claims are removed by keying on claim ID. Missing claims are detected by comparing
+   * the number of distinct claims collected with the total count reported by the API. If the counts
+   * do not match, the sweep is retried, allowing a different page ordering to contribute additional
+   * claims to the result set.
+   *
+   * <p>If the reported total still cannot be reconciled after retrying, the upload is failed rather
+   * than risking silent data loss.
+   */
+  private Map<UUID, ClaimResponseV2> fetchAllValidClaims(String officeCode) {
+    Map<UUID, ClaimResponseV2> claimsById = new LinkedHashMap<>();
+    int totalElements = collectDistinctClaimsInto(officeCode, claimsById);
 
-    var firstPage = safeFetch(officeCode, 1, PAGE_SIZE);
-    int totalPages = Optional.of(firstPage.totalPages()).orElse(1);
+    int attempts = 1;
+    while (claimsById.size() < totalElements && attempts < MAX_FETCH_ATTEMPTS) {
+      totalElements = collectDistinctClaimsInto(officeCode, claimsById);
+      attempts++;
+    }
 
-    // Stream first page
-    Stream<ClaimResponseV2> pageOne = firstPage.claimResponseV2Stream();
-
-    // Stream remaining pages
-    Stream<ClaimResponseV2> others =
-        IntStream.rangeClosed(2, totalPages)
-            .mapToObj(p -> safeFetch(officeCode, p, PAGE_SIZE))
-            .flatMap(PageResult::claimResponseV2Stream);
-
-    return Stream.concat(pageOne, others);
+    if (claimsById.size() < totalElements) {
+      throw new RuntimeException(
+          String.format(
+              "Could not retrieve all valid claims for office code %s: expected %d but only "
+                  + "resolved %d distinct claims after %d attempts",
+              officeCode, totalElements, claimsById.size(), attempts));
+    }
+    return claimsById;
   }
 
-  private PageResult safeFetch(String officeCode, int page, int pageSize) {
+  private int collectDistinctClaimsInto(String officeCode, Map<UUID, ClaimResponseV2> claimsById) {
+    var firstPage = safeFetch(officeCode, 1);
+    addDistinct(firstPage, claimsById);
+
+    int totalPages = firstPage.totalPages();
+    for (int page = 2; page <= totalPages; page++) {
+      addDistinct(safeFetch(officeCode, page), claimsById);
+    }
+    return firstPage.totalElements();
+  }
+
+  private void addDistinct(PageResult page, Map<UUID, ClaimResponseV2> claimsById) {
+    page.claimResponseV2Stream()
+        .forEach(
+            claim ->
+                claimsById.putIfAbsent(
+                    UUID.fromString(Objects.requireNonNull(claim.getId())), claim));
+  }
+
+  private PageResult safeFetch(String officeCode, int page) {
     try {
       var result =
           claimService.searchClaims(
@@ -120,22 +153,24 @@ public class BulkUploadHelper {
               Optional.of(true),
               List.of(ClaimStatus.VALID),
               page,
-              pageSize,
+              BulkUploadHelper.PAGE_SIZE,
               null);
       if (result == null || result.getContent() == null) {
         throw new RuntimeException("No claims found for office code " + officeCode);
       }
       int totalPages = Optional.ofNullable(result.getTotalPages()).orElse(1);
+      int totalElements = Optional.ofNullable(result.getTotalElements()).orElse(0);
 
       Stream<ClaimResponseV2> responseStream =
           (result.getContent().isEmpty()) ? Stream.empty() : result.getContent().stream();
 
-      return new PageResult(responseStream, totalPages);
+      return new PageResult(responseStream, totalPages, totalElements);
     } catch (Exception e) {
       throw new RuntimeException(
           "Error fetching claims for office code " + officeCode + " page " + page, e);
     }
   }
 
-  private record PageResult(Stream<ClaimResponseV2> claimResponseV2Stream, int totalPages) {}
+  private record PageResult(
+      Stream<ClaimResponseV2> claimResponseV2Stream, int totalPages, int totalElements) {}
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
@@ -3,10 +3,12 @@ package uk.gov.justice.laa.amend.claim.bulkupload;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -42,11 +44,12 @@ public class BulkUploadHelper {
 
   private List<ClaimResponseV2> getAllClaims(
       String officeCode, Map<Pair<String, String>, BulkUploadCivilClaim> officeCodeUfnRows) {
-    List<ClaimResponseV2> claims = new ArrayList<>();
+    //  Deduplicate claims by ID, as the API may return the same claim on multiple pages
+    Map<UUID, ClaimResponseV2> claimsById = new LinkedHashMap<>();
     fetchValidClaims(officeCode)
         .filter(ufnExistsInRowsPredicate(officeCodeUfnRows))
-        .forEach(claims::add);
-    return claims;
+        .forEach(claim -> claimsById.putIfAbsent(UUID.fromString(claim.getId()), claim));
+    return new ArrayList<>(claimsById.values());
   }
 
   /** Map officeCode with UFN and row index from given rows of csv. */

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
@@ -95,29 +95,28 @@ public class BulkUploadHelper {
    * single paginated sweep may return the same claim more than once or omit claims entirely.
    *
    * <p>Duplicate claims are removed by keying on claim ID. Missing claims are detected by comparing
-   * the number of distinct claims collected with the total count reported by the API. If the counts
-   * do not match, the sweep is retried, allowing a different page ordering to contribute additional
-   * claims to the result set.
+   * the number of distinct claims collected with the total element count reported by the initial
+   * call.
    *
    * <p>If the reported total still cannot be reconciled after retrying, the upload is failed rather
    * than risking silent data loss.
    */
   private Map<UUID, ClaimResponseV2> fetchAllValidClaims(String officeCode) {
     Map<UUID, ClaimResponseV2> claimsById = new LinkedHashMap<>();
-    int totalElements = collectDistinctClaimsInto(officeCode, claimsById);
+    int expectedTotal = collectDistinctClaimsInto(officeCode, claimsById);
 
     int attempts = 1;
-    while (claimsById.size() < totalElements && attempts < MAX_FETCH_ATTEMPTS) {
-      totalElements = collectDistinctClaimsInto(officeCode, claimsById);
+    while (claimsById.size() < expectedTotal && attempts < MAX_FETCH_ATTEMPTS) {
+      collectDistinctClaimsInto(officeCode, claimsById);
       attempts++;
     }
 
-    if (claimsById.size() < totalElements) {
+    if (claimsById.size() < expectedTotal) {
       throw new RuntimeException(
           String.format(
               "Could not retrieve all valid claims for office code %s: expected %d but only "
                   + "resolved %d distinct claims after %d attempts",
-              officeCode, totalElements, claimsById.size(), attempts));
+              officeCode, expectedTotal, claimsById.size(), attempts));
     }
     return claimsById;
   }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilService.java
@@ -46,7 +46,20 @@ public class BulkUploadCivilService extends BulkUploadService<BulkUploadCivilCla
     List<BulkUploadError> errors = new ArrayList<>();
     List<ClaimDetails> claimsData = new ArrayList<>();
 
-    var apiClaimResponseObjects = bulkUploadHelper.getAllClaims(rows, errors);
+    List<ClaimResponseV2> apiClaimResponseObjects;
+    try {
+      apiClaimResponseObjects = bulkUploadHelper.getAllClaims(rows, errors);
+    } catch (Exception ex) {
+      log.error("Failed to retrieve claims required to validate the bulk upload", ex);
+      errors.add(
+          new BulkUploadError(
+              null,
+              "Unable to retrieve all claims required to validate the upload. "
+                  + "This may be a temporary problem, please try again."));
+      return new BulkUploadValidationOutcome(
+          BulkUploadResult.failure(VALIDATION_FAILURE, sortedByRowNumber(errors)), List.of());
+    }
+
     var claimsByOfficeCodeAndUfn =
         apiClaimResponseObjects.stream()
             .collect(

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
@@ -10,7 +10,6 @@ import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus.VAL
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -56,95 +55,40 @@ class BulkUploadHelperTest {
   void getAllClaimsShouldMatchClaimsAndReturnClaims() {
     var officeCode = "123456";
     var ufn = "20220101/020244";
-    // Mock claim returned from paging API
-    ClaimResponseV2 claim = new ClaimResponseV2();
-    claim.setId("11111111-1111-1111-1111-111111111111");
-    claim.setOfficeCode(officeCode);
-    claim.setUniqueFileNumber(ufn);
-    claim.setStatus(VALID);
-
-    when(claimService.searchClaims(
-            officeCode,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(AreaOfLaw.LEGAL_HELP),
-            Optional.of(true),
-            List.of(VALID),
-            1,
-            200,
-            null))
-        .thenReturn(claimList(claim));
-
-    // After page 1, return empty content (stop)
-    when(claimService.searchClaims(
-            officeCode,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(AreaOfLaw.LEGAL_HELP),
-            Optional.of(true),
-            List.of(VALID),
-            2,
-            200,
-            null))
-        .thenReturn(emptyList());
+    var claimId = "11111111-1111-1111-1111-111111111111";
+    whenSearchPage(officeCode, 1).thenReturn(claimList(claim(claimId, officeCode, ufn)));
 
     List<BulkUploadError> errors = new ArrayList<>();
-    BulkUploadCivilClaim row = row(officeCode, ufn, 1);
-    List<BulkUploadCivilClaim> rows = List.of(row);
-    var response = helper.getAllClaims(rows, errors);
+    var response = helper.getAllClaims(List.of(row(officeCode, ufn, 1)), errors);
 
-    assertEquals(List.of(claim), response);
+    assertEquals(1, response.size());
+    assertEquals(claimId, response.getFirst().getId());
     assertTrue(errors.isEmpty());
   }
 
   @Test
   void getAllClaimsShouldDeduplicateSameClaimReturnedAcrossPages() {
-    // Simulate the API returning the same claim on multiple pages due to unstable pagination.
-    // The claim should be deduplicated and not treated as a duplicate submission.
+    // Unstable pagination returns the same claim (same ID) on two pages as distinct instances.
+    // It must be deduplicated by claim ID, not treated as a duplicate submission.
     var officeCode = "123456";
     var ufn = "20220101/020244";
-    ClaimResponseV2 claim = new ClaimResponseV2();
-    claim.setId("22222222-2222-2222-2222-222222222222");
-    claim.setOfficeCode(officeCode);
-    claim.setUniqueFileNumber(ufn);
-    claim.setStatus(VALID);
+    var sharedId = "22222222-2222-2222-2222-222222222222";
+    ClaimResponseV2 pageOneClaim = claim(sharedId, officeCode, ufn);
+    ClaimResponseV2 pageTwoClaim = claim(sharedId, officeCode, ufn);
 
-    ClaimResultSetV2 pageOne = claimList(claim);
+    ClaimResultSetV2 pageOne = claimList(pageOneClaim);
     pageOne.setTotalPages(2);
-    when(claimService.searchClaims(
-            officeCode,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(AreaOfLaw.LEGAL_HELP),
-            Optional.of(true),
-            List.of(VALID),
-            1,
-            200,
-            null))
-        .thenReturn(pageOne);
+    whenSearchPage(officeCode, 1).thenReturn(pageOne);
 
-    ClaimResultSetV2 pageTwo = claimList(claim);
+    ClaimResultSetV2 pageTwo = claimList(pageTwoClaim);
     pageTwo.setTotalPages(2);
-    when(claimService.searchClaims(
-            officeCode,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(AreaOfLaw.LEGAL_HELP),
-            Optional.of(true),
-            List.of(VALID),
-            2,
-            200,
-            null))
-        .thenReturn(pageTwo);
+    whenSearchPage(officeCode, 2).thenReturn(pageTwo);
 
     List<BulkUploadError> errors = new ArrayList<>();
     var response = helper.getAllClaims(List.of(row(officeCode, ufn, 1)), errors);
 
-    assertEquals(List.of(claim), response);
+    assertEquals(1, response.size());
+    assertEquals(sharedId, response.getFirst().getId());
     assertTrue(errors.isEmpty());
   }
 
@@ -154,48 +98,19 @@ class BulkUploadHelperTest {
     // retained so downstream duplicate detection can still flag them.
     var officeCode = "123456";
     var ufn = "20220101/020244";
-    ClaimResponseV2 claimOne = new ClaimResponseV2();
-    claimOne.setId("11111111-1111-1111-1111-111111111111");
-    claimOne.setOfficeCode(officeCode);
-    claimOne.setUniqueFileNumber(ufn);
-    claimOne.setStatus(VALID);
+    var claimOneId = "11111111-1111-1111-1111-111111111111";
+    var claimTwoId = "22222222-2222-2222-2222-222222222222";
+    ClaimResponseV2 claimOne = claim(claimOneId, officeCode, ufn);
+    ClaimResponseV2 claimTwo = claim(claimTwoId, officeCode, ufn);
 
-    ClaimResponseV2 claimTwo = new ClaimResponseV2();
-    claimTwo.setId("22222222-2222-2222-2222-222222222222");
-    claimTwo.setOfficeCode(officeCode);
-    claimTwo.setUniqueFileNumber(ufn);
-    claimTwo.setStatus(VALID);
-
-    when(claimService.searchClaims(
-            officeCode,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(AreaOfLaw.LEGAL_HELP),
-            Optional.of(true),
-            List.of(VALID),
-            1,
-            200,
-            null))
-        .thenReturn(claimList(claimOne, claimTwo));
-
-    when(claimService.searchClaims(
-            officeCode,
-            Optional.empty(),
-            Optional.empty(),
-            Optional.empty(),
-            Optional.of(AreaOfLaw.LEGAL_HELP),
-            Optional.of(true),
-            List.of(VALID),
-            2,
-            200,
-            null))
-        .thenReturn(emptyList());
+    whenSearchPage(officeCode, 1).thenReturn(claimList(claimOne, claimTwo));
 
     List<BulkUploadError> errors = new ArrayList<>();
     var response = helper.getAllClaims(List.of(row(officeCode, ufn, 1)), errors);
 
-    assertEquals(List.of(claimOne, claimTwo), response);
+    assertEquals(2, response.size());
+    assertEquals(
+        List.of(claimOneId, claimTwoId), response.stream().map(ClaimResponseV2::getId).toList());
     assertTrue(errors.isEmpty());
   }
 
@@ -258,14 +173,6 @@ class BulkUploadHelperTest {
     result.setContent(Arrays.asList(claims));
     result.setTotalPages(1);
     result.setTotalElements(claims.length);
-    return result;
-  }
-
-  private ClaimResultSetV2 emptyList() {
-    ClaimResultSetV2 result = new ClaimResultSetV2();
-    result.setContent(Collections.emptyList());
-    result.setTotalPages(1);
-    result.setTotalElements(0);
     return result;
   }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
@@ -57,6 +57,7 @@ class BulkUploadHelperTest {
     var ufn = "20220101/020244";
     // Mock claim returned from paging API
     ClaimResponseV2 claim = new ClaimResponseV2();
+    claim.setId("11111111-1111-1111-1111-111111111111");
     claim.setOfficeCode(officeCode);
     claim.setUniqueFileNumber(ufn);
     claim.setStatus(VALID);
@@ -94,6 +95,106 @@ class BulkUploadHelperTest {
     var response = helper.getAllClaims(rows, errors);
 
     assertEquals(List.of(claim), response);
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void getAllClaimsShouldDeduplicateSameClaimReturnedAcrossPages() {
+    // Simulate the API returning the same claim on multiple pages due to unstable pagination.
+    // The claim should be deduplicated and not treated as a duplicate submission.
+    var officeCode = "123456";
+    var ufn = "20220101/020244";
+    ClaimResponseV2 claim = new ClaimResponseV2();
+    claim.setId("22222222-2222-2222-2222-222222222222");
+    claim.setOfficeCode(officeCode);
+    claim.setUniqueFileNumber(ufn);
+    claim.setStatus(VALID);
+
+    ClaimResultSetV2 pageOne = claimList(claim);
+    pageOne.setTotalPages(2);
+    when(claimService.searchClaims(
+            officeCode,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(AreaOfLaw.LEGAL_HELP),
+            Optional.of(true),
+            List.of(VALID),
+            1,
+            200,
+            null))
+        .thenReturn(pageOne);
+
+    ClaimResultSetV2 pageTwo = claimList(claim);
+    pageTwo.setTotalPages(2);
+    when(claimService.searchClaims(
+            officeCode,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(AreaOfLaw.LEGAL_HELP),
+            Optional.of(true),
+            List.of(VALID),
+            2,
+            200,
+            null))
+        .thenReturn(pageTwo);
+
+    List<BulkUploadError> errors = new ArrayList<>();
+    var response = helper.getAllClaims(List.of(row(officeCode, ufn, 1)), errors);
+
+    assertEquals(List.of(claim), response);
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void getAllClaimsShouldRetainDistinctClaimsWithSameOfficeAndUfn() {
+    // Two distinct claims sharing an office code and UFN must both be
+    // retained so downstream duplicate detection can still flag them.
+    var officeCode = "123456";
+    var ufn = "20220101/020244";
+    ClaimResponseV2 claimOne = new ClaimResponseV2();
+    claimOne.setId("11111111-1111-1111-1111-111111111111");
+    claimOne.setOfficeCode(officeCode);
+    claimOne.setUniqueFileNumber(ufn);
+    claimOne.setStatus(VALID);
+
+    ClaimResponseV2 claimTwo = new ClaimResponseV2();
+    claimTwo.setId("22222222-2222-2222-2222-222222222222");
+    claimTwo.setOfficeCode(officeCode);
+    claimTwo.setUniqueFileNumber(ufn);
+    claimTwo.setStatus(VALID);
+
+    when(claimService.searchClaims(
+            officeCode,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(AreaOfLaw.LEGAL_HELP),
+            Optional.of(true),
+            List.of(VALID),
+            1,
+            200,
+            null))
+        .thenReturn(claimList(claimOne, claimTwo));
+
+    when(claimService.searchClaims(
+            officeCode,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(AreaOfLaw.LEGAL_HELP),
+            Optional.of(true),
+            List.of(VALID),
+            2,
+            200,
+            null))
+        .thenReturn(emptyList());
+
+    List<BulkUploadError> errors = new ArrayList<>();
+    var response = helper.getAllClaims(List.of(row(officeCode, ufn, 1)), errors);
+
+    assertEquals(List.of(claimOne, claimTwo), response);
     assertTrue(errors.isEmpty());
   }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.bulkupload;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -198,6 +199,49 @@ class BulkUploadHelperTest {
     assertTrue(errors.isEmpty());
   }
 
+  @Test
+  void getAllClaimsShouldRetryUntilAllClaimsReportedByTotalElementsAreResolved() {
+    // The first sweep skips a claim (returns fewer than total_elements); a retry reconciles the
+    // full set, so no claim is missed.
+    var officeCode = "123456";
+    var ufn = "20220101/020244";
+    ClaimResponseV2 claimOne = claim("11111111-1111-1111-1111-111111111111", officeCode, ufn);
+    ClaimResponseV2 claimTwo = claim("22222222-2222-2222-2222-222222222222", officeCode, ufn);
+
+    ClaimResultSetV2 incompleteSweep = claimList(claimOne);
+    incompleteSweep.setTotalElements(2);
+    ClaimResultSetV2 completeSweep = claimList(claimOne, claimTwo);
+
+    whenSearchPage(officeCode, 1).thenReturn(incompleteSweep, completeSweep);
+
+    List<BulkUploadError> errors = new ArrayList<>();
+    var response = helper.getAllClaims(List.of(row(officeCode, ufn, 1)), errors);
+
+    assertEquals(2, response.size());
+    assertTrue(response.containsAll(List.of(claimOne, claimTwo)));
+    assertTrue(errors.isEmpty());
+  }
+
+  @Test
+  void getAllClaimsShouldFailWhenClaimsCannotBeReconciledWithTotalElements() {
+    // Every sweep returns fewer claims than total_elements reports, so completeness can never be
+    // confirmed. The upload must fail loudly rather than silently dropping a claim.
+    var officeCode = "123456";
+    var ufn = "20220101/020244";
+    ClaimResponseV2 claimOne = claim("11111111-1111-1111-1111-111111111111", officeCode, ufn);
+
+    ClaimResultSetV2 alwaysIncomplete = claimList(claimOne);
+    alwaysIncomplete.setTotalElements(2);
+    whenSearchPage(officeCode, 1).thenReturn(alwaysIncomplete);
+
+    List<BulkUploadCivilClaim> rows = List.of(row(officeCode, ufn, 1));
+    List<BulkUploadError> errors = new ArrayList<>();
+
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> helper.getAllClaims(rows, errors));
+    assertTrue(exception.getMessage().contains(officeCode));
+  }
+
   private BulkUploadCivilClaim row(String officeCode, String ufn, int rowNumber) {
     BulkUploadCivilClaim r = new BulkUploadCivilClaim();
     r.setOfficeCode(officeCode);
@@ -212,12 +256,41 @@ class BulkUploadHelperTest {
   private ClaimResultSetV2 claimList(ClaimResponseV2... claims) {
     ClaimResultSetV2 result = new ClaimResultSetV2();
     result.setContent(Arrays.asList(claims));
+    result.setTotalPages(1);
+    result.setTotalElements(claims.length);
     return result;
   }
 
   private ClaimResultSetV2 emptyList() {
     ClaimResultSetV2 result = new ClaimResultSetV2();
     result.setContent(Collections.emptyList());
+    result.setTotalPages(1);
+    result.setTotalElements(0);
     return result;
+  }
+
+  private ClaimResponseV2 claim(String id, String officeCode, String ufn) {
+    ClaimResponseV2 claim = new ClaimResponseV2();
+    claim.setId(id);
+    claim.setOfficeCode(officeCode);
+    claim.setUniqueFileNumber(ufn);
+    claim.setStatus(VALID);
+    return claim;
+  }
+
+  private org.mockito.stubbing.OngoingStubbing<ClaimResultSetV2> whenSearchPage(
+      String officeCode, int page) {
+    return when(
+        claimService.searchClaims(
+            officeCode,
+            Optional.empty(),
+            Optional.empty(),
+            Optional.empty(),
+            Optional.of(AreaOfLaw.LEGAL_HELP),
+            Optional.of(true),
+            List.of(VALID),
+            page,
+            200,
+            null));
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/BulkUploadCivilServiceTest.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.amend.claim.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -121,6 +122,21 @@ class BulkUploadCivilServiceTest {
 
     // --- verify mapper called correctly ---
     verify(claimMapper, times(1)).mapToCivilClaimDetails(apiResponse);
+  }
+
+  @Test
+  void validateRowsShouldFailValidationWhenClaimsCannotBeRetrieved() {
+    BulkUploadCivilClaim row = buildRow();
+    when(bulkUploadHelper.getAllClaims(anyList(), anyList()))
+        .thenThrow(new RuntimeException("could not reconcile claims for office"));
+
+    BulkUploadValidationOutcome outcome = service.validateRows(List.of(row));
+
+    assertEquals(VALIDATION_FAILURE, outcome.result().status());
+    assertTrue(outcome.claimDetailsList().isEmpty());
+    BulkUploadError error = outcome.result().errors().getFirst();
+    assertNull(error.rowNumber());
+    assertTrue(error.message().contains("Unable to retrieve all claims"));
   }
 
   @Test


### PR DESCRIPTION
## What is this PR?

- Deduplicate claims when fetching from the data claims API during the bulk upload process as claims are not guaranteed to only appear once whilst paginating across the set.

- Ensures all claims are fetched by asserting the total elements count match the length of the total claim set and retries if this is not the case.

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

