### PR TITLE
Make amend-ui auth profile overridable; drop redundant amend-ui-local.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,45 +31,7 @@ services:
       CLAIMS_TOKEN: f67f968e-b479-4e61-b66e-f57984931e56
       PROVIDER_API: ${PROVIDER_DETAILS_API_HOSTNAME}
       PROVIDER_TOKEN: ${PROVIDER_DETAILS_API_ACCESS_TOKEN}
-      SPRING_PROFILES_ACTIVE: docker
-      IS_BULK_UPLOAD_ENABLED: true
-      IS_REQUESTED_AND_CALCULATED_SWAP_ENABLED: true
-      IS_FULL_CLAIM_DETAILS_ENABLED: true
-      IS_CLAIM_AMENDMENT_ENABLED: true
-      JAVA_TOOL_OPTIONS: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005
-  amend-ui-local:
-    container_name: amend-a-claim-app
-    profiles:
-      - application-mocked-auth
-    depends_on:
-      - amend-redis
-    build:
-      context: .
-      dockerfile: Dockerfile
-      args:
-        - BUILD_SOURCE=internal
-      secrets:
-        - github_actor
-        - github_token
-    # Information on why these ports here: https://github.com/ministryofjustice/laa-data-claims-parent#exposed-ports
-    ports:
-      - "8090:8090"
-      - "8190:8190"
-      - "5090:5005"
-    environment:
-      AZURE_CLIENT_ID: ${AMEND_SILAS_CLIENT_ID}
-      AZURE_CLIENT_SECRET: ${AMEND_SILAS_CLIENT_SECRET}
-      AZURE_TENANT_ID: ${AMEND_SILAS_TENANT_ID}
-      BASE_URL_HOMEPAGE: http://localhost:8090
-      FEEDBACK_URL: https://www.smartsurvey.co.uk/s/AaBC_Beta_DevTest
-      LAA_URL: https://dev.your-legal-aid-services.service.justice.gov.uk
-      SENTRY_ENABLED: false # Disabled for docker environment
-      REDIS_URL: redis://amend-redis:6379
-      CLAIMS_API: http://host.docker.internal:8080
-      CLAIMS_TOKEN: f67f968e-b479-4e61-b66e-f57984931e56
-      PROVIDER_API: ${PROVIDER_DETAILS_API_HOSTNAME}
-      PROVIDER_TOKEN: ${PROVIDER_DETAILS_API_ACCESS_TOKEN}
-      SPRING_PROFILES_ACTIVE: local
+      SPRING_PROFILES_ACTIVE: ${AMEND_UI_SPRING_PROFILES_ACTIVE:-docker}
       IS_BULK_UPLOAD_ENABLED: true
       IS_REQUESTED_AND_CALCULATED_SWAP_ENABLED: true
       IS_FULL_CLAIM_DETAILS_ENABLED: true
@@ -81,7 +43,6 @@ services:
     restart: always
     profiles:
       - application
-      - application-mocked-auth
     ports:
       - "6390:6379" #Updated to 6390 to avoid conflict with SaBC Redis instance
     command: redis-server --appendonly yes
@@ -92,7 +53,6 @@ services:
     container_name: wiremock
     profiles:
       - application
-      - application-mocked-auth
     ports:
       - "8081:8080" # Expose WireMock on port 8081
     volumes:


### PR DESCRIPTION
Set amend-ui's SPRING_PROFILES_ACTIVE to ${AMEND_UI_SPRING_PROFILES_ACTIVE:-docker}
so developers can run the UI with the mocked-auth `local` profile via an env
var, without a separate service. Default stays `docker`, so existing behaviour is unchanged.

