### PR TITLE
BC-618: show assessed-claim warning banner on amend claim tabs.

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendmentsHeaderAdvice.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendmentsHeaderAdvice.java
@@ -1,0 +1,37 @@
+package uk.gov.justice.laa.amend.claim.controllers.amendments;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import uk.gov.justice.laa.amend.claim.exceptions.NoClaimInSessionException;
+import uk.gov.justice.laa.amend.claim.utils.SessionUtils;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderViewFactory;
+
+@ControllerAdvice(basePackageClasses = AmendmentsHeaderAdvice.class)
+@RequiredArgsConstructor
+public class AmendmentsHeaderAdvice {
+
+  private final AmendmentsHeaderViewFactory amendmentsHeaderViewFactory;
+
+  @ModelAttribute("amendmentsHeaderView")
+  public AmendmentsHeaderView amendmentsHeaderView(
+      HttpServletRequest request,
+      HttpSession session,
+      @PathVariable(required = false) UUID submissionId,
+      @PathVariable(required = false) UUID claimId) {
+    if (!"GET".equalsIgnoreCase(request.getMethod()) || submissionId == null || claimId == null) {
+      return null;
+    }
+    try {
+      var claim = SessionUtils.getClaim(session, submissionId, claimId);
+      return amendmentsHeaderViewFactory.create(claim);
+    } catch (NoClaimInSessionException e) {
+      return null;
+    }
+  }
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsController.java
@@ -7,6 +7,7 @@ import static uk.gov.justice.laa.amend.claim.utils.SessionUtils.saveAmendmentFor
 import jakarta.servlet.http.HttpSession;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -14,10 +15,13 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.amend.claim.annotations.HasRoleClaimAmendmentsCaseworker;
 import uk.gov.justice.laa.amend.claim.annotations.RequiresFeatureFlag;
 import uk.gov.justice.laa.amend.claim.config.features.Feature;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
 import uk.gov.justice.laa.amend.claim.viewmodels.claimcosts.ClaimCostsViewFactory;
 
 @Controller
@@ -44,6 +48,11 @@ public class CostsController {
       Model model,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
+    var claim = getValidClaim(session, submissionId, claimId);
+    if (AmendmentsHeaderView.isAssessed(claim)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
+
     addCostsModelAttributes(session, model, submissionId, claimId);
 
     return "amendments/amend-costs";
@@ -55,12 +64,31 @@ public class CostsController {
       @ModelAttribute("costsForm") AmendmentForm costsForm,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
-    var amendmentForms = getAmendmentForms(session, claimId);
+    var claim = getValidClaim(session, submissionId, claimId);
+    if (AmendmentsHeaderView.isAssessed(claim)) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
 
+    retainEditableInputs(costsForm, claim);
+
+    var amendmentForms = getAmendmentForms(session, claimId);
     amendmentForms.getCostsForm().setCurrent(costsForm);
     saveAmendmentForms(session, claimId, amendmentForms);
 
+    return redirectToViewCosts(submissionId, claimId);
+  }
+
+  private static String redirectToViewCosts(UUID submissionId, UUID claimId) {
     return "redirect:/submissions/%s/claims/%s/amendments/costs".formatted(submissionId, claimId);
+  }
+
+  private static void retainEditableInputs(AmendmentForm costsForm, ClaimDetails claim) {
+    var editableFieldNames =
+        ClaimCostsViewFactory.create(claim).costFields().keySet().stream()
+            .filter(field -> field.isEditable())
+            .map(field -> field.name())
+            .toList();
+    costsForm.getInputs().keySet().retainAll(editableFieldNames);
   }
 
   private void addCostsModelAttributes(

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderView.java
@@ -1,0 +1,29 @@
+package uk.gov.justice.laa.amend.claim.viewmodels;
+
+import java.util.Optional;
+import org.springframework.web.util.HtmlUtils;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.MicrosoftApiUser;
+import uk.gov.justice.laa.amend.claim.utils.DateUtils;
+
+public record AmendmentsHeaderView(boolean assessedAlertPresent, ThymeleafMessage alertContent) {
+
+  public AmendmentsHeaderView(ClaimDetails claim, MicrosoftApiUser user) {
+    this(isAssessed(claim), alertContent(claim, user));
+  }
+
+  public static boolean isAssessed(ClaimDetails claim) {
+    return claim.isHasAssessment() && claim.getLastAssessment() != null;
+  }
+
+  private static ThymeleafMessage alertContent(ClaimDetails claim, MicrosoftApiUser user) {
+    String date = DateUtils.displayDateTimeDateValue(claim.getLastUpdatedDateTime());
+    String time = DateUtils.displayDateTimeTimeValue(claim.getLastUpdatedDateTime());
+
+    Optional<String> userName =
+        Optional.ofNullable(user).map(MicrosoftApiUser::name).map(HtmlUtils::htmlEscape);
+    return userName
+        .map(name -> new ThymeleafMessage("amendments.assessed.body", name, date, time))
+        .orElseGet(() -> new ThymeleafMessage("amendments.assessed.body.noUser", date, time));
+  }
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderViewFactory.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderViewFactory.java
@@ -1,0 +1,33 @@
+package uk.gov.justice.laa.amend.claim.viewmodels;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.MicrosoftApiUser;
+import uk.gov.justice.laa.amend.claim.service.UserRetrievalService;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmendmentsHeaderViewFactory {
+
+  private final UserRetrievalService userRetrievalService;
+
+  public AmendmentsHeaderView create(ClaimDetails claim) {
+    MicrosoftApiUser user = null;
+    if (AmendmentsHeaderView.isAssessed(claim) && claim.getLastUpdatedUser() != null) {
+      user = resolveUser(claim.getLastUpdatedUser());
+    }
+    return new AmendmentsHeaderView(claim, user);
+  }
+
+  private MicrosoftApiUser resolveUser(String userId) {
+    try {
+      return userRetrievalService.getUser(userId);
+    } catch (RuntimeException e) {
+      log.warn("Could not resolve last-updated user {} for assessed-claim banner", userId, e);
+      return null;
+    }
+  }
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -570,6 +570,10 @@ bulkUploadResult.errorTable.errorHeader=Error
 bulkUploadResult.errorTable.noRow=N/A
 
 amendments.amended=Amended
+amendments.assessed.alert.h2=This claim has been assessed
+amendments.assessed.alert.ariaLabel=warning: This claim has been assessed
+amendments.assessed.body=You cannot amend anything that would change the overall value of the claim.<br/>Last edited by {0} on {1} at {2}
+amendments.assessed.body.noUser=You cannot amend anything that would change the overall value of the claim.<br/>Last edited on {0} at {1}
 amendments.backToClaim=Back to claim details
 amendments.change=Change
 amendments.continue=Continue

--- a/src/main/resources/templates/amendments/amend-case-details.html
+++ b/src/main/resources/templates/amendments/amend-case-details.html
@@ -12,6 +12,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+      <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBanner}"></th:block>
+
       <h1 class="govuk-heading-l">
         <span th:text="#{amendments.title}"></span>
       </h1>

--- a/src/main/resources/templates/amendments/amend-client-1.html
+++ b/src/main/resources/templates/amendments/amend-client-1.html
@@ -12,6 +12,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+      <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBanner}"></th:block>
+
       <h1 class="govuk-heading-l">
         <span th:text="#{amendments.title}"></span>
       </h1>

--- a/src/main/resources/templates/amendments/amend-client-2.html
+++ b/src/main/resources/templates/amendments/amend-client-2.html
@@ -12,6 +12,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+      <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBanner}"></th:block>
+
       <h1 class="govuk-heading-l">
         <span th:text="#{amendments.title}"></span>
       </h1>

--- a/src/main/resources/templates/amendments/amend-fee-code.html
+++ b/src/main/resources/templates/amendments/amend-fee-code.html
@@ -9,6 +9,7 @@
     )}">
 <body>
 <main class="govuk-main-wrapper" id="main-content">
+  <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBannerRow}"></th:block>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/src/main/resources/templates/amendments/amend-matter-type.html
+++ b/src/main/resources/templates/amendments/amend-matter-type.html
@@ -9,6 +9,7 @@
     )}">
 <body>
 <main class="govuk-main-wrapper" id="main-content">
