### PR TITLE
BC-662 | Added validation for stage reach screen

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeController.java
@@ -129,7 +129,9 @@ public class AmendCaseTypeController extends AbstractAmendController {
   @PostMapping("/amend-stage-reached")
   public String postAmendStageReached(
       HttpSession session,
-      @ModelAttribute("caseTypeForm") AmendmentForm caseTypeForm,
+      @Valid @ModelAttribute("caseTypeForm") AmendmentForm caseTypeForm,
+      BindingResult bindingResult,
+      RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
     var claim = getValidClaim(session, submissionId, claimId);
@@ -142,6 +144,15 @@ public class AmendCaseTypeController extends AbstractAmendController {
 
     amendmentForms.getCaseTypeForm().setCurrent(caseTypeForm);
     saveAmendmentForms(session, claimId, amendmentForms);
+
+    if (bindingResult.hasErrors()) {
+      return redirectWithErrors(
+          redirectAttributes,
+          bindingResult,
+          "caseTypeFormErrors",
+          "/submissions/%s/claims/%s/amendments/amend-stage-reached"
+              .formatted(submissionId, claimId));
+    }
 
     return "redirect:/submissions/%s/claims/%s/amendments/case".formatted(submissionId, claimId);
   }

--- a/src/main/resources/templates/amendments/amend-fee-code.html
+++ b/src/main/resources/templates/amendments/amend-fee-code.html
@@ -13,16 +13,17 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">
-        <span th:text="#{amendments.feeCode.title}"></span>
-      </h1>
 
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-fee-code(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${caseTypeForm}"
             th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
-
         <th:block th:replace="~{partials/error-summary :: error-summary(${formErrors})}"></th:block>
+
+
+        <h1 class="govuk-heading-l">
+          <span th:text="#{amendments.feeCode.title}"></span>
+        </h1>
 
         <input type="hidden" th:each="entry : *{inputs}"
                th:if="${entry.key != 'FEE_CODE'}"
@@ -39,11 +40,14 @@
           </div>
         </dl>
 
-        <div class="govuk-body">
+        <div class="govuk-form-group"
+             th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'FEE_CODE') ? 'govuk-form-group--error' : ''}">
           <div class="autocomplete-wrapper">
             <span id="FEE_CODE"></span>
-            <label class="govuk-label govuk-!-font-weight-bold" for="fee-code-input" th:text="#{amendments.feeCode.amended}"></label>
-            <th:block th:replace="~{partials/amendments/field-error :: fieldError('FEE_CODE', ${formErrors})}"></th:block>
+            <label class="govuk-label govuk-!-font-weight-bold" for="fee-code-input"
+                   th:text="#{amendments.feeCode.amended}"></label>
+            <th:block
+                th:replace="~{partials/amendments/field-error :: fieldError('FEE_CODE', ${formErrors})}"></th:block>
             <select class="govuk-select" id="fee-code-input"
                     th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'FEE_CODE') ? 'govuk-select--error' : ''}"
                     th:field="*{inputs['FEE_CODE']}"

--- a/src/main/resources/templates/amendments/amend-matter-type.html
+++ b/src/main/resources/templates/amendments/amend-matter-type.html
@@ -9,14 +9,17 @@
     )}">
 <body>
 <main class="govuk-main-wrapper" id="main-content">
-  <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBannerRow}"></th:block>
-  <div class="govuk-grid-row">
 
 
-    <form method="post"
-          th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-matter-type(submissionId=${submissionId}, claimId=${claimId})}"
-          th:object="${caseTypeForm}"
-          th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+  <form method="post"
+        th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-matter-type(submissionId=${submissionId}, claimId=${claimId})}"
+        th:object="${caseTypeForm}"
+        th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+    <div class="govuk-grid-row">
+
+      <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBannerRow}"></th:block>
+
+
       <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">
           <span th:text="#{amendments.matterType.title}"></span>
@@ -41,7 +44,8 @@
         </dl>
 
         <input type="hidden" th:field="*{inputs['FEE_CODE']}"/>
