### PR TITLE
Add default sort and increase page size for bulk upload

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.amend.claim.bulkupload.civil.BulkUploadCivilClaim;
 import uk.gov.justice.laa.amend.claim.models.AreaOfLaw;
+import uk.gov.justice.laa.amend.claim.models.search.SearchSort;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponseV2;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
@@ -118,7 +119,7 @@ public class BulkUploadHelper {
               List.of(ClaimStatus.VALID),
               page,
               pageSize,
-              null);
+              SearchSort.defaults());
       if (result == null || result.getContent() == null) {
         throw new RuntimeException("No claims found for office code " + officeCode);
       }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelper.java
@@ -26,7 +26,7 @@ import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 @RequiredArgsConstructor
 public class BulkUploadHelper {
   public static final int MAX_ROWS = 10000;
-  public static final int PAGE_SIZE = 200;
+  public static final int PAGE_SIZE = 10000;
 
   private final ClaimService claimService;
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
@@ -71,7 +71,7 @@ class BulkUploadHelperTest {
             Optional.of(true),
             List.of(VALID),
             1,
-            200,
+            10000,
             SearchSort.defaults()))
         .thenReturn(claimList(claim));
 
@@ -85,7 +85,7 @@ class BulkUploadHelperTest {
             Optional.of(true),
             List.of(VALID),
             2,
-            200,
+            10000,
             SearchSort.defaults()))
         .thenReturn(emptyList());
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/bulkupload/BulkUploadHelperTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.gov.justice.laa.amend.claim.bulkupload.civil.BulkUploadCivilClaim;
 import uk.gov.justice.laa.amend.claim.models.AreaOfLaw;
+import uk.gov.justice.laa.amend.claim.models.search.SearchSort;
 import uk.gov.justice.laa.amend.claim.service.ClaimService;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResponseV2;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimResultSetV2;
@@ -71,7 +72,7 @@ class BulkUploadHelperTest {
             List.of(VALID),
             1,
             200,
-            null))
+            SearchSort.defaults()))
         .thenReturn(claimList(claim));
 
     // After page 1, return empty content (stop)
@@ -85,7 +86,7 @@ class BulkUploadHelperTest {
             List.of(VALID),
             2,
             200,
-            null))
+            SearchSort.defaults()))
         .thenReturn(emptyList());
 
     List<BulkUploadError> errors = new ArrayList<>();


### PR DESCRIPTION
## What is this PR?

- Add default UFN sort when fetching claims for the duplicate check of the bulk upload process.
- Increase page size to 10,000 to reduce errors from unstable pagination.

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

