### PR TITLE
Fix/null vs empty amendment comparison

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
@@ -98,15 +98,15 @@ public class AmendmentForm {
     var original = originalForm.getInputs().get(key);
     var current = inputs.get(key);
 
-    if (original == null && current == null) {
+    if (isBlank(original) && isBlank(current)) {
       return false;
     }
 
-    if (original == null || current == null) {
+    if (isBlank(original) || isBlank(current)) {
       return true;
     }
 
-    return !originalForm.getInputs().get(key).equals(getInputs().get(key));
+    return !original.equals(current);
   }
 
   public boolean hasAmendments(AmendmentForm original) {
@@ -230,7 +230,7 @@ public class AmendmentForm {
 
   private static String formatBooleanValue(String name, Object value) {
     return switch (value) {
-      case null -> "";
+      case null -> null;
       case Boolean booleanValue -> booleanValue.toString();
       default ->
           throw new IllegalArgumentException(
@@ -241,7 +241,7 @@ public class AmendmentForm {
 
   private static String formatNumberValue(String name, Object value) {
     return switch (value) {
-      case null -> "";
+      case null -> null;
       case Integer intValue -> intValue.toString();
       default ->
           throw new IllegalArgumentException(

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/ClaimFieldRow.java
@@ -115,7 +115,7 @@ public record ClaimFieldRow(
 
   public static ClaimFieldRow fromCustom(BoltOnClaimField claimField) {
     if (!claimField.hasSubmittedValue()) {
-      return createRow(claimField, "Not applicable", "Not applicable");
+      return createRow(claimField, null, null);
     }
     return createRow(claimField, claimField.getSubmitted(), claimField.getCalculated());
   }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentFormTest.java
@@ -76,13 +76,13 @@ class AmendmentFormTest {
   }
 
   @Test
-  void seedsNullBooleanFieldAsEmptyInput() {
+  void seedsNullBooleanFieldAsNullInput() {
     var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
     rows.put(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT, null);
 
     var form = new AmendmentForm(rows);
 
-    assertThat(form.getInputs()).containsEntry("IS_ELIGIBLE_CLIENT", "");
+    assertThat(form.getInputs()).containsEntry("IS_ELIGIBLE_CLIENT", null);
   }
 
   @Test
@@ -206,16 +206,40 @@ class AmendmentFormTest {
   }
 
   @Test
-  void seedsNullNumberFieldAsEmptyInput() {
+  void seedsNullNumberFieldAsNullInput() {
     var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
     rows.put(CivilClaimDetailsViewField.TRAVEL_TIME, null);
     var original = new AmendmentForm(rows);
 
-    assertThat(original.getInputs()).containsEntry("TRAVEL_TIME", "");
+    assertThat(original.getInputs()).containsEntry("TRAVEL_TIME", null);
 
     var current = new AmendmentForm();
     current.setInputs(new HashMap<>(Map.of("TRAVEL_TIME", "")));
     assertThat(current.isAmendment("TRAVEL_TIME", original)).isFalse();
+  }
+
+  @Test
+  void isAmendmentTreatsSeededEmptyNumberAndAbsentCurrentAsUnchanged() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.TRAVEL_TIME, null);
+    var original = new AmendmentForm(rows);
+
+    var current = new AmendmentForm();
+    current.setInputs(new HashMap<>());
+
+    assertThat(current.isAmendment("TRAVEL_TIME", original)).isFalse();
+  }
+
+  @Test
+  void isAmendmentTreatsSeededEmptyBooleanAndAbsentCurrentAsUnchanged() {
+    var rows = new LinkedHashMap<ClaimViewField<CivilClaimDetails>, Object>();
+    rows.put(CivilClaimDetailsViewField.IS_ELIGIBLE_CLIENT, null);
+    var original = new AmendmentForm(rows);
+
+    var current = new AmendmentForm();
+    current.setInputs(new HashMap<>());
+
+    assertThat(current.isAmendment("IS_ELIGIBLE_CLIENT", original)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
- Fix spurious "Not applicable" entries appearing in the amended column for boolean and number fields the user never changed.