-        <div class="govuk-form-group" th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_1') ? 'govuk-form-group--error' : ''}">
+        <div class="govuk-form-group"
+             th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_1') ? 'govuk-form-group--error' : ''}">
           <span id="MATTER_TYPE_CODE_1"></span>
           <label class="govuk-label govuk-!-font-weight-bold" for="matter-type-one-input"
                  th:text="#{amendments.matterType.amended.one}"/>
@@ -52,7 +56,8 @@
                  th:field="*{inputs['MATTER_TYPE_CODE_1']}"
                  type="text">
         </div>
-        <div class="govuk-form-group" th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_2') ? 'govuk-form-group--error' : ''}">
+        <div class="govuk-form-group"
+             th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_2') ? 'govuk-form-group--error' : ''}">
           <span id="MATTER_TYPE_CODE_2"></span>
           <label class="govuk-label govuk-!-font-weight-bold" for="matter-type-two-input"
                  th:text="#{amendments.matterType.amended.two}"/>
@@ -72,8 +77,8 @@
           </a>
         </div>
       </div>
-    </form>
-  </div>
+    </div>
+  </form>
 </main>
 </body>
 </html>

--- a/src/main/resources/templates/amendments/amend-matter-type.html
+++ b/src/main/resources/templates/amendments/amend-matter-type.html
@@ -11,55 +11,58 @@
 <main class="govuk-main-wrapper" id="main-content">
   <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBannerRow}"></th:block>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-half">
 
-      <h1 class="govuk-heading-l">
-        <span th:text="#{amendments.matterType.title}"></span>
-      </h1>
 
-      <dl class="govuk-summary-list"
-          th:with="originalMatterTypes=${forms.caseTypeForm.getOriginal()}">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key govuk-!-width-one-half"
-              th:text="#{amendments.matterType.current.one}"/>
-          <dd class="govuk-summary-list__value"
-              th:text="${originalMatterTypes.getInputs()['MATTER_TYPE_CODE_1']}"/>
-        </div>
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key govuk-!-width-one-half"
-              th:text="#{amendments.matterType.current.two}"/>
-          <dd class="govuk-summary-list__value"
-              th:text="${originalMatterTypes.getInputs()['MATTER_TYPE_CODE_2']}"/>
-        </div>
-      </dl>
-      <form method="post"
-            th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-matter-type(submissionId=${submissionId}, claimId=${claimId})}"
-            th:object="${caseTypeForm}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
-
+    <form method="post"
+          th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-matter-type(submissionId=${submissionId}, claimId=${claimId})}"
+          th:object="${caseTypeForm}"
+          th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+          <span th:text="#{amendments.matterType.title}"></span>
+        </h1>
         <th:block th:replace="~{partials/error-summary :: error-summary(${formErrors})}"></th:block>
+      </div>
+      <div class="govuk-grid-column-one-half">
+        <dl class="govuk-summary-list"
+            th:with="originalMatterTypes=${forms.caseTypeForm.getOriginal()}">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-!-width-one-half"
+                th:text="#{amendments.matterType.current.one}"/>
+            <dd class="govuk-summary-list__value"
+                th:text="${originalMatterTypes.getInputs()['MATTER_TYPE_CODE_1']}"/>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-!-width-one-half"
+                th:text="#{amendments.matterType.current.two}"/>
+            <dd class="govuk-summary-list__value"
+                th:text="${originalMatterTypes.getInputs()['MATTER_TYPE_CODE_2']}"/>
+          </div>
+        </dl>
 
         <input type="hidden" th:field="*{inputs['FEE_CODE']}"/>