+  <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBannerRow}"></th:block>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-half">
 

--- a/src/main/resources/templates/amendments/check-your-answers.html
+++ b/src/main/resources/templates/amendments/check-your-answers.html
@@ -12,6 +12,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
+      <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBanner}"></th:block>
+
       <h1 class="govuk-heading-l">
         <span th:text="#{amendments.check.title}"></span>
       </h1>

--- a/src/main/resources/templates/amendments/view-costs.html
+++ b/src/main/resources/templates/amendments/view-costs.html
@@ -20,7 +20,8 @@
       <div class="govuk-summary-card">
         <div class="govuk-summary-card__title-wrapper">
           <h2 class="govuk-summary-card__title" th:text="#{claimCosts.listOfCosts}"></h2>
-          <ul class="govuk-summary-card__actions">
+          <ul class="govuk-summary-card__actions"
+              th:if="${amendmentsHeaderView == null || !amendmentsHeaderView.assessedAlertPresent}">
             <li class="govuk-summary-card__action">
               <a class="govuk-link"
                  id="amend-costs-link"

--- a/src/main/resources/templates/partials/amendments-assessed-banner.html
+++ b/src/main/resources/templates/partials/amendments-assessed-banner.html
@@ -1,0 +1,13 @@
+<th:block th:fragment="assessedBanner" xmlns:th="http://www.thymeleaf.org">
+    <th:block th:if="${amendmentsHeaderView != null && amendmentsHeaderView.assessedAlertPresent}">
+        <th:block th:replace="~{partials/warning-alert :: warningAlert('amendments.assessed', ${amendmentsHeaderView.alertContent.resolve(#messages)})}"></th:block>
+    </th:block>
+</th:block>
+
+<th:block th:fragment="assessedBannerRow" xmlns:th="http://www.thymeleaf.org">
+    <div class="govuk-grid-row" th:if="${amendmentsHeaderView != null && amendmentsHeaderView.assessedAlertPresent}">
+        <div class="govuk-grid-column-full">
+            <th:block th:replace="~{partials/warning-alert :: warningAlert('amendments.assessed', ${amendmentsHeaderView.alertContent.resolve(#messages)})}"></th:block>
+        </div>
+    </div>
+</th:block>

