### PR TITLE
BC-691: Big decimal input for Value of costs.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
@@ -157,7 +157,8 @@ public class AmendmentForm {
       return null;
     }
     try {
-      return setScale(NumberUtils.parse(value));
+      var parsed = NumberUtils.parse(value);
+      return parsed.scale() > 2 ? null : setScale(parsed);
     } catch (NumberFormatException | ParseException e) {
       return null;
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
@@ -1,7 +1,10 @@
 package uk.gov.justice.laa.amend.claim.forms.amendments;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static uk.gov.justice.laa.amend.claim.utils.CurrencyUtils.setScale;
 
+import java.math.BigDecimal;
+import java.text.ParseException;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.HashMap;
@@ -15,6 +18,7 @@ import uk.gov.justice.laa.amend.claim.converters.StringToBooleanConverter;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.MediationClaimDetails;
+import uk.gov.justice.laa.amend.claim.utils.NumberUtils;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
@@ -128,6 +132,7 @@ public class AmendmentForm {
     return switch (field.getType()) {
       case DATE -> getDateValue(field.name());
       case BOOLEAN -> getBooleanValue(field.name());
+      case BIG_DECIMAL -> getBigDecimalValue(field.name());
       case ENUM -> inputs.get(field.name());
       case TEXT -> inputs.get(field.name());
     };
@@ -143,6 +148,18 @@ public class AmendmentForm {
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           "Invalid boolean value for field '%s'".formatted(fieldName), e);
+    }
+  }
+
+  public BigDecimal getBigDecimalValue(String fieldName) {
+    var value = inputs.get(fieldName);
+    if (isBlank(value)) {
+      return null;
+    }
+    try {
+      return setScale(NumberUtils.parse(value));
+    } catch (NumberFormatException | ParseException e) {
+      return null;
     }
   }
 
