### PR TITLE
BC-689: Add Yes/No dropdowns for indicator amendment fields

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/converters/StringToBooleanConverter.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/converters/StringToBooleanConverter.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.converters;
 
+import java.util.Locale;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -12,5 +13,16 @@ public class StringToBooleanConverter implements Converter<String, Boolean> {
       return null;
     }
     return "yes".equalsIgnoreCase(source) || Boolean.parseBoolean(source);
+  }
+
+  public static Boolean convertStrict(String source) {
+    if (source == null || source.isBlank()) {
+      return null;
+    }
+    return switch (source.trim().toLowerCase(Locale.ROOT)) {
+      case "true", "yes" -> true;
+      case "false", "no" -> false;
+      default -> throw new IllegalArgumentException("Invalid boolean value: " + source);
+    };
   }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
@@ -45,6 +45,8 @@ public class AmendmentForm {
       var field = entry.getKey();
       if (field.getType() == FieldType.DATE) {
         putDateInputs(inputs, field.name(), entry.getValue());
+      } else if (field.getType() == FieldType.BOOLEAN) {
+        inputs.put(field.name(), formatBooleanValue(field.name(), entry.getValue()));
       } else {
         inputs.put(field.name(), formatValue(entry.getValue()));
       }
@@ -121,6 +123,28 @@ public class AmendmentForm {
     return isDateField(fieldName) ? getDateValue(fieldName) : inputs.get(fieldName);
   }
 
+  public Object getAmendedValue(ClaimViewField<?> field) {
+    return switch (field.getType()) {
+      case DATE -> getDateValue(field.name());
+      case BOOLEAN -> getBooleanValue(field.name());
+      case TEXT -> inputs.get(field.name());
+    };
+  }
+
+  public Boolean getBooleanValue(String fieldName) {
+    var value = inputs.get(fieldName);
+    if (isBlank(value)) {
+      return null;
+    }
+    return switch (value.trim().toLowerCase()) {
+      case "true" -> true;
+      case "false" -> false;
+      default ->
+          throw new IllegalArgumentException(
+              "Invalid boolean value for field '%s'".formatted(fieldName));
+    };
+  }
+
   public LocalDate getDateValue(String fieldName) {
     var day = inputs.get(fieldName + DAY_SUFFIX);
     var month = inputs.get(fieldName + MONTH_SUFFIX);
@@ -166,6 +190,17 @@ public class AmendmentForm {
           throw new IllegalArgumentException(
               "LocalDate value must be handled as a date field (FieldType.DATE), not formatted here");
       default -> "TODO";
+    };
+  }
+
+  private static String formatBooleanValue(String name, Object value) {
+    return switch (value) {
+      case null -> "";
+      case Boolean booleanValue -> booleanValue.toString();
+      default ->
+          throw new IllegalArgumentException(
+              "Expected Boolean for boolean field '%s' but got %s"
+                  .formatted(name, value.getClass()));
     };
   }
 

--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import lombok.Data;
+import uk.gov.justice.laa.amend.claim.converters.StringToBooleanConverter;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.MediationClaimDetails;
@@ -136,13 +137,12 @@ public class AmendmentForm {
     if (isBlank(value)) {
       return null;
     }
-    return switch (value.trim().toLowerCase()) {
-      case "true" -> true;
-      case "false" -> false;
-      default ->
-          throw new IllegalArgumentException(
-              "Invalid boolean value for field '%s'".formatted(fieldName));
-    };
+    try {
+      return StringToBooleanConverter.convertStrict(value);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid boolean value for field '%s'".formatted(fieldName), e);
+    }
   }
 
   public LocalDate getDateValue(String fieldName) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CivilClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CivilClaimDetailsViewField.java
@@ -9,11 +9,12 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
   // Client fields
   DATE_OF_BIRTH(new Accessor<>(CivilClaimDetails::getClientDateOfBirth), FieldType.DATE),
   POSTCODE(new Accessor<>(CivilClaimDetails::getClientPostcode)),
-  IS_ELIGIBLE_CLIENT(new Accessor<>(CivilClaimDetails::getIsEligibleClient)),
+  IS_ELIGIBLE_CLIENT(new Accessor<>(CivilClaimDetails::getIsEligibleClient), FieldType.BOOLEAN),
   CLIENT_TYPE(new Accessor<>(CivilClaimDetails::getClientType)),
   UNIQUE_CLIENT_NUMBER(new Accessor<>(CivilClaimDetails::getUniqueClientNumber)),
   HOME_OFFICE_CLIENT_NUMBER(new Accessor<>(CivilClaimDetails::getHomeOfficeClientNumber)),
-  IS_POSTAL_APPLICATION_ACCEPTED(new Accessor<>(CivilClaimDetails::getIsPostalApplication)),
+  IS_POSTAL_APPLICATION_ACCEPTED(
+      new Accessor<>(CivilClaimDetails::getIsPostalApplication), FieldType.BOOLEAN),
 
   // Case type fields
   FEE_CODE(new Accessor<>(CivilClaimDetails::getFeeCode)),
@@ -46,22 +47,24 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
   ADVICE_TIME(new Accessor<>(CivilClaimDetails::getAdviceTime)),
   TRAVEL_TIME(new Accessor<>(CivilClaimDetails::getTravelTime)),
   WAITING_TIME(new Accessor<>(CivilClaimDetails::getWaitingTime)),
-  ADDITIONAL_TRAVEL_PAYMENT(new Accessor<>(CivilClaimDetails::getIsAdditionalTravelPayment)),
+  ADDITIONAL_TRAVEL_PAYMENT(
+      new Accessor<>(CivilClaimDetails::getIsAdditionalTravelPayment), FieldType.BOOLEAN),
   FOLLOW_ON_WORK(new Accessor<>(CivilClaimDetails::getFollowOnWork)),
-  TOLERANCE_INDICATOR(new Accessor<>(CivilClaimDetails::getIsToleranceApplicable)),
-  LEGACY_CASE(new Accessor<>(CivilClaimDetails::getIsLegacyCase)),
+  TOLERANCE_INDICATOR(
+      new Accessor<>(CivilClaimDetails::getIsToleranceApplicable), FieldType.BOOLEAN),
+  LEGACY_CASE(new Accessor<>(CivilClaimDetails::getIsLegacyCase), FieldType.BOOLEAN),
   MEETINGS_ATTENDED(new Accessor<>(CivilClaimDetails::getMeetingsAttended)),
   ADVICE_TYPE(new Accessor<>(CivilClaimDetails::getAdviceType)),
   TRANSFER_DATE(new Accessor<>(CivilClaimDetails::getTransferDate), FieldType.DATE),
   MEDICAL_REPORTS_CLAIMED(new Accessor<>(CivilClaimDetails::getMedicalReportsClaimed)),
   EXEMPTION_CRITERIA_SATISFIED(new Accessor<>(CivilClaimDetails::getExemptionCriteriaSatisfied)),
-  IRC_SURGERY(new Accessor<>(CivilClaimDetails::getIsIrcSurgery)),
+  IRC_SURGERY(new Accessor<>(CivilClaimDetails::getIsIrcSurgery), FieldType.BOOLEAN),
   SURGERY_DATE(new Accessor<>(CivilClaimDetails::getSurgeryDate), FieldType.DATE),
   SURGERY_CLIENTS_COUNT(new Accessor<>(CivilClaimDetails::getSurgeryClientsCount)),
   SURGERY_MATTERS_COUNT(new Accessor<>(CivilClaimDetails::getSurgeryMattersCount)),
   MENTAL_HEALTH_TRIBUNAL_REFERENCE(
       new Accessor<>(CivilClaimDetails::getMentalHealthTribunalReference)),
-  IS_NRM_ADVICE(new Accessor<>(CivilClaimDetails::getIsNrmAdvice)),
+  IS_NRM_ADVICE(new Accessor<>(CivilClaimDetails::getIsNrmAdvice), FieldType.BOOLEAN),
   ;
 
   private final Accessor<?> accessor;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CrimeClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CrimeClaimDetailsViewField.java
@@ -27,8 +27,8 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
   MAAT_ID(new Accessor<>(CrimeClaimDetails::getMaatId)),
   PRISON_LAW_PRIOR_APPROVAL_NUMBER(
       new Accessor<>(CrimeClaimDetails::getPrisonLawPriorApprovalNumber)),
-  IS_DUTY_SOLICITOR(new Accessor<>(CrimeClaimDetails::getIsDutySolicitor)),
-  IS_YOUTH_COURT(new Accessor<>(CrimeClaimDetails::getIsYouthCourt));
+  IS_DUTY_SOLICITOR(new Accessor<>(CrimeClaimDetails::getIsDutySolicitor), FieldType.BOOLEAN),
+  IS_YOUTH_COURT(new Accessor<>(CrimeClaimDetails::getIsYouthCourt), FieldType.BOOLEAN);
 
   private final Accessor<?> accessor;
   private final FieldType type;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/FieldType.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/FieldType.java
@@ -2,5 +2,6 @@ package uk.gov.justice.laa.amend.claim.viewmodels.viewfield;
 
 public enum FieldType {
   TEXT,
+  BOOLEAN,
   DATE
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/MediationClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/MediationClaimDetailsViewField.java
@@ -11,9 +11,11 @@ public enum MediationClaimDetailsViewField implements ClaimViewField<MediationCl
   DATE_OF_BIRTH(new Accessor<>(MediationClaimDetails::getClientDateOfBirth), FieldType.DATE),
   POSTCODE(new Accessor<>(MediationClaimDetails::getClientPostcode)),
   UNIQUE_CLIENT_NUMBER(new Accessor<>(MediationClaimDetails::getUniqueClientNumber)),
-  IS_LEGALLY_AIDED(new Accessor<>(MediationClaimDetails::getIsClientLegallyAided)),
+  IS_LEGALLY_AIDED(
+      new Accessor<>(MediationClaimDetails::getIsClientLegallyAided), FieldType.BOOLEAN),
   IS_POSTAL_APPLICATION_ACCEPTED(
-      new Accessor<>(MediationClaimDetails::getIsClientPostalApplicationAccepted)),
+      new Accessor<>(MediationClaimDetails::getIsClientPostalApplicationAccepted),
+      FieldType.BOOLEAN),
 
   // Client 2 fields
   CLIENT_2_FORENAME(new Accessor<>(MediationClaimDetails::getClient2Forename)),
@@ -25,9 +27,11 @@ public enum MediationClaimDetailsViewField implements ClaimViewField<MediationCl
   CLIENT_2_GENDER(new Accessor<>(MediationClaimDetails::getClient2Gender)),
   CLIENT_2_ETHNICITY(new Accessor<>(MediationClaimDetails::getClient2Ethnicity)),
   CLIENT_2_DISABILITY(new Accessor<>(MediationClaimDetails::getClient2Disability)),
-  IS_CLIENT_2_LEGALLY_AIDED(new Accessor<>(MediationClaimDetails::getIsClient2LegallyAided)),
+  IS_CLIENT_2_LEGALLY_AIDED(
+      new Accessor<>(MediationClaimDetails::getIsClient2LegallyAided), FieldType.BOOLEAN),
   IS_CLIENT_2_POSTAL_APPLICATION_ACCEPTED(
-      new Accessor<>(MediationClaimDetails::getIsClient2PostalApplicationAccepted)),
+      new Accessor<>(MediationClaimDetails::getIsClient2PostalApplicationAccepted),
+      FieldType.BOOLEAN),
 
   // Case Type fields
   FEE_CODE(new Accessor<>(MediationClaimDetails::getFeeCode)),

