### PR TITLE
Makes the autocomplete alphabetical when typing

### DIFF
--- a/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/amendments/AmendFeeCodePage.java
+++ b/src/e2e/main/java/uk/gov/justice/laa/amend/claim/pages/amendments/AmendFeeCodePage.java
@@ -17,7 +17,7 @@ public class AmendFeeCodePage extends LaaPage {
     this.continueButton =
         page.getByRole(AriaRole.BUTTON, new Page.GetByRoleOptions().setName("Continue"));
     this.feeCodeInput =
-        page.locator("#fee-code-input.autocomplete__input.autocomplete__input--default");
+        page.locator("#fee-code-input.autocomplete__input.autocomplete__input--show-all-values");
   }
 
   public void fillFeeCodeInput(String value) {

--- a/src/main/resources/es/accessible-autocomplete.d.ts
+++ b/src/main/resources/es/accessible-autocomplete.d.ts
@@ -19,6 +19,7 @@ interface AccessibleAutocompleteOptions {
   onConfirm?: (confirmed: string) => void;
   required?: boolean;
   showAllValues?: boolean;
+  dropdownArrow?(props: { className: string }): string | ReactElement;
   showNoOptionsFound?: boolean;
   templates?: {
     inputValue?: (result: string) => string;

--- a/src/main/resources/es/app.ts
+++ b/src/main/resources/es/app.ts
@@ -34,16 +34,23 @@ const selectDropdowns = document.querySelectorAll<HTMLSelectElement>('[data-modu
 
 // For each dropdown
 selectDropdowns.forEach(function (select: HTMLSelectElement) {
+    const defaultValue = select.options[select.options.selectedIndex].innerHTML;
+
     accessibleAutocomplete.enhanceSelectElement({
         element: select,
         id: select.id,
-        defaultValue: select.options[select.options.selectedIndex].innerHTML,
+        defaultValue: defaultValue,
         selectElement: select,
         allowEmpty: true,
         displayMenu: 'overlay',
+        showAllValues: true,
+        dropdownArrow: () => `<svg class="autocomplete__dropdown-arrow-down" style="top: 8px;" viewBox="0 0 512 512"><path d="M256,298.3L256,298.3L256,298.3l174.2-167.2c4.3-4.2,11.4-4.1,15.8,0.2l30.6,29.9c4.4,4.3,4.5,11.3,0.2,15.5L264.1,380.9  c-2.2,2.2-5.2,3.2-8.1,3c-3,0.1-5.9-0.9-8.1-3L35.2,176.7c-4.3-4.2-4.2-11.2,0.2-15.5L66,131.3c4.4-4.3,11.5-4.4,15.8-0.2L256,298.3  z"></path></svg>`,
         // Match the query anywhere in the text, but list matches at the start first, alphabetically.
+        // Treat a query equal to the pre-filled default value as "not actively searching" so that
+        // showAllValues shows the full list rather than just the already-selected option.
         source: function (query: string, populateResults: (results: string[]) => void): void {
-            const lowerQuery = query.toLowerCase();
+            const isUnfilteredQuery = query === '' || query === defaultValue;
+            const lowerQuery = isUnfilteredQuery ? '' : query.toLowerCase();
             const options = [].filter.call(select.options, (option: HTMLOptionElement) => option.value)
                 .map((option: HTMLOptionElement) => option.textContent || option.innerText);
             const results = options.filter((option: string) => option.toLowerCase().includes(lowerQuery));

--- a/src/main/resources/es/app.ts
+++ b/src/main/resources/es/app.ts
@@ -40,6 +40,11 @@ selectDropdowns.forEach(function (select: HTMLSelectElement) {
         defaultValue: select.options[select.options.selectedIndex].innerHTML,
         selectElement: select,
         allowEmpty: true,
-        displayMenu: 'overlay'
+        displayMenu: 'overlay',
+        source: function (query: string, populateResults: (results: string[]) => void): void {
+            const options = [].filter.call(select.options, (option: HTMLOptionElement) => option.value)
+                .map((option: HTMLOptionElement) => option.textContent || option.innerText);
+            populateResults(options.filter((option: string) => option.toLowerCase().startsWith(query.toLowerCase())));
+        }
     });
 });

--- a/src/main/resources/es/app.ts
+++ b/src/main/resources/es/app.ts
@@ -41,10 +41,21 @@ selectDropdowns.forEach(function (select: HTMLSelectElement) {
         selectElement: select,
         allowEmpty: true,
         displayMenu: 'overlay',
+        // Match the query anywhere in the text, but list matches at the start first, alphabetically.
         source: function (query: string, populateResults: (results: string[]) => void): void {
+            const lowerQuery = query.toLowerCase();
             const options = [].filter.call(select.options, (option: HTMLOptionElement) => option.value)
                 .map((option: HTMLOptionElement) => option.textContent || option.innerText);
-            populateResults(options.filter((option: string) => option.toLowerCase().startsWith(query.toLowerCase())));
+            const results = options.filter((option: string) => option.toLowerCase().includes(lowerQuery));
+            results.sort((a: string, b: string) => {
+                const aStartsWith = a.toLowerCase().startsWith(lowerQuery);
+                const bStartsWith = b.toLowerCase().startsWith(lowerQuery);
+                if (aStartsWith !== bStartsWith) {
+                    return aStartsWith ? -1 : 1;
+                }
+                return a.localeCompare(b);
+            });
+            populateResults(results);
         }
     });
 });

--- a/src/main/resources/sass/app.scss
+++ b/src/main/resources/sass/app.scss
@@ -3,3 +3,4 @@
 @use "govuk-frontend/dist/govuk" as *;
 @use "styles.scss";
 @import "accessible-autocomplete/src/autocomplete";
+

--- a/src/main/resources/sass/styles.scss
+++ b/src/main/resources/sass/styles.scss
@@ -60,6 +60,13 @@
   display: none; /* Hidden until required */
 }
 
+/* Without this, the wrapper doesn't form its own stacking context, so the
+   dropdown arrow's negative z-index escapes to the document root and gets
+   painted behind the page background instead of behind just the input. */
+.autocomplete__dropdown-arrow-down {
+  z-index: 0 !important;
+}
+
 /* Adapted from https://design.homeoffice.gov.uk/design-system/components?name=Loading%20spinner */
 .loading-spinner {
   margin-left: auto;


### PR DESCRIPTION
## What is this PR?

[Link to story](https://dsdmoj.atlassian.net/browse/BC-701)

Should make it so when the user types into an autocomplete box, the options are ordered based on the left of the values and not if there is a string match anywhere in the values.

<img width="583" height="538" alt="Screenshot 2026-07-28 at 17 37 55" src="https://github.com/user-attachments/assets/dd83d406-7157-43ef-a2ba-e5d2d69f1da6" />

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

