### PR TITLE
BC-618: show assessed column on costs screen when claim is assessed

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsController.java
@@ -108,6 +108,7 @@ public class CostsController {
     model.addAttribute("costFields", costFields);
     model.addAttribute("costsForm", costs.getCurrent());
     model.addAttribute("costsFormIsAmended", costsFormIsAmended);
+    model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
     model.addAttribute("forms", amendmentForms);
   }
 }

--- a/src/main/resources/templates/amendments/view-costs.html
+++ b/src/main/resources/templates/amendments/view-costs.html
@@ -37,6 +37,9 @@
               <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimCosts.submitted}"></dd>
               <dd class="govuk-summary-list__value govuk-!-font-weight-bold" th:text="#{claimCosts.calculated}"></dd>
               <dd class="govuk-summary-list__value govuk-!-font-weight-bold"
+                  th:if="${claimIsAssessed}"
+                  th:text="#{claimCosts.assessed}"></dd>
+              <dd class="govuk-summary-list__value govuk-!-font-weight-bold"
                   th:if="${costsFormIsAmended}"
                   th:text="#{amendments.amended}"></dd>
             </div>
@@ -48,6 +51,9 @@
               <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></dd>
               <dd class="govuk-summary-list__value"
                   th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></dd>
+              <dd class="govuk-summary-list__value"
+                  th:if="${claimIsAssessed}"
+                  th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}"></dd>
               <dd class="govuk-summary-list__value"
                   th:if="${costsFormIsAmended}"
                   th:text="${costsForm.isAmendment(field.name(), originalCostsForm, field.fieldType) ? @ThymeleafUtils.getFormattedValue(costsForm.getAmendedValue(field)).resolve(#messages) : ''}"></dd>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/ViewCostsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/ViewCostsViewTest.java
@@ -99,6 +99,41 @@ class ViewCostsViewTest extends AmendmentsBaseTest {
   }
 
   @Test
+  void showsAssessedColumnWhenClaimAssessed() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCostsForms(claim));
+
+    var doc = renderDocument();
+
+    var costs = getSummaryListInCard(doc, "List of costs");
+    assertSummaryListRowContainsValues(
+        costs.getFirst(), "Item", "Reported", "Calculated", "Assessed");
+    assertSummaryListRowContainsValues(
+        costs.get(1), "Fixed fee", "Not applicable", "£200.00", "£300.00");
+    assertSummaryListRowContainsValues(
+        costs.get(2), "Net profit costs", "£100.00", "Not applicable", "£300.00");
+  }
+
+  @Test
+  void doesNotShowAssessedColumnWhenClaimNotAssessed() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCostsForms(claim));
+
+    var doc = renderDocument();
+
+    var costs = getSummaryListInCard(doc, "List of costs");
+    Assertions.assertEquals(3, costs.getFirst().size(), "Assessed column should not be shown");
+  }
+
+  @Test
   void showsAssessedBanner() {
     var claim = MockClaimsFunctions.createMockCrimeClaim();
     this.claim = claim;


### PR DESCRIPTION
[BC-618](https://dsdmoj.atlassian.net/browse/BC-618)

Adds an **Assessed** column to the costs summary list on the amend-a-claim
costs screen, shown only when the claim has been assessed.

<img width="1137" height="900" alt="Screenshot 2026-08-12 at 08 41 55" src="https://github.com/user-attachments/assets/e359cb04-482b-44ba-b825-be5511e12680" />



[BC-618]: https://dsdmoj.atlassian.net/browse/BC-618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