--- a/src/main/resources/templates/amendments/amend-case-details.html
+++ b/src/main/resources/templates/amendments/amend-case-details.html
@@ -43,7 +43,7 @@
                 <dt class="govuk-summary-list__key" th:text="#{${'claimCase.rows.' + entry.key.name()}}"></dt>
                 <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.value).resolve(#messages)}"></dd>
                 <dd class="govuk-summary-list__value">
-                  <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${entry.key})}"></th:block>
+                  <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${entry.key}, ${'claimCase.rows.' + entry.key.name()})}"></th:block>
                 </dd>
               </div>
             </dl>

--- a/src/main/resources/templates/amendments/amend-client-1.html
+++ b/src/main/resources/templates/amendments/amend-client-1.html
@@ -44,7 +44,7 @@
                 <dt class="govuk-summary-list__key" th:text="#{${'claimClient.rows.' + entry.key.name()}}"></dt>
                 <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.value).resolve(#messages)}"></dd>
                 <dd class="govuk-summary-list__value">
-                  <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${entry.key})}"></th:block>
+                  <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${entry.key}, ${'claimClient.rows.' + entry.key.name()})}"></th:block>
                 </dd>
               </div>
             </dl>

--- a/src/main/resources/templates/amendments/view-case.html
+++ b/src/main/resources/templates/amendments/view-case.html
@@ -51,7 +51,7 @@
                   th:text="${@ThymeleafUtils.getFormattedValue(entry.value).resolve(#messages)}"></dd>
               <dd class="govuk-summary-list__value"
                   th:if="${caseTypeForm.isAmendment(entry.key.name(), originalCaseTypeForm)}"