-          <div class="govuk-form-group">
-            <span id="MATTER_TYPE_CODE_1"></span>
-            <label class="govuk-label govuk-!-font-weight-bold" for="matter-type-one-input"
-                   th:text="#{amendments.matterType.amended.one}"/>
-            <th:block th:replace="~{partials/amendments/field-error :: fieldError('MATTER_TYPE_CODE_1', ${formErrors})}"></th:block>
-            <input class="govuk-input govuk-input--width-20" id="matter-type-one-input"
-                   th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_1') ? 'govuk-input--error' : ''}"
-                   th:field="*{inputs['MATTER_TYPE_CODE_1']}"
-                   type="text">
-          </div>
-          <div class="govuk-form-group">
-            <span id="MATTER_TYPE_CODE_2"></span>
-            <label class="govuk-label govuk-!-font-weight-bold" for="matter-type-two-input"
-                   th:text="#{amendments.matterType.amended.two}"/>
-            <th:block th:replace="~{partials/amendments/field-error :: fieldError('MATTER_TYPE_CODE_2', ${formErrors})}"></th:block>
-            <input class="govuk-input govuk-input--width-20" id="matter-type-two-input"
-                   th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_2') ? 'govuk-input--error' : ''}"
-                   th:field="*{inputs['MATTER_TYPE_CODE_2']}"
-                   type="text">
-          </div>
+        <div class="govuk-form-group" th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_1') ? 'govuk-form-group--error' : ''}">
+          <span id="MATTER_TYPE_CODE_1"></span>
+          <label class="govuk-label govuk-!-font-weight-bold" for="matter-type-one-input"
+                 th:text="#{amendments.matterType.amended.one}"/>
+          <th:block
+              th:replace="~{partials/amendments/field-error :: fieldError('MATTER_TYPE_CODE_1', ${formErrors})}"></th:block>
+          <input class="govuk-input govuk-input--width-20" id="matter-type-one-input"
+                 th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_1') ? 'govuk-input--error' : ''}"
+                 th:field="*{inputs['MATTER_TYPE_CODE_1']}"
+                 type="text">
+        </div>
+        <div class="govuk-form-group" th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_2') ? 'govuk-form-group--error' : ''}">
+          <span id="MATTER_TYPE_CODE_2"></span>
+          <label class="govuk-label govuk-!-font-weight-bold" for="matter-type-two-input"
+                 th:text="#{amendments.matterType.amended.two}"/>
+          <th:block
+              th:replace="~{partials/amendments/field-error :: fieldError('MATTER_TYPE_CODE_2', ${formErrors})}"></th:block>
+          <input class="govuk-input govuk-input--width-20" id="matter-type-two-input"
+                 th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'MATTER_TYPE_CODE_2') ? 'govuk-input--error' : ''}"
+                 th:field="*{inputs['MATTER_TYPE_CODE_2']}"
+                 type="text">
+        </div>
         <div class="govuk-button-group">
           <button class="govuk-button" type="submit" th:text="#{amendments.continue}"></button>
           <a th:href="@{/submissions/{submissionId}/claims/{claimId}/amendments/case(submissionId=${submissionId}, claimId=${claimId})}"
@@ -68,8 +71,8 @@
              th:text="#{service.cancel}">
           </a>
         </div>
-      </form>
-    </div>
+      </div>
+    </form>
   </div>
 </main>
 </body>

--- a/src/main/resources/templates/amendments/amend-stage-reached.html
+++ b/src/main/resources/templates/amendments/amend-stage-reached.html
@@ -12,34 +12,43 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
-      <h1 class="govuk-heading-l">
-        <span th:text="#{amendments.stageReached.title}"></span>
-      </h1>
-
-      <dl class="govuk-summary-list"
-          th:with="currentStageReachedCode=${forms.caseTypeForm.original.inputs['STAGE_REACHED']}">
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key govuk-!-width-one-half" th:text="#{amendments.stageReached.current}">
-          </dt>
-          <dd class="govuk-summary-list__value"
-              th:text="${#messages.msgOrNull('claimCase.options.stageReached.' + currentStageReachedCode) ?: currentStageReachedCode}">
-          </dd>
-        </div>
-      </dl>
 
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-stage-reached(submissionId=${submissionId}, claimId=${claimId})}"
-            th:object="${caseTypeForm}">
+            th:object="${caseTypeForm}"
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+
+        <th:block th:replace="~{partials/error-summary :: error-summary(${formErrors})}"></th:block>
+
+        <h1 class="govuk-heading-l">
+          <span th:text="#{amendments.stageReached.title}"></span>
+        </h1>
+
+        <dl class="govuk-summary-list"
+            th:with="currentStageReachedCode=${forms.caseTypeForm.original.inputs['STAGE_REACHED']}">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key govuk-!-width-one-half"
+                th:text="#{amendments.stageReached.current}">
+            </dt>
+            <dd class="govuk-summary-list__value"
+                th:text="${#messages.msgOrNull('claimCase.options.stageReached.' + currentStageReachedCode) ?: currentStageReachedCode}">
+            </dd>
+          </div>
+        </dl>
+
         <input type="hidden" th:each="entry : *{inputs}"
                th:if="${entry.key != 'STAGE_REACHED'}"
                th:field="*{inputs[__${entry.key}__]}"
                th:value="${entry.value}"/>
 