--- a/src/main/resources/templates/partials/amendments-view-header.html
+++ b/src/main/resources/templates/partials/amendments-view-header.html
@@ -1,5 +1,7 @@
 <th:block th:fragment="viewHeader(currentPage)" xmlns:th="http://www.thymeleaf.org">
 
+    <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBanner}"></th:block>
+
     <h1 class="govuk-heading-l">
         <span th:text="#{amendments.title}"></span>
     </h1>

--- a/src/main/resources/templates/partials/warning-alert.html
+++ b/src/main/resources/templates/partials/warning-alert.html
@@ -1,0 +1,13 @@
+<th:block th:fragment="warningAlert(prefix,content)" xmlns:th="http://www.thymeleaf.org">
+    <div role="region" class="moj-alert moj-alert--warning" id="warning-alert" th:with="key=${prefix} + '.alert.ariaLabel'" th:aria-label="#{${key}}" data-module="moj-alert">
+        <div>
+            <svg class="moj-alert__icon" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 30" height="30" width="30">
+                <path fill-rule="evenodd" clip-rule="evenodd" d="M15 2.44922L28.75 26.1992H1.25L15 2.44922ZM13.5107 9.49579H16.4697L16.2431 17.7678H13.7461L13.5107 9.49579ZM13.1299 21.82C13.1299 21.5661 13.1787 21.3285 13.2764 21.1071C13.374 20.8793 13.5075 20.6807 13.6768 20.5114C13.8525 20.3421 14.0544 20.2087 14.2822 20.111C14.5101 20.0134 14.7542 19.9645 15.0146 19.9645C15.2686 19.9645 15.5062 20.0134 15.7275 20.111C15.9554 20.2087 16.154 20.3421 16.3232 20.5114C16.4925 20.6807 16.626 20.8793 16.7236 21.1071C16.8213 21.3285 16.8701 21.5661 16.8701 21.82C16.8701 22.0804 16.8213 22.3246 16.7236 22.5524C16.626 22.7803 16.4925 22.9789 16.3232 23.1481C16.154 23.3174 15.9554 23.4509 15.7275 23.5485C15.5062 23.6462 15.2686 23.695 15.0146 23.695C14.7542 23.695 14.5101 23.6462 14.2822 23.5485C14.0544 23.4509 13.8525 23.3174 13.6768 23.1481C13.5075 22.9789 13.374 22.7803 13.2764 22.5524C13.1787 22.3246 13.1299 22.0804 13.1299 21.82Z" fill="currentColor" />
+            </svg>
+        </div>
+        <div class="moj-alert__content">
+            <h2 class="moj-alert__heading" th:with="key=${prefix} + '.alert.h2'" th:text="#{${key}}"></h2>
+            <span th:utext="${content}"></span>
+        </div>
+    </div>
+</th:block>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/config/ViewTestConfig.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/config/ViewTestConfig.java
@@ -3,6 +3,7 @@ package uk.gov.justice.laa.amend.claim.config;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderViewFactory;
 
 @TestConfiguration
 public class ViewTestConfig {
@@ -10,5 +11,10 @@ public class ViewTestConfig {
   @Bean
   DateWrapperUtil dateWrapperUtil() {
     return new DateWrapperUtil();
+  }
+
+  @Bean
+  AmendmentsHeaderViewFactory amendmentsHeaderViewFactory() {
+    return new AmendmentsHeaderViewFactory(userId -> null);
   }
 }

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/BaseControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/BaseControllerTest.java
@@ -14,6 +14,7 @@ import uk.gov.justice.laa.amend.claim.config.security.LocalSecurityConfig;
 import uk.gov.justice.laa.amend.claim.models.enums.Role;
 import uk.gov.justice.laa.amend.claim.service.DummyUserSecurityService;
 import uk.gov.justice.laa.amend.claim.service.MaintenanceService;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderViewFactory;
 
 @ActiveProfiles("local")
 @WebMvcTest(ConfirmationController.class)
@@ -29,6 +30,8 @@ public abstract class BaseControllerTest {
   @MockitoBean protected MaintenanceService maintenanceService;
 
   @MockitoBean protected OutageBannerAdvice outageBannerAdvice;
+
+  @MockitoBean protected AmendmentsHeaderViewFactory amendmentsHeaderViewFactory;
 
   @BeforeEach
   public void beforeEach() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendClientTabControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendClientTabControllerTest.java
@@ -1,5 +1,7 @@
 package uk.gov.justice.laa.amend.claim.controllers.amendments;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,6 +19,7 @@ import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.enums.AreaOfLaw;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
 
 @WebMvcTest(controllers = {AmendClientTabController.class})
 class AmendClientTabControllerTest extends BaseControllerTest {
@@ -44,6 +47,8 @@ class AmendClientTabControllerTest extends BaseControllerTest {
     claim.setClaimId(claimId);
     MockClaimsFunctions.updateStatus(claim, claim.getAssessmentOutcome());
     session.setAttribute(claimId.toString(), claim);
+    when(amendmentsHeaderViewFactory.create(any()))
+        .thenReturn(new AmendmentsHeaderView(false, null));
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsControllerTest.java
@@ -1,6 +1,8 @@
 package uk.gov.justice.laa.amend.claim.controllers.amendments;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -19,7 +21,10 @@ import uk.gov.justice.laa.amend.claim.controllers.BaseControllerTest;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 
 @WebMvcTest(controllers = CostsController.class)
 class CostsControllerTest extends BaseControllerTest {
@@ -41,6 +46,8 @@ class CostsControllerTest extends BaseControllerTest {
     claim.setClaimId(claimId);
     MockClaimsFunctions.updateStatus(claim, claim.getAssessmentOutcome());
     session.setAttribute(claimId.toString(), claim);
+    when(amendmentsHeaderViewFactory.create(any()))
+        .thenReturn(new AmendmentsHeaderView(false, null));
   }
 
   @Test
@@ -78,6 +85,54 @@ class CostsControllerTest extends BaseControllerTest {
   }
 
   @Test
+  void getAmendCostsReturnsNotFoundWhenClaimAssessed() throws Exception {
+    claim.setStatus(ClaimStatus.VALID);
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
+
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    mockMvc
+        .perform(get(buildAmendCostsPath()).session(session).with(csrf()))
+        .andExpect(status().isNotFound());
+  }
+
+  @Test
+  void postAmendCostsReturnsNotFoundWithoutSavingWhenClaimAssessed() throws Exception {
+    claim.setStatus(ClaimStatus.VALID);
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
+
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    mockMvc
+        .perform(
+            post(buildAmendCostsPath())
+                .param(INPUTS.formatted("PROFIT_COST"), "150.25")
+                .session(session)
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+
+    AmendmentForms unchanged =
+        (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
+    assertThat(unchanged.getCostsForm().getCurrent().getInputs().get("PROFIT_COST")).isNull();
+  }
+
+  @Test
   void postCostsAsExpected() throws Exception {
     var forms =
         AmendmentForms.builder()
@@ -102,6 +157,58 @@ class CostsControllerTest extends BaseControllerTest {
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCostsForm().getCurrent().getInputs().get("PROFIT_COST"))
         .isEqualTo("150.25");
+  }
+
+  @Test
+  void postIgnoresTamperedNonEditableCostInput() throws Exception {
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var request =
+        post(buildAmendCostsPath())
+            .param(INPUTS.formatted("FIXED_FEE"), "9999")
+            .param(INPUTS.formatted("PROFIT_COST"), "150.25")
+            .session(session)
+            .with(csrf());
+
+    mockMvc.perform(request).andExpect(status().is3xxRedirection());
+
+    AmendmentForms updatedForm =
+        (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
+    var inputs = updatedForm.getCostsForm().getCurrent().getInputs();
+    assertThat(inputs.get("FIXED_FEE")).isNull();
+    assertThat(inputs.get("PROFIT_COST")).isEqualTo("150.25");
+  }
+
+  @Test
+  void postDropsUnknownCostInput() throws Exception {
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var request =
+        post(buildAmendCostsPath())
+            .param(INPUTS.formatted("NOT_A_REAL_FIELD"), "666")
+            .param(INPUTS.formatted("PROFIT_COST"), "150.25")
+            .session(session)
+            .with(csrf());
+
+    mockMvc.perform(request).andExpect(status().is3xxRedirection());
+
+    AmendmentForms updatedForm =
+        (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
+    var inputs = updatedForm.getCostsForm().getCurrent().getInputs();
+    assertThat(inputs.containsKey("NOT_A_REAL_FIELD")).isFalse();
+    assertThat(inputs.get("PROFIT_COST")).isEqualTo("150.25");
   }
 
   private String buildCostsPath() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderViewFactoryTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderViewFactoryTest.java
@@ -1,0 +1,86 @@
+package uk.gov.justice.laa.amend.claim.viewmodels;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.amend.claim.models.AssessmentInfo;
+import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.MicrosoftApiUser;
+import uk.gov.justice.laa.amend.claim.models.enums.OutcomeType;
+import uk.gov.justice.laa.amend.claim.service.UserRetrievalService;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+@ExtendWith(MockitoExtension.class)
+class AmendmentsHeaderViewFactoryTest {
+
+  @Mock private UserRetrievalService userRetrievalService;
+
+  @InjectMocks private AmendmentsHeaderViewFactory factory;
+
+  private CivilClaimDetails assessedClaim() {
+    var claim = new CivilClaimDetails();
+    claim.setStatus(ClaimStatus.VALID);
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(
+        AssessmentInfo.builder().lastAssessmentOutcome(OutcomeType.NILLED).build());
+    claim.setLastUpdatedUser("user-id");
+    claim.setLastUpdatedDateTime(OffsetDateTime.now());
+    return claim;
+  }
+
+  @Test
+  void resolvesUserWhenAssessed() {
+    when(userRetrievalService.getUser("user-id"))
+        .thenReturn(new MicrosoftApiUser("user-id", "Joe Bloggs", "Joe", "Bloggs"));
+
+    var view = factory.create(assessedClaim());
+
+    assertThat(view.assessedAlertPresent()).isTrue();
+    assertThat(view.alertContent().getKey()).isEqualTo("amendments.assessed.body");
+    assertThat(view.alertContent().getParams()[0]).isEqualTo("Joe Bloggs");
+  }
+
+  @Test
+  void stillRendersBannerWhenUserLookupFails() {
+    when(userRetrievalService.getUser("user-id")).thenThrow(new RuntimeException("graph down"));
+
+    var view = factory.create(assessedClaim());
+
+    assertThat(view.assessedAlertPresent()).isTrue();
+    assertThat(view.alertContent().getKey()).isEqualTo("amendments.assessed.body.noUser");
+  }
+
+  @Test
+  void doesNotLookUpUserWhenLastAssessmentMissing() {
+    var claim = new CivilClaimDetails();
+    claim.setStatus(ClaimStatus.VALID);
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(null);
+    claim.setLastUpdatedUser("user-id");
+
+    var view = factory.create(claim);
+
+    assertThat(view.assessedAlertPresent()).isFalse();
+    verify(userRetrievalService, never()).getUser("user-id");
+  }
+
+  @Test
+  void doesNotLookUpUserWhenNoLastUpdatedUser() {
+    var claim = assessedClaim();
+    claim.setLastUpdatedUser(null);
+
+    var view = factory.create(claim);
+
+    assertThat(view.assessedAlertPresent()).isTrue();
+    assertThat(view.alertContent().getKey()).isEqualTo("amendments.assessed.body.noUser");
+    verify(userRetrievalService, never()).getUser(null);
+  }
+}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/AmendmentsHeaderViewTest.java
@@ -1,0 +1,77 @@
+package uk.gov.justice.laa.amend.claim.viewmodels;
+
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.amend.claim.models.AssessmentInfo;
+import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.MicrosoftApiUser;
+import uk.gov.justice.laa.amend.claim.models.enums.OutcomeType;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+
+class AmendmentsHeaderViewTest {
+
+  private CivilClaimDetails assessedClaim() {
+    var claim = new CivilClaimDetails();
+    var assessmentInfo =
+        AssessmentInfo.builder()
+            // UTC 14:30:00 on a BST day (June) = London 3:30pm
+            .lastAssessmentDate(
+                OffsetDateTime.of(LocalDateTime.of(2025, 6, 15, 14, 30, 0), ZoneOffset.UTC))
+            .lastAssessmentOutcome(OutcomeType.NILLED)
+            .build();
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(assessmentInfo);
+    claim.setLastUpdatedUser(assessmentInfo.lastAssessedBy());
+    claim.setLastUpdatedDateTime(assessmentInfo.lastAssessmentDate());
+    claim.setStatus(ClaimStatus.VALID);
+    return claim;
+  }
+
+  @Test
+  void showsAssessedAlertWithUserDateAndTime() {
+    var user = new MicrosoftApiUser("id", "Bloggs, Joe", "Joe", "Bloggs");
+
+    var viewModel = new AmendmentsHeaderView(assessedClaim(), user);
+
+    Assertions.assertTrue(viewModel.assessedAlertPresent());
+    ThymeleafMessage content = viewModel.alertContent();
+    Assertions.assertEquals("amendments.assessed.body", content.getKey());
+    Assertions.assertEquals("Joe Bloggs", content.getParams()[0]);
+    Assertions.assertEquals("15 June 2025", content.getParams()[1]);
+    Assertions.assertEquals("3:30pm", content.getParams()[2]);
+  }
+
+  @Test
+  void escapesHtmlInUserName() {
+    var user = new MicrosoftApiUser("id", "<script>alert(1)</script>", null, null);
+
+    var viewModel = new AmendmentsHeaderView(assessedClaim(), user);
+
+    ThymeleafMessage content = viewModel.alertContent();
+    Assertions.assertEquals("&lt;script&gt;alert(1)&lt;/script&gt;", content.getParams()[0]);
+  }
+
+  @Test
+  void usesNoUserMessageWhenUserIsNull() {
+    var viewModel = new AmendmentsHeaderView(assessedClaim(), null);
+
+    ThymeleafMessage content = viewModel.alertContent();
+    Assertions.assertEquals("amendments.assessed.body.noUser", content.getKey());
+    Assertions.assertEquals("15 June 2025", content.getParams()[0]);
+    Assertions.assertEquals("3:30pm", content.getParams()[1]);
+  }
+
+  @Test
+  void doesNotShowAlertWhenClaimNotAssessed() {
+    var claim = new CivilClaimDetails();
+    claim.setHasAssessment(false);
+    claim.setStatus(ClaimStatus.VALID);
+
+    var viewModel = new AmendmentsHeaderView(claim, null);
+
+    Assertions.assertFalse(viewModel.assessedAlertPresent());
+  }
+}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
@@ -435,6 +435,18 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
     assertPageHasLink(doc, "cancel", "Cancel", caseUrl);
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private static @NonNull AmendmentForms createCaseForms(ClaimDetails claimDetails) {
     var view = ClaimCaseViewFactory.create(claimDetails);
     return AmendmentForms.builder()

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseTabViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseTabViewTest.java
@@ -654,6 +654,18 @@ class AmendCaseTabViewTest extends AmendmentsBaseTest {
     assertPageHasLink(doc, "amend-case-details-link", "Change", amendCaseDetailsUrl);
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private static @NonNull AmendmentForms createCaseForms(ClaimDetails claimDetails) {
     var view = ClaimCaseViewFactory.create(claimDetails);
     return AmendmentForms.builder()

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClient1ViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClient1ViewTest.java
@@ -211,6 +211,19 @@ class AmendClient1ViewTest extends AmendmentsBaseTest {
     Assertions.assertEquals("1", selectedMonth.attr("value"), "Selected month value");
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId), MockAmendmentFormsFunctions.justClient1Filled(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private void assertCommonPageContent(Document doc) {
     assertPageHasTitle(doc, "Amend claim details");
     assertPageHasHeading(doc, "Amend claim details");

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClient2ViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClient2ViewTest.java
@@ -117,6 +117,19 @@ class AmendClient2ViewTest extends AmendmentsBaseTest {
     Assertions.assertEquals("1", selectedMonth.attr("value"), "Selected month value");
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockMediationClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId), MockAmendmentFormsFunctions.justClient2Filled(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private void assertCommonPageContent(Document doc) {
     assertPageHasTitle(doc, "Amend claim details");
     assertPageHasHeading(doc, "Amend claim details");

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClientTabViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendClientTabViewTest.java
@@ -399,6 +399,18 @@ class AmendClientTabViewTest extends AmendmentsBaseTest {
     assertPageHasLink(doc, "cancel", "Cancel", overviewUrl);
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createClientForms(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private AmendmentForms createClientForms(ClaimDetails claim) {
     var view = ClaimClientViewFactory.create(claim);
     return AmendmentForms.builder()

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendFeeCodeViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendFeeCodeViewTest.java
@@ -49,6 +49,20 @@ class AmendFeeCodeViewTest extends AmendmentsBaseTest {
     assertAutocompleteDropDownList(doc, "Amended fee code", "ABC");
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    claim.setFeeCode(FEE_CODE);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseTypeForm(claim));
+    when(availableFeeCodesService.getAvailableFeeCodes(any())).thenReturn(Map.of(FEE_CODE, "ABC"));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private AmendmentForms createCaseTypeForm(ClaimDetails claim) {
     var view = ClaimCaseViewFactory.create(claim);
     return AmendmentForms.builder()

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendMatterTypeCodeViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendMatterTypeCodeViewTest.java
@@ -84,6 +84,24 @@ class AmendMatterTypeCodeViewTest extends AmendmentsBaseTest {
     assertPageHasLabel(doc, "matter-type-two-input", "Amended matter type 2");
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    this.claim = claim;
+    this.claim.setAreaOfLaw(AreaOfLaw.LEGAL_HELP);
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    claim.setFeeCode(FEE_CODE);
+    claim.setMatterType1(MATTER_TYPE_CODE_1);
+    claim.setMatterType2(MATTER_TYPE_CODE_2);
+    markAssessed(claim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId), MockAmendmentFormsFunctions.justCaseTypeFilled(claim));
+    when(availableFeeCodesService.getAvailableFeeCodes(any())).thenReturn(Map.of(FEE_CODE, "ABC"));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private void assertCommonPageContent(Document doc) {
     assertPageHasTitle(doc, "Amend claim details");
     assertPageHasHeading(doc, "Amend matter type");

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendmentsBaseTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendmentsBaseTest.java
@@ -1,13 +1,19 @@
 package uk.gov.justice.laa.amend.claim.views.amendments;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.util.List;
+import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Assertions;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.AssessmentTypeEnum;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.utils.CurrencyUtils;
 import uk.gov.justice.laa.amend.claim.views.ViewTestBase;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 
 public abstract class AmendmentsBaseTest extends ViewTestBase {
 
@@ -58,6 +64,26 @@ public abstract class AmendmentsBaseTest extends ViewTestBase {
     checkUrl = "/submissions/%s/claims/%s/amendments/check".formatted(submissionId, claimId);
     confirmationUrl =
         "/submissions/%s/claims/%s/amendments/confirmation".formatted(submissionId, claimId);
+  }
+
+  protected void markAssessed(ClaimDetails claim) {
+    claim.setStatus(ClaimStatus.VALID);
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
+    claim.setLastUpdatedDateTime(OffsetDateTime.now());
+  }
+
+  protected void assertShowsAssessedBanner(Document doc) {
+    Element alert = selectFirst(doc, "#warning-alert");
+    Assertions.assertEquals(
+        "This claim has been assessed", selectFirst(alert, ".moj-alert__heading").text());
+    Assertions.assertTrue(
+        alert
+            .text()
+            .contains(
+                "You cannot amend anything that would change the overall value of the claim."),
+        "Expected assessed warning banner body text");
   }
 
   protected void assertBooleanSelectRow(

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/CheckAmendmentsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/CheckAmendmentsViewTest.java
@@ -240,6 +240,18 @@ class CheckAmendmentsViewTest extends AmendmentsBaseTest {
     assertPageHasLink(doc, "change-costs", "Change", amendCostsUrl);
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    setupClaim(claim);
+    markAssessed(claim);
+    var forms = createCrimeForms(claim);
+    forms.getClient1Form().getCurrent().getInputs().put("SURNAME", "changedSurname");
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private void setupClaim(ClaimDetails claim) {
     this.claim = claim;
     claim.setSubmissionId(submissionId);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/ViewCostsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/ViewCostsViewTest.java
@@ -83,6 +83,33 @@ class ViewCostsViewTest extends AmendmentsBaseTest {
     Assertions.assertEquals(3, costs.getFirst().size(), "Amended column should not be shown");
   }
 
+  @Test
+  void hidesChangeLinkWhenClaimAssessed() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCostsForms(claim));
+
+    var doc = renderDocument();
+
+    Assertions.assertTrue(
+        doc.select("#amend-costs-link").isEmpty(), "Change link should be hidden when assessed");
+  }
+
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCostsForms(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private static AmendmentForms createCostsForms(ClaimDetails claimDetails) {
     var costsForm = new AmendmentForm(ClaimCostsViewFactory.create(claimDetails).costRows());
     return AmendmentForms.builder()


### PR DESCRIPTION
## What is this PR?

[BC-618](https://dsdmoj.atlassian.net/browse/BC-618)

When a claim has already been assessed, the amend flow now shows the "This claim has been assessed" banner warning that amendments must not change the overall claim value.

<img width="1081" height="621" alt="Screenshot 2026-08-04 at 15 45 17" src="https://github.com/user-attachments/assets/b2564e91-c328-42d9-b354-970a65a0fe1e" />









[BC-618]: https://dsdmoj.atlassian.net/browse/BC-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