-                  th:text="${@ThymeleafUtils.getFormattedValue(caseTypeForm.getAmendedValue(entry.key.name())).resolve(#messages)}"></dd>
+                  th:text="${@ThymeleafUtils.getFormattedValue(caseTypeForm.getAmendedValue(entry.key)).resolve(#messages)}"></dd>
             </div>
           </dl>
         </div>
@@ -86,7 +86,7 @@
                   th:text="${@ThymeleafUtils.getFormattedValue(entry.value).resolve(#messages)}"></dd>
               <dd class="govuk-summary-list__value"
                   th:if="${caseDetailsForm.isAmendment(entry.key.name(), originalCaseDetailsForm)}"
-                  th:text="${@ThymeleafUtils.getFormattedValue(caseDetailsForm.getAmendedValue(entry.key.name())).resolve(#messages)}"></dd>
+                  th:text="${@ThymeleafUtils.getFormattedValue(caseDetailsForm.getAmendedValue(entry.key)).resolve(#messages)}"></dd>
             </div>
           </dl>
         </div>

--- a/src/main/resources/templates/amendments/view-client.html
+++ b/src/main/resources/templates/amendments/view-client.html
@@ -47,7 +47,7 @@
 
               <dd class="govuk-summary-list__value"
                   th:if="${client1Form.isAmendment(entry.key, forms.client1Form.original)}"
-                  th:text="${@ThymeleafUtils.getFormattedValue(client1Form.getAmendedValue(entry.key.name())).resolve(#messages)}"></dd>
+                  th:text="${@ThymeleafUtils.getFormattedValue(client1Form.getAmendedValue(entry.key)).resolve(#messages)}"></dd>
             </div>
           </dl>
         </div>

--- a/src/main/resources/templates/amendments/view-client.html
+++ b/src/main/resources/templates/amendments/view-client.html
@@ -46,7 +46,7 @@
               <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.value).resolve(#messages)}"></dd>
 
               <dd class="govuk-summary-list__value"
-                  th:if="${client1Form.isAmendment(entry.key, forms.client1Form.original)}"
+                  th:if="${client1Form.isAmendment(entry.key.name(), forms.client1Form.original)}"
                   th:text="${@ThymeleafUtils.getFormattedValue(client1Form.getAmendedValue(entry.key)).resolve(#messages)}"></dd>
             </div>
           </dl>

--- a/src/main/resources/templates/partials/amendments/amendment-input.html
+++ b/src/main/resources/templates/partials/amendments/amendment-input.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
 <body>
-<th:block th:fragment="amendmentInput(field)">
+<th:block th:fragment="amendmentInput(field, labelMessageKey)">
   <th:block th:if="${field.type.name() == 'DATE'}">
     <th:block th:replace="~{partials/amendments/date-input :: amendmentDateInput(${field.name()})}"></th:block>
+  </th:block>
+  <th:block th:if="${field.type.name() == 'BOOLEAN'}">
+    <th:block th:replace="~{partials/amendments/boolean-input :: amendmentBooleanInput(${field.name()}, ${labelMessageKey})}"></th:block>
   </th:block>
   <input th:if="${field.type.name() == 'TEXT'}"
          class="govuk-input"

--- a/src/main/resources/templates/partials/amendments/boolean-input.html
+++ b/src/main/resources/templates/partials/amendments/boolean-input.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="amendmentBooleanInput(fieldKey, labelMessageKey)"
+          th:with="label=${#messages.msgOrNull(labelMessageKey) ?: fieldKey}">
+  <label class="govuk-label govuk-visually-hidden"
+         th:for="${fieldKey}"
+         th:text="${label}"></label>
+  <select class="govuk-select"
+          th:id="${fieldKey}"
+          th:field="*{inputs[__${fieldKey}__]}">
+    <option value=""></option>
+    <option value="true" th:text="#{service.yes}"></option>
+    <option value="false" th:text="#{service.no}"></option>
+  </select>
+</th:block>
+</body>
+</html>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/StartControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/StartControllerTest.java
@@ -99,8 +99,8 @@ class StartControllerTest extends BaseControllerTest {
     caseDetailsRows.put("MAAT_ID", claim.getMaatId());
     caseDetailsRows.put(
         "PRISON_LAW_PRIOR_APPROVAL_NUMBER", claim.getPrisonLawPriorApprovalNumber());
-    caseDetailsRows.put("IS_DUTY_SOLICITOR", "TODO");
-    caseDetailsRows.put("IS_YOUTH_COURT", "TODO");
+    caseDetailsRows.put("IS_DUTY_SOLICITOR", "true");
+    caseDetailsRows.put("IS_YOUTH_COURT", "true");
 
     var caseDetailsForm = new AmendmentForm();
     caseDetailsForm.setInputs(caseDetailsRows);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/converters/StringToBooleanConverterTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/converters/StringToBooleanConverterTest.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.amend.claim.converters;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,5 +30,22 @@ public class StringToBooleanConverterTest {
   @ParameterizedTest
   void convertsStringToBoolean(String input, Boolean expected) {
     assertEquals(expected, converter.convert(input));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidArguments")
+  void existingConverterTreatsInvalidInputAsFalse(String input) {
+    assertEquals(false, converter.convert(input));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidArguments")
+  void strictConverterThrowsWhenInputIsNotBoolean(String input) {
+    assertThrows(
+        IllegalArgumentException.class, () -> StringToBooleanConverter.convertStrict(input));
+  }
+
+  private static Stream<Arguments> provideInvalidArguments() {
+    return Stream.of(Arguments.of("not-a-boolean"), Arguments.of("1"), Arguments.of("0"));
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
@@ -62,6 +62,39 @@ class AmendmentFormTest {
   }
 
   @Test
+  void seedsBooleanFieldAsTrueFalseInput() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT, true);
+    rows.put(CivilClaimDetailsViewField.IS_POSTAL_APPLICATION_ACCEPTED, false);
+
+    var form = new AmendmentForm(rows);
+
+    assertThat(form.getInputs())
+        .containsEntry("IS_ELIGIBLE_CLIENT", "true")
+        .containsEntry("IS_POSTAL_APPLICATION_ACCEPTED", "false");
+  }
+
+  @Test
+  void seedsNullBooleanFieldAsEmptyInput() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT, null);
+
+    var form = new AmendmentForm(rows);
+
+    assertThat(form.getInputs()).containsEntry("IS_ELIGIBLE_CLIENT", "");
+  }
+
+  @Test
+  void throwsWhenBooleanFieldValueIsNotBoolean() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT, "not-a-boolean");
+
+    assertThatThrownBy(() -> new AmendmentForm(rows))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("IS_ELIGIBLE_CLIENT");
+  }
+
+  @Test
   void getFieldInputsCollapsesDateSubInputsIntoSingleField() {
     var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
     rows.put(CivilClaimDetailsViewField.DATE_OF_BIRTH, LocalDate.of(2002, 5, 14));
@@ -127,6 +160,32 @@ class AmendmentFormTest {
   }
 
   @Test
+  void getAmendedValueReturnsBooleanForBooleanField() {
+    var form = new AmendmentForm();
+    form.setInputs(new HashMap<>(Map.of("IS_ELIGIBLE_CLIENT", "true")));
+
+    assertThat(form.getAmendedValue(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT)).isEqualTo(true);
+  }
+
+  @Test
+  void getBooleanValueReturnsNullWhenInputBlank() {
+    var form = new AmendmentForm();
+    form.setInputs(new HashMap<>(Map.of("IS_ELIGIBLE_CLIENT", "")));
+
+    assertThat(form.getBooleanValue("IS_ELIGIBLE_CLIENT")).isNull();
+  }
+
+  @Test
+  void getBooleanValueThrowsWhenInputIsNotTrueOrFalse() {
+    var form = new AmendmentForm();
+    form.setInputs(new HashMap<>(Map.of("IS_ELIGIBLE_CLIENT", "not-a-boolean")));
+
+    assertThatThrownBy(() -> form.getBooleanValue("IS_ELIGIBLE_CLIENT"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("IS_ELIGIBLE_CLIENT");
+  }
+
+  @Test
   void isAmendmentDetectsChangedDateField() {
     var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
     rows.put(CivilClaimDetailsViewField.DATE_OF_BIRTH, LocalDate.of(2002, 5, 14));
@@ -170,6 +229,18 @@ class AmendmentFormTest {
 
     var current = new AmendmentForm(original);
     current.getInputs().put("DATE_OF_BIRTH-year", "2003");
+
+    assertThat(current.hasAmendments(original)).isTrue();
+  }
+
+  @Test
+  void hasAmendmentsDetectsChangedBoolean() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT, true);
+    var original = new AmendmentForm(rows);
+
+    var current = new AmendmentForm(original);
+    current.getInputs().put("IS_ELIGIBLE_CLIENT", "false");
 
     assertThat(current.hasAmendments(original)).isTrue();
   }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
@@ -219,12 +219,13 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
         caseDetails.get(22), "Travel time", String.valueOf(TRAVEL_TIME), "TODO");
     assertSummaryListRowContainsValues(
         caseDetails.get(23), "Waiting time", String.valueOf(WAITING_TIME), "TODO");
-    assertSummaryListRowContainsValues(
-        caseDetails.get(24), "Additional travel payment", YES, "TODO");
+    assertBooleanSelectRow(
+        caseDetails.get(24), "Additional travel payment", YES, "ADDITIONAL_TRAVEL_PAYMENT", true);
     assertSummaryListRowContainsValues(
         caseDetails.get(25), "Follow on work", FOLLOW_ON_WORK, FOLLOW_ON_WORK);
-    assertSummaryListRowContainsValues(caseDetails.get(26), "Tolerance indicator", YES, "TODO");
-    assertSummaryListRowContainsValues(caseDetails.get(27), "Legacy case", YES, "TODO");
+    assertBooleanSelectRow(
+        caseDetails.get(26), "Tolerance indicator", YES, "TOLERANCE_INDICATOR", true);
+    assertBooleanSelectRow(caseDetails.get(27), "Legacy case", YES, "LEGACY_CASE", true);
     assertSummaryListRowContainsValues(
         caseDetails.get(28), "Meetings attended", MEETINGS_ATTENDED, MEETINGS_ATTENDED);
     assertSummaryListRowContainsValues(
@@ -240,8 +241,8 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
         "Exemption criteria satisfied",
         EXEMPTION_CRITERIA_SATISFIED,
         EXEMPTION_CRITERIA_SATISFIED);
-    assertSummaryListRowContainsValues(
-        caseDetails.get(33), "Immigration removal centre (IRC) surgery", YES, "TODO");
+    assertBooleanSelectRow(
+        caseDetails.get(33), "Immigration removal centre (IRC) surgery", YES, "IRC_SURGERY", true);
     assertDateRow(caseDetails.get(34), "Surgery date", SURGERY_DATE, "SURGERY_DATE");
     assertSummaryListRowContainsValues(
         caseDetails.get(35),
@@ -258,8 +259,12 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
         "Mental health tribunal reference",
         MENTAL_HEALTH_TRIBUNAL_REFERENCE,
         MENTAL_HEALTH_TRIBUNAL_REFERENCE);
-    assertSummaryListRowContainsValues(
-        caseDetails.get(38), "National referral mechanism (NRM) advice", YES, "TODO");
+    assertBooleanSelectRow(
+        caseDetails.get(38),
+        "National referral mechanism (NRM) advice",
+        YES,
+        "IS_NRM_ADVICE",
+        true);
   }
 
   @Test
@@ -334,8 +339,8 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
         "Prison Law Prior Approval number",
         PRISON_LAW_PRIOR_APPROVAL_NUMBER,
         PRISON_LAW_PRIOR_APPROVAL_NUMBER);
-    assertSummaryListRowContainsValues(caseDetails.get(14), "Duty solicitor", YES, "TODO");
-    assertSummaryListRowContainsValues(caseDetails.get(15), "Youth court", YES, "TODO");
+    assertBooleanSelectRow(caseDetails.get(14), "Duty solicitor", YES, "IS_DUTY_SOLICITOR", true);
+    assertBooleanSelectRow(caseDetails.get(15), "Youth court", YES, "IS_YOUTH_COURT", true);
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClient1ViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClient1ViewTest.java
@@ -117,11 +117,13 @@ class AmendClient1ViewTest extends AmendmentsBaseTest {
     assertSummaryListRowContainsValues(client1Details.get(6), "Gender", GENDER, GENDER);
     assertSummaryListRowContainsValues(client1Details.get(7), "Ethnicity", ETHNICITY, ETHNICITY);
     assertSummaryListRowContainsValues(client1Details.get(8), "Disability", DISABILITY, DISABILITY);
-    // TODO: Correct assertion when booleans are correctly parsed
-    assertSummaryListRowContainsValues(client1Details.get(9), "Legally aided", "Yes", "TODO");
-    // TODO: Correct assertion when booleans are correctly parsed
-    assertSummaryListRowContainsValues(
-        client1Details.get(10), "Postal application accepted", "No", "TODO");
+    assertBooleanSelectRow(client1Details.get(9), "Legally aided", "Yes", "IS_LEGALLY_AIDED", true);
+    assertBooleanSelectRow(
+        client1Details.get(10),
+        "Postal application accepted",
+        "No",
+        "IS_POSTAL_APPLICATION_ACCEPTED",
+        false);
   }
 
   @Test