@@ -187,6 +204,7 @@ public class AmendmentForm {
     return switch (value) {
       case null -> null;
       case String stringValue -> stringValue;
+      case BigDecimal bigDecimal -> setScale(bigDecimal).toString();
       case LocalDate ignored ->
           throw new IllegalArgumentException(
               "LocalDate value must be handled as a date field (FieldType.DATE), not formatted here");

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CivilClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CivilClaimDetailsViewField.java
@@ -31,7 +31,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       new Accessor<>(CivilClaimDetails::getCaseConcludedDate), FieldType.DATE),
   UNIQUE_FILE_NUMBER(new Accessor<>(CivilClaimDetails::getUniqueFileNumber)),
   CASE_STAGE(new Accessor<>(CivilClaimDetails::getCaseStage), FieldOptions.CASE_STAGE),
-  VALUE_OF_COSTS(new Accessor<>(CivilClaimDetails::getValueOfCosts)),
+  VALUE_OF_COSTS(new Accessor<>(CivilClaimDetails::getValueOfCosts), FieldType.BIG_DECIMAL),
   PROCUREMENT_AREA(new Accessor<>(CivilClaimDetails::getProcurementArea)),
   ACCESS_POINT(new Accessor<>(CivilClaimDetails::getAccessPoint)),
   STAGE_REACHED(new Accessor<>(CivilClaimDetails::getStageReached), FieldOptions.STAGE_REACHED),

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/FieldType.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/FieldType.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.amend.claim.viewmodels.viewfield;
 public enum FieldType {
   TEXT,
   BOOLEAN,
+  BIG_DECIMAL,
   DATE,
   ENUM
 }

--- a/src/main/resources/templates/partials/amendments/amendment-input.html
+++ b/src/main/resources/templates/partials/amendments/amendment-input.html
@@ -11,6 +11,9 @@
   <th:block th:if="${field.type.name() == 'ENUM'}">
     <th:block th:replace="~{partials/amendments/enum-input :: amendmentEnumInput(${field}, ${labelMessageKey})}"></th:block>
   </th:block>
+  <th:block th:if="${field.type.name() == 'BIG_DECIMAL'}">
+    <th:block th:replace="~{partials/amendments/big-decimal-input :: amendmentBigDecimalInput(${field.name()}, ${labelMessageKey})}"></th:block>
+  </th:block>
   <input th:if="${field.type.name() == 'TEXT'}"
          class="govuk-input"
          type="text"

--- a/src/main/resources/templates/partials/amendments/big-decimal-input.html
+++ b/src/main/resources/templates/partials/amendments/big-decimal-input.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<body>
+<th:block th:fragment="amendmentBigDecimalInput(fieldKey, labelMessageKey)"
+          th:with="label=${#messages.msgOrNull(labelMessageKey) ?: fieldKey}">
+  <label class="govuk-label govuk-visually-hidden"
+         th:for="${fieldKey}"
+         th:text="${label}"></label>
+  <div class="govuk-input__wrapper amend-big-decimal-input">
+    <div class="govuk-input__prefix" aria-hidden="true">£</div>
+    <input class="govuk-input govuk-input--width-10"
+           type="text"
+           inputmode="decimal"
+           spellcheck="false"
+           th:id="${fieldKey}"
+           th:field="*{inputs[__${fieldKey}__]}" />
+  </div>
+</th:block>
+</body>
+</html>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.amend.claim.forms.amendments;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -165,6 +166,25 @@ class AmendmentFormTest {
     form.setInputs(new HashMap<>(Map.of("IS_ELIGIBLE_CLIENT", "true")));
 
     assertThat(form.getAmendedValue(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT)).isEqualTo(true);
+  }
+
+  @Test
+  void seedsBigDecimalFieldAsScaledInput() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.VALUE_OF_COSTS, BigDecimal.valueOf(10.1));
+
+    var form = new AmendmentForm(rows);
+
+    assertThat(form.getInputs()).containsEntry("VALUE_OF_COSTS", "10.10");
+  }
+
+  @Test
+  void getAmendedValueReturnsBigDecimalForBigDecimalField() {
+    var form = new AmendmentForm();
+    form.setInputs(new HashMap<>(Map.of("VALUE_OF_COSTS", "10.1")));
+
+    assertThat(form.getAmendedValue(CivilClaimDetailsViewField.VALUE_OF_COSTS))
+        .isEqualTo(BigDecimal.valueOf(10.10).setScale(2));
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
@@ -188,6 +188,14 @@ class AmendmentFormTest {
   }
 
   @Test
+  void getBigDecimalValueRejectsMoreThanTwoDecimalPlacesRatherThanRounding() {
+    var form = new AmendmentForm();
+    form.setInputs(new HashMap<>(Map.of("VALUE_OF_COSTS", "10.129")));
+
+    assertThat(form.getBigDecimalValue("VALUE_OF_COSTS")).isNull();
+  }
+
+  @Test
   void getBooleanValueReturnsNullWhenInputBlank() {
     var form = new AmendmentForm();
     form.setInputs(new HashMap<>(Map.of("IS_ELIGIBLE_CLIENT", "")));

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
@@ -167,11 +167,11 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
     assertSummaryListRowContainsValues(caseDetails.get(6), "Unique file number (UFN)", UFN, UFN);
     assertEnumTypeaheadRow(
         caseDetails.get(7), "Case stage or level", CASE_STAGE, "CASE_STAGE", CASE_STAGE);
-    assertSummaryListRowContainsValues(
+    assertBigDecimalInputRow(
         caseDetails.get(8),
         "Value of costs or damages recovered",
-        "£" + VALUE_OF_COSTS.toString(),
-        "TODO");
+        VALUE_OF_COSTS,
+        "VALUE_OF_COSTS");
     assertSummaryListRowContainsValues(
         caseDetails.get(9), "Procurement area", PROCUREMENT_AREA, PROCUREMENT_AREA);
     assertSummaryListRowContainsValues(
@@ -478,5 +478,20 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
         String.valueOf(expectedDate.getMonthValue()),
         selectedMonth.attr("value"),
         "Selected month value");
+  }
+
+  private void assertBigDecimalInputRow(
+      List<Element> row, String label, BigDecimal expectedValue, String inputId) {
+    assertCellContainsText(row.getFirst(), label);
+    assertCellContainsText(row.get(1), "£" + expectedValue);
+
+    Element amended = row.get(2);
+    Element inputWrapper = selectFirst(amended, ".govuk-input__wrapper");
+    Assertions.assertEquals("£", selectFirst(inputWrapper, ".govuk-input__prefix").text());
+
+    Element input = selectFirst(inputWrapper, "input.govuk-input--width-10");
+    Assertions.assertEquals(inputId, input.attr("id"), "BigDecimal input id");
+    Assertions.assertEquals(
+        expectedValue.toString(), input.attr("value"), "BigDecimal input value");
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
@@ -19,7 +19,6 @@ import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
-import uk.gov.justice.laa.amend.claim.utils.CurrencyUtils;
 import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
 
 @WebMvcTest(AmendCaseDetailsController.class)
@@ -479,22 +478,5 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
         String.valueOf(expectedDate.getMonthValue()),
         selectedMonth.attr("value"),
         "Selected month value");
-  }
-
-  private void assertBigDecimalInputRow(
-      List<Element> row, String label, BigDecimal expectedValue, String inputId) {
-    assertCellContainsText(row.getFirst(), label);
-    assertCellContainsText(row.get(1), CurrencyUtils.formatCurrency(expectedValue));
-
-    Element amended = row.get(2);
-    Element inputWrapper = selectFirst(amended, ".govuk-input__wrapper");
-    Assertions.assertEquals("£", selectFirst(inputWrapper, ".govuk-input__prefix").text());
-
-    Element input = selectFirst(inputWrapper, "input.govuk-input--width-10");
-    Assertions.assertEquals(inputId, input.attr("id"), "BigDecimal input id");
-    Assertions.assertEquals(
-        CurrencyUtils.setScale(expectedValue).toString(),
-        input.attr("value"),
-        "BigDecimal input value");
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
@@ -19,6 +19,7 @@ import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.utils.CurrencyUtils;
 import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
 
 @WebMvcTest(AmendCaseDetailsController.class)
@@ -35,7 +36,7 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
   private static final LocalDate CASE_CONCLUDED_DATE = LocalDate.of(2020, 2, 1);
   private static final String UFN = "ufn";
   private static final String CASE_STAGE = "MHL04";
-  private static final BigDecimal VALUE_OF_COSTS = BigDecimal.valueOf(10.12);
+  private static final BigDecimal VALUE_OF_COSTS = BigDecimal.valueOf(1234.5);
   private static final String PROCUREMENT_AREA = "procurementarea";
   private static final String ACCESS_POINT = "accesspoint";
   private static final String STAGE_REACHED = "INVA";
@@ -483,7 +484,7 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
   private void assertBigDecimalInputRow(
       List<Element> row, String label, BigDecimal expectedValue, String inputId) {
     assertCellContainsText(row.getFirst(), label);
-    assertCellContainsText(row.get(1), "£" + expectedValue);
+    assertCellContainsText(row.get(1), CurrencyUtils.formatCurrency(expectedValue));
 
     Element amended = row.get(2);
     Element inputWrapper = selectFirst(amended, ".govuk-input__wrapper");
@@ -492,6 +493,8 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
     Element input = selectFirst(inputWrapper, "input.govuk-input--width-10");
     Assertions.assertEquals(inputId, input.attr("id"), "BigDecimal input id");
     Assertions.assertEquals(
-        expectedValue.toString(), input.attr("value"), "BigDecimal input value");
+        CurrencyUtils.setScale(expectedValue).toString(),
+        input.attr("value"),
+        "BigDecimal input value");
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendmentsBaseTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendmentsBaseTest.java
@@ -1,10 +1,12 @@
 package uk.gov.justice.laa.amend.claim.views.amendments;
 
+import java.math.BigDecimal;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Assertions;
+import uk.gov.justice.laa.amend.claim.utils.CurrencyUtils;
 import uk.gov.justice.laa.amend.claim.views.ViewTestBase;
 
 public abstract class AmendmentsBaseTest extends ViewTestBase {
@@ -76,5 +78,22 @@ public abstract class AmendmentsBaseTest extends ViewTestBase {
     Element selectedOption = selectFirst(select, "option[selected]");
     Assertions.assertEquals(expectedValue, selectedOption.attr("value"));
     Assertions.assertEquals(currentValue, selectedOption.text());
+  }
+
+  protected void assertBigDecimalInputRow(
+      List<Element> row, String label, BigDecimal expectedValue, String inputId) {
+    assertCellContainsText(row.getFirst(), label);
+    assertCellContainsText(row.get(1), CurrencyUtils.formatCurrency(expectedValue));
+
+    Element amended = row.get(2);
+    Element inputWrapper = selectFirst(amended, ".govuk-input__wrapper");
+    Assertions.assertEquals("£", selectFirst(inputWrapper, ".govuk-input__prefix").text());
+
+    Element input = selectFirst(inputWrapper, "input.govuk-input--width-10");
+    Assertions.assertEquals(inputId, input.attr("id"), "BigDecimal input id");
+    Assertions.assertEquals(
+        CurrencyUtils.setScale(expectedValue).toString(),
+        input.attr("value"),
+        "BigDecimal input value");
   }
 }


### PR DESCRIPTION
## What is this PR?

[BC-691](https://dsdmoj.atlassian.net/browse/BC-691)

- Renders the **Value of costs or damages recovered** field on the amend Case Details screen as a currency input with a **£ prefix**



[BC-691]: https://dsdmoj.atlassian.net/browse/BC-691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