-        <div class="govuk-body">
+        <div class="govuk-form-group" th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'STAGE_REACHED') ? 'govuk-form-group--error' : ''}">
           <div class="autocomplete-wrapper">
+            <span id="STAGE_REACHED"></span>
             <label class="govuk-label govuk-!-font-weight-bold" for="stage-reached-input"
                    th:text="#{amendments.stageReached.amended}"></label>
+            <th:block th:replace="~{partials/amendments/field-error :: fieldError('STAGE_REACHED', ${formErrors})}"></th:block>
             <select class="govuk-select" id="stage-reached-input"
+                    th:classappend="${@ThymeleafUtils.hasAmendmentFieldError(formErrors, 'STAGE_REACHED') ? 'govuk-select--error' : ''}"
                     th:field="*{inputs['STAGE_REACHED']}"
                     data-module="make-autocomplete">
               <option value="" selected></option>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
@@ -25,6 +25,7 @@ import uk.gov.justice.laa.amend.claim.controllers.BaseControllerTest;
 import uk.gov.justice.laa.amend.claim.exceptions.FeeCodeNotFoundException;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
+import uk.gov.justice.laa.amend.claim.forms.amendments.validators.EnumAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.FeeCodeAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.TextAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
@@ -33,7 +34,11 @@ import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AvailableFeeCodesService;
 
 @WebMvcTest(AmendCaseTypeController.class)
-@Import({FeeCodeAmendmentFieldValidator.class, TextAmendmentFieldValidator.class})
+@Import({
+  FeeCodeAmendmentFieldValidator.class,
+  TextAmendmentFieldValidator.class,
+  EnumAmendmentFieldValidator.class
+})
 class AmendCaseTypeControllerTest extends BaseControllerTest {
 
   private static final String INPUTS = "inputs[%s]";
@@ -246,6 +251,9 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .build();
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms);
 
+    when(availableFeeCodesService.getAvailableFeeCodes(AreaOfLaw.CRIME_LOWER))
+        .thenReturn(Map.of(FEE_CODE, FEE_CODE));
+
     var request = post(buildAmendStageReachedPath()).session(session).with(csrf());
     for (var entry : caseTypeRows.entrySet()) {
       request.param(INPUTS.formatted(entry.getKey()), entry.getValue());
@@ -256,6 +264,91 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrl(buildAmendCasePath()))
         .andExpect(request().sessionAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms));