@@ -159,8 +161,8 @@ class AmendClient1ViewTest extends AmendmentsBaseTest {
     assertSummaryListRowContainsValues(clientDetails.get(5), "Ethnicity", ETHNICITY, ETHNICITY);
     assertSummaryListRowContainsValues(clientDetails.get(6), "Disability", DISABILITY, DISABILITY);
     assertSummaryListRowContainsValues(clientDetails.get(7), "Postcode", POSTCODE, POSTCODE);
-    // TODO: Correct assertion when booleans are correctly parsed
-    assertSummaryListRowContainsValues(clientDetails.get(8), "Eligible client", "Yes", "TODO");
+    assertBooleanSelectRow(
+        clientDetails.get(8), "Eligible client", "Yes", "IS_ELIGIBLE_CLIENT", true);
     assertSummaryListRowContainsValues(
         clientDetails.get(9), "Client type", CLIENT_TYPE, CLIENT_TYPE);
     assertSummaryListRowContainsValues(
@@ -170,9 +172,12 @@ class AmendClient1ViewTest extends AmendmentsBaseTest {
         "Home Office unique client number (HO UCN)",
         HOME_OFFICE_CLIENT_NUMBER,
         HOME_OFFICE_CLIENT_NUMBER);
-    // TODO: Correct assertion when booleans are correctly parsed
-    assertSummaryListRowContainsValues(
-        clientDetails.get(12), "Postal application accepted", "No", "TODO");
+    assertBooleanSelectRow(
+        clientDetails.get(12),
+        "Postal application accepted",
+        "No",
+        "IS_POSTAL_APPLICATION_ACCEPTED",
+        false);
   }
 
   private void assertDateOfBirthRow(List<Element> row) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendmentsBaseTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendmentsBaseTest.java
@@ -2,6 +2,9 @@ package uk.gov.justice.laa.amend.claim.views.amendments;
 
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
+import java.util.List;
+import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.Assertions;
 import uk.gov.justice.laa.amend.claim.views.ViewTestBase;
 
 public abstract class AmendmentsBaseTest extends ViewTestBase {
@@ -38,5 +41,21 @@ public abstract class AmendmentsBaseTest extends ViewTestBase {
         "/submissions/%s/claims/%s/amendments/amend-case-details".formatted(submissionId, claimId);
 
     checkUrl = "/submissions/%s/claims/%s/amendments/check".formatted(submissionId, claimId);
+  }
+
+  protected void assertBooleanSelectRow(
+      List<Element> row, String label, String currentValue, String inputId, boolean expectedValue) {
+    assertCellContainsText(row.getFirst(), label);
+    assertCellContainsText(row.get(1), currentValue);
+
+    Element select = selectFirst(row.get(2), "select.govuk-select");
+    Assertions.assertEquals(inputId, select.attr("id"), "Boolean select id");
+    Assertions.assertEquals(2, select.select("option[value=true], option[value=false]").size());
+    Element selectLabel = selectFirst(row.get(2), "label[for=%s]".formatted(inputId));
+    Assertions.assertEquals(label, selectLabel.text());
+
+    Element selectedOption = selectFirst(select, "option[selected]");
+    Assertions.assertEquals(Boolean.toString(expectedValue), selectedOption.attr("value"));
+    Assertions.assertEquals(expectedValue ? "Yes" : "No", selectedOption.text());
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/ViewClientViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/ViewClientViewTest.java
@@ -229,8 +229,8 @@ class ViewClientViewTest extends AmendmentsBaseTest {
     forms.getClient1Form().getCurrent().getInputs().put("GENDER", "changed");
     forms.getClient1Form().getCurrent().getInputs().put("ETHNICITY", "changed");
     forms.getClient1Form().getCurrent().getInputs().put("DISABILITY", "changed");
-    forms.getClient1Form().getCurrent().getInputs().put("IS_LEGALLY_AIDED", "changed");
-    forms.getClient1Form().getCurrent().getInputs().put("IS_POSTAL_APPLICATION_ACCEPTED", "false");
+    forms.getClient1Form().getCurrent().getInputs().put("IS_LEGALLY_AIDED", "false");
+    forms.getClient1Form().getCurrent().getInputs().put("IS_POSTAL_APPLICATION_ACCEPTED", "true");
 
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
 
@@ -249,9 +249,9 @@ class ViewClientViewTest extends AmendmentsBaseTest {
     assertSummaryListRowContainsValues(client1Details.get(6), "Gender", GENDER, "changed");
     assertSummaryListRowContainsValues(client1Details.get(7), "Ethnicity", ETHNICITY, "changed");
     assertSummaryListRowContainsValues(client1Details.get(8), "Disability", DISABILITY, "changed");
-    assertSummaryListRowContainsValues(client1Details.get(9), "Legally aided", "Yes", "changed");
+    assertSummaryListRowContainsValues(client1Details.get(9), "Legally aided", "Yes", "No");
     assertSummaryListRowContainsValues(
-        client1Details.get(10), "Postal application accepted", "No", "false");
+        client1Details.get(10), "Postal application accepted", "No", "Yes");
 
     var client2Details = getSummaryListInCard(doc, "Client 2 details");
     assertSummaryListRowContainsValues(client2Details.getFirst(), "First name", CLIENT_2_FORENAME);
@@ -347,7 +347,7 @@ class ViewClientViewTest extends AmendmentsBaseTest {
     forms.getClient1Form().getCurrent().getInputs().put("GENDER", "changed");
     forms.getClient1Form().getCurrent().getInputs().put("ETHNICITY", "changed");
     forms.getClient1Form().getCurrent().getInputs().put("DISABILITY", "changed");
-    forms.getClient1Form().getCurrent().getInputs().put("IS_ELIGIBLE_CLIENT", "changed");
+    forms.getClient1Form().getCurrent().getInputs().put("IS_ELIGIBLE_CLIENT", "false");
     forms.getClient1Form().getCurrent().getInputs().put("CLIENT_TYPE", "changed");
     forms.getClient1Form().getCurrent().getInputs().put("HOME_OFFICE_CLIENT_NUMBER", "changed");
     forms.getClient1Form().getCurrent().getInputs().put("IS_POSTAL_APPLICATION_ACCEPTED", "false");
@@ -366,7 +366,7 @@ class ViewClientViewTest extends AmendmentsBaseTest {
     assertSummaryListRowContainsValues(clientDetails.get(5), "Ethnicity", ETHNICITY, "changed");
     assertSummaryListRowContainsValues(clientDetails.get(6), "Disability", DISABILITY, "changed");
     assertSummaryListRowContainsValues(clientDetails.get(7), "Postcode", POSTCODE, "changed");
-    assertSummaryListRowContainsValues(clientDetails.get(8), "Eligible client", "Yes", "changed");
+    assertSummaryListRowContainsValues(clientDetails.get(8), "Eligible client", "Yes", "No");
     assertSummaryListRowContainsValues(clientDetails.get(9), "Client type", CLIENT_TYPE, "changed");
     assertSummaryListRowContainsValues(
         clientDetails.get(10), "Unique client number (UCN)", UCN, "changed");
@@ -376,7 +376,7 @@ class ViewClientViewTest extends AmendmentsBaseTest {
         HOME_OFFICE_CLIENT_NUMBER,
         "changed");
     assertSummaryListRowContainsValues(
-        clientDetails.get(12), "Postal application accepted", "Yes", "false");
+        clientDetails.get(12), "Postal application accepted", "Yes", "No");
 
     assertPageHasLink(doc, "check", "Continue", checkUrl);
     assertPageHasLink(doc, "cancel", "Cancel", overviewUrl);


### PR DESCRIPTION
[BC-689](https://dsdmoj.atlassian.net/browse/BC-689)

- Adds Yes/No dropdown inputs for boolean indicator fields in the claim amendment journey.



[BC-689]: https://dsdmoj.atlassian.net/browse/BC-689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