+  }
+
+  @Test
+  void postAmendStageReachedWithInvalidValueRedirectsBackAndPreservesInput() throws Exception {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setFeeCode(FEE_CODE);
+    claim.setStageReached(STAGE_REACHED);
+    claim.setAreaOfLaw(AreaOfLaw.CRIME_LOWER);
+    session.setAttribute(claimId.toString(), claim);
+
+    var caseTypeRows = Map.of("FEE_CODE", FEE_CODE, "STAGE_REACHED", STAGE_REACHED);
+    var caseTypeForm = new AmendmentForm();
+    caseTypeForm.setInputs(caseTypeRows);
+
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(caseTypeForm)
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var invalidStageReached = "NOT_A_VALID_STAGE";
+    var request =
+        post(buildAmendStageReachedPath())
+            .param(INPUTS.formatted("FEE_CODE"), FEE_CODE)
+            .param(INPUTS.formatted("STAGE_REACHED"), invalidStageReached)
+            .session(session)
+            .with(csrf());
+
+    mockMvc
+        .perform(request)
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(buildAmendStageReachedPath()));
+
+    AmendmentForms updatedForm =
+        (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
+    assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("STAGE_REACHED"))
+        .isEqualTo(invalidStageReached);
+  }
+
+  @Test
+  void postAmendStageReachedWithInvalidValueRendersErrorSummaryAndInlineErrorOnRedirect()
+      throws Exception {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setFeeCode(FEE_CODE);
+    claim.setStageReached(STAGE_REACHED);
+    claim.setAreaOfLaw(AreaOfLaw.CRIME_LOWER);
+    session.setAttribute(claimId.toString(), claim);
+
+    var caseTypeRows = Map.of("FEE_CODE", FEE_CODE, "STAGE_REACHED", STAGE_REACHED);
+    var caseTypeForm = new AmendmentForm();
+    caseTypeForm.setInputs(caseTypeRows);
+
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(caseTypeForm)
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var invalidStageReached = "NOT_A_VALID_STAGE";
+    var postRequest =
+        post(buildAmendStageReachedPath())
+            .param(INPUTS.formatted("FEE_CODE"), FEE_CODE)
+            .param(INPUTS.formatted("STAGE_REACHED"), invalidStageReached)
+            .session(session)
+            .with(csrf());
+
+    var postResult =
+        mockMvc.perform(postRequest).andExpect(status().is3xxRedirection()).andReturn();
+
+    var getRequest =
+        get(buildAmendStageReachedPath())
+            .session(session)
+            .flashAttrs(postResult.getFlashMap())
+            .with(csrf());
+
+    mockMvc
+        .perform(getRequest)
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("govuk-error-summary")))
+        .andExpect(content().string(containsString("govuk-error-message")))
+        .andExpect(content().string(containsString("Stage reached must be a valid option")));
   }
 
   @Test

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
@@ -286,6 +286,9 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .build();
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
 
+    when(availableFeeCodesService.getAvailableFeeCodes(AreaOfLaw.CRIME_LOWER))
+        .thenReturn(Map.of(FEE_CODE, FEE_CODE));
+
     var invalidStageReached = "NOT_A_VALID_STAGE";
     var request =
         post(buildAmendStageReachedPath())
@@ -333,6 +336,9 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .param(INPUTS.formatted("STAGE_REACHED"), invalidStageReached)
             .session(session)
             .with(csrf());
+
+    when(availableFeeCodesService.getAvailableFeeCodes(AreaOfLaw.CRIME_LOWER))
+        .thenReturn(Map.of(FEE_CODE, FEE_CODE));
 
     var postResult =
         mockMvc.perform(postRequest).andExpect(status().is3xxRedirection()).andReturn();


### PR DESCRIPTION
Added validation for stage reach screen, and fixed error summary rendering on fee code, matter type code, and stage reached screen.

**Fee Code**
<img width="712" height="684" alt="Screenshot 2026-08-06 at 16 36 38" src="https://github.com/user-attachments/assets/82c5799d-2d5a-46e7-bb2e-44ac5ee8a357" />

---

**Matter Type**
<img width="786" height="720" alt="Screenshot 2026-08-06 at 16 29 19" src="https://github.com/user-attachments/assets/d12e767f-6181-46aa-8ebc-649aaa49ed09" />

---

**Stage Reached**
<img width="668" height="650" alt="Screenshot 2026-08-06 at 16 37 02" src="https://github.com/user-attachments/assets/6d42f69d-9f54-454c-8fbc-f1c01d6abd05" />

## What is this PR?

[Link to story](https://dsdmoj.atlassian.net/browse/BC-662)

Describe what you did and why.

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

