### PR TITLE
BC-745: lock non-amendable fields on assessed claims

### DIFF
--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AbstractAmendController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AbstractAmendController.java
@@ -4,12 +4,20 @@ import static uk.gov.justice.laa.amend.claim.utils.SessionUtils.getValidClaim;
 
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.FieldSpecificAmendmentValidator;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.GenericAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.forms.validators.AmendmentFormValidator;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
 
 @RequiredArgsConstructor
 public abstract class AbstractAmendController {
@@ -23,5 +31,34 @@ public abstract class AbstractAmendController {
     binder.addValidators(
         new AmendmentFormValidator(
             claim, genericAmendmentFieldValidators, fieldSpecificAmendmentValidators));
+  }
+
+  protected static void requireEditable(ClaimViewField<?> field, ClaimDetails claim) {
+    if (!field.isEditable(AmendmentsHeaderView.isAssessed(claim))) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND);
+    }
+  }
+
+  protected static Set<ClaimViewField<?>> lockedFields(
+      Set<? extends ClaimViewField<?>> rowFields, ClaimDetails claim) {
+    var claimIsAssessed = AmendmentsHeaderView.isAssessed(claim);
+    return rowFields.stream()
+        .map(field -> (ClaimViewField<?>) field)
+        .filter(field -> !field.isEditable(claimIsAssessed))
+        .collect(Collectors.toSet());
+  }
+
+  protected static AmendmentForm retainLockedInputs(
+      AmendmentForm submitted, AmendmentForm original, Set<ClaimViewField<?>> lockedFields) {
+    var lockedKeys =
+        lockedFields.stream()
+            .flatMap(field -> AmendmentForm.inputKeys(field).stream())
+            .collect(Collectors.toSet());
+
+    var merged = new AmendmentForm(original);
+    submitted.getInputs().entrySet().stream()
+        .filter(entry -> !lockedKeys.contains(entry.getKey()))
+        .forEach(entry -> merged.getInputs().put(entry.getKey(), entry.getValue()));
+    return merged;
   }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AbstractAmendController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AbstractAmendController.java
@@ -57,6 +57,7 @@ public abstract class AbstractAmendController {
 
     var merged = new AmendmentForm(original);
     submitted.getInputs().entrySet().stream()
+        .filter(entry -> original.getInputs().containsKey(entry.getKey()))
         .filter(entry -> !lockedKeys.contains(entry.getKey()))
         .forEach(entry -> merged.getInputs().put(entry.getKey(), entry.getValue()));
     return merged;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseDetailsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseDetailsController.java
@@ -26,6 +26,7 @@ import uk.gov.justice.laa.amend.claim.config.features.Feature;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.FieldSpecificAmendmentValidator;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.GenericAmendmentFieldValidator;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
 import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
 
 @Controller
@@ -62,6 +63,7 @@ public class AmendCaseDetailsController extends AbstractAmendController {
     model.addAttribute("caseView", caseView);
     model.addAttribute("caseDetailsForm", amendmentForms.getCaseDetailsForm().getCurrent());
     model.addAttribute("forms", amendmentForms);
+    model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
     return "amendments/amend-case-details";
   }
 
@@ -73,9 +75,15 @@ public class AmendCaseDetailsController extends AbstractAmendController {
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
+    var claim = getValidClaim(session, submissionId, claimId);
     var amendmentForms = getAmendmentForms(session, claimId);
+    var caseDetails = amendmentForms.getCaseDetailsForm();
 
-    amendmentForms.getCaseDetailsForm().setCurrent(caseDetailsForm);
+    caseDetails.setCurrent(
+        retainLockedInputs(
+            caseDetailsForm,
+            caseDetails.getOriginal(),
+            lockedFields(ClaimCaseViewFactory.create(claim).caseDetailsRows().keySet(), claim)));
     saveAmendmentForms(session, claimId, amendmentForms);
 
     if (bindingResult.hasErrors()) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTabController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTabController.java
@@ -14,7 +14,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.justice.laa.amend.claim.annotations.HasRoleClaimAmendmentsCaseworker;
 import uk.gov.justice.laa.amend.claim.annotations.RequiresFeatureFlag;
 import uk.gov.justice.laa.amend.claim.config.features.Feature;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.AreaOfLaw;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
 import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
 
 @Controller
 @RequestMapping("/submissions/{submissionId}/claims/{claimId}/amendments")
@@ -35,7 +39,22 @@ public class AmendCaseTabController {
     var claimView = ClaimCaseViewFactory.create(claim);
     model.addAttribute("claim", claimView);
     model.addAttribute("forms", amendmentForms);
+    model.addAttribute("caseTypeAmendUrl", caseTypeAmendUrl(claim, submissionId, claimId));
 
     return "amendments/view-case";
+  }
+
+  private static String caseTypeAmendUrl(ClaimDetails claim, UUID submissionId, UUID claimId) {
+    var page = caseTypeAmendPage(claim);
+    return "/submissions/%s/claims/%s/amendments/%s".formatted(submissionId, claimId, page);
+  }
+
+  private static String caseTypeAmendPage(ClaimDetails claim) {
+    if (ClaimDetailsViewField.FEE_CODE.isEditable(AmendmentsHeaderView.isAssessed(claim))) {
+      return "amend-fee-code";
+    }
+    return claim.getAreaOfLaw() == AreaOfLaw.CRIME_LOWER
+        ? "amend-stage-reached"
+        : "amend-matter-type";
   }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeController.java
@@ -173,6 +173,8 @@ public class AmendCaseTypeController extends AbstractAmendController {
       Model model,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
+    getValidClaim(session, submissionId, claimId);
+
     var amendmentForms = getAmendmentForms(session, claimId);
 
     model.addAttribute("forms", amendmentForms);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeController.java
@@ -25,10 +25,15 @@ import uk.gov.justice.laa.amend.claim.annotations.RequiresFeatureFlag;
 import uk.gov.justice.laa.amend.claim.config.features.Feature;
 import uk.gov.justice.laa.amend.claim.exceptions.FeeCodeNotFoundException;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.FieldSpecificAmendmentValidator;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.GenericAmendmentFieldValidator;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.enums.AreaOfLaw;
 import uk.gov.justice.laa.amend.claim.service.AvailableFeeCodesService;
+import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.FieldOptions;
 
 @Controller
@@ -63,6 +68,8 @@ public class AmendCaseTypeController extends AbstractAmendController {
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
     var claim = getValidClaim(session, submissionId, claimId);
+    requireEditable(ClaimDetailsViewField.FEE_CODE, claim);
+
     var availableFeeCodes = availableFeeCodesService.getAvailableFeeCodes(claim.getAreaOfLaw());
     if (!availableFeeCodes.containsKey(claim.getFeeCode())) {
       throw new FeeCodeNotFoundException(claim.getFeeCode());
@@ -85,10 +92,12 @@ public class AmendCaseTypeController extends AbstractAmendController {
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
+    var claim = getValidClaim(session, submissionId, claimId);
+    requireEditable(ClaimDetailsViewField.FEE_CODE, claim);
+
     var amendmentForms = getAmendmentForms(session, claimId);
 
-    amendmentForms.getCaseTypeForm().setCurrent(caseTypeForm);
-    saveAmendmentForms(session, claimId, amendmentForms);
+    saveCaseTypeForm(session, claimId, amendmentForms, caseTypeForm, claim);
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
@@ -98,7 +107,6 @@ public class AmendCaseTypeController extends AbstractAmendController {
           "/submissions/%s/claims/%s/amendments/amend-fee-code".formatted(submissionId, claimId));
     }
 
-    var claim = getValidClaim(session, submissionId, claimId);
     if (claim.getAreaOfLaw() == AreaOfLaw.CRIME_LOWER) {
       return "redirect:/submissions/%s/claims/%s/amendments/amend-stage-reached"
           .formatted(submissionId, claimId);
@@ -119,6 +127,8 @@ public class AmendCaseTypeController extends AbstractAmendController {
       return "redirect:/submissions/%s/claims/%s/amendments/amend-matter-type"
           .formatted(submissionId, claimId);
     }
+    requireEditable(CrimeClaimDetailsViewField.STAGE_REACHED, claim);
+
     var amendmentForms = getAmendmentForms(session, claimId);
     model.addAttribute("forms", amendmentForms);
     model.addAttribute("stageReachedOptions", FieldOptions.CRIME_STAGE_REACHED);
@@ -139,11 +149,11 @@ public class AmendCaseTypeController extends AbstractAmendController {
       return "redirect:/submissions/%s/claims/%s/amendments/amend-matter-type"
           .formatted(submissionId, claimId);
     }
+    requireEditable(CrimeClaimDetailsViewField.STAGE_REACHED, claim);
 
     var amendmentForms = getAmendmentForms(session, claimId);
 
-    amendmentForms.getCaseTypeForm().setCurrent(caseTypeForm);
-    saveAmendmentForms(session, claimId, amendmentForms);
+    saveCaseTypeForm(session, claimId, amendmentForms, caseTypeForm, claim);
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
@@ -163,8 +173,6 @@ public class AmendCaseTypeController extends AbstractAmendController {
       Model model,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
-    var claim = getValidClaim(session, submissionId, claimId);
-
     var amendmentForms = getAmendmentForms(session, claimId);
 
     model.addAttribute("forms", amendmentForms);
@@ -181,10 +189,10 @@ public class AmendCaseTypeController extends AbstractAmendController {
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
+    var claim = getValidClaim(session, submissionId, claimId);
     var amendmentForms = getAmendmentForms(session, claimId);
 
-    amendmentForms.getCaseTypeForm().setCurrent(caseTypeForm);
-    saveAmendmentForms(session, claimId, amendmentForms);
+    saveCaseTypeForm(session, claimId, amendmentForms, caseTypeForm, claim);
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
@@ -196,5 +204,19 @@ public class AmendCaseTypeController extends AbstractAmendController {
     }
 
     return "redirect:/submissions/%s/claims/%s/amendments/case".formatted(submissionId, claimId);
+  }
+
+  private static void saveCaseTypeForm(
+      HttpSession session,
+      UUID claimId,
+      AmendmentForms amendmentForms,
+      AmendmentForm caseTypeForm,
+      ClaimDetails claim) {
+    var caseType = amendmentForms.getCaseTypeForm();
+    var lockedFields =
+        lockedFields(ClaimCaseViewFactory.create(claim).caseTypeRows().keySet(), claim);
+
+    caseType.setCurrent(retainLockedInputs(caseTypeForm, caseType.getOriginal(), lockedFields));
+    saveAmendmentForms(session, claimId, amendmentForms);
   }
 }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsController.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/controllers/amendments/CostsController.java
@@ -83,9 +83,10 @@ public class CostsController {
   }
 
   private static void retainEditableInputs(AmendmentForm costsForm, ClaimDetails claim) {
+    var claimIsAssessed = AmendmentsHeaderView.isAssessed(claim);
     var editableFieldNames =
         ClaimCostsViewFactory.create(claim).costFields().keySet().stream()
-            .filter(field -> field.isEditable())
+            .filter(field -> field.isEditable(claimIsAssessed))
             .map(field -> field.name())
             .toList();
     costsForm.getInputs().keySet().retainAll(editableFieldNames);

--- a/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/AmendmentForm.java
@@ -81,6 +81,13 @@ public class AmendmentForm {
     return fieldInputs;
   }
 
+  public static List<String> inputKeys(ClaimViewField<?> field) {
+    if (field.getFieldType() != FieldType.DATE) {
+      return List.of(field.name());
+    }
+    return DATE_SUFFIXES.stream().map(suffix -> field.name() + suffix).toList();
+  }
+
   private static String dateFieldNameOrNull(String key) {
     for (var suffix : DATE_SUFFIXES) {
       if (key.endsWith(suffix)) {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/models/enums/Amendability.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/models/enums/Amendability.java
@@ -1,0 +1,7 @@
+package uk.gov.justice.laa.amend.claim.models.enums;
+
+public enum Amendability {
+  ALWAYS,
+  UNTIL_ASSESSED,
+  NEVER
+}

--- a/src/main/java/uk/gov/justice/laa/amend/claim/service/CheckAmendmentsService.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/service/CheckAmendmentsService.java
@@ -14,6 +14,7 @@ import uk.gov.justice.laa.amend.claim.forms.amendments.OriginalAndCurrent;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.MediationClaimDetails;
+import uk.gov.justice.laa.amend.claim.viewmodels.AmendmentsHeaderView;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 
 @Service
@@ -37,16 +38,16 @@ public class CheckAmendmentsService {
             .amendmentRequestedBy("PROVIDER")
             .version(claim.getVersion());
 
-    applyAmendments(patchBuilder, amendmentForms.getClient1Form(), claim.getClass());
+    applyAmendments(patchBuilder, amendmentForms.getClient1Form(), claim);
     if (amendmentForms.getClient2Form() != null) {
-      applyAmendments(patchBuilder, amendmentForms.getClient2Form(), claim.getClass());
+      applyAmendments(patchBuilder, amendmentForms.getClient2Form(), claim);
     }
-    applyAmendments(patchBuilder, amendmentForms.getCaseTypeForm(), claim.getClass());
+    applyAmendments(patchBuilder, amendmentForms.getCaseTypeForm(), claim);
     if (claim instanceof CivilClaimDetails || claim instanceof MediationClaimDetails) {
       applyLegalHelpMatterTypeAmendments(patchBuilder, amendmentForms.getCaseTypeForm());
     }
-    applyAmendments(patchBuilder, amendmentForms.getCaseDetailsForm(), claim.getClass());
-    applyAmendments(patchBuilder, amendmentForms.getCostsForm(), claim.getClass());
+    applyAmendments(patchBuilder, amendmentForms.getCaseDetailsForm(), claim);
+    applyAmendments(patchBuilder, amendmentForms.getCostsForm(), claim);
 
     try {
       claimsApiClient.updateClaim(submissionId, claimId, patchBuilder.build()).block();
@@ -67,16 +68,16 @@ public class CheckAmendmentsService {
   }
 
   private void applyAmendments(
-      ClaimPatch.Builder builder,
-      OriginalAndCurrent forms,
-      Class<? extends ClaimDetails> claimDetailsType) {
+      ClaimPatch.Builder builder, OriginalAndCurrent forms, ClaimDetails claim) {
 
     var original = forms.getOriginal();
     var current = forms.getCurrent();
+    var claimIsAssessed = AmendmentsHeaderView.isAssessed(claim);
 
-    for (var fieldValue : current.getFieldValues(claimDetailsType).entrySet()) {
+    for (var fieldValue : current.getFieldValues(claim.getClass()).entrySet()) {
       var field = fieldValue.getKey();
-      if (field.isEditable() && current.isAmendment(field.name(), original, field.getFieldType())) {
+      if (field.isEditable(claimIsAssessed)
+          && current.isAmendment(field.name(), original, field.getFieldType())) {
         field.applyPatch(builder, fieldValue.getValue());
       }
     }

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/claimcase/CivilClaimCaseView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/claimcase/CivilClaimCaseView.java
@@ -35,12 +35,12 @@ import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDeta
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField.TOLERANCE_INDICATOR;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField.TRANSFER_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField.TRAVEL_TIME;
+import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField.UNIQUE_FILE_NUMBER;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField.VALUE_OF_COSTS;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField.WAITING_TIME;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.CASE_REFERENCE_NUMBER;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.CASE_START_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.FEE_CODE;
-import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.UNIQUE_FILE_NUMBER;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField.asCivilField;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField.toFieldMap;
 
@@ -75,7 +75,7 @@ public record CivilClaimCaseView(
             asCivilField(CASE_REFERENCE_NUMBER),
             asCivilField(CASE_START_DATE),
             CASE_CONCLUDED_CLAIMED_DATE,
-            asCivilField(UNIQUE_FILE_NUMBER),
+            UNIQUE_FILE_NUMBER,
             CASE_STAGE,
             VALUE_OF_COSTS,
             PROCUREMENT_AREA,

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/claimcase/CrimeClaimCaseView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/claimcase/CrimeClaimCaseView.java
@@ -1,10 +1,9 @@
 package uk.gov.justice.laa.amend.claim.viewmodels.claimcase;
 
-import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.CASE_CONCLUDED_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.FEE_CODE;
-import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.UNIQUE_FILE_NUMBER;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField.asCrimeField;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField.toFieldMap;
+import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.DSCC_NUMBER;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.IS_DUTY_SOLICITOR;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.IS_YOUTH_COURT;
@@ -19,6 +18,7 @@ import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDeta
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.STAGE_REACHED;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.STANDARD_FEE_CATEGORY;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.SUSPECTS_DEFENDANTS_COUNT;
+import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER;
 
 import java.util.LinkedHashMap;
 import java.util.stream.Stream;
@@ -47,9 +47,9 @@ public record CrimeClaimCaseView(
     Stream<ClaimViewField<CrimeClaimDetails>> fields =
         Stream.of(
             MATTER_TYPE_CODE,
-            asCrimeField(UNIQUE_FILE_NUMBER),
+            UNIQUE_FILE_NUMBER,
             REPRESENTATION_ORDER_DATE,
-            asCrimeField(CASE_CONCLUDED_DATE),
+            CASE_CONCLUDED_DATE,
             STANDARD_FEE_CATEGORY,
             OUTCOME_FOR_CLIENT,
             SUSPECTS_DEFENDANTS_COUNT,

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/claimcase/MediationClaimCaseView.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/claimcase/MediationClaimCaseView.java
@@ -1,11 +1,11 @@
 package uk.gov.justice.laa.amend.claim.viewmodels.claimcase;
 
-import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.CASE_CONCLUDED_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.CASE_REFERENCE_NUMBER;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.CASE_START_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField.FEE_CODE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField.asMediationField;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField.toFieldMap;
+import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField.CASE_CONCLUDED_DATE;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField.CLAIM_ID;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField.MATTER_TYPE_CODE_1;
 import static uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField.MATTER_TYPE_CODE_2;
@@ -48,7 +48,7 @@ public record MediationClaimCaseView(
             asMediationField(CASE_START_DATE),
             CLAIM_ID,
             UNIQUE_CASE_ID,
-            asMediationField(CASE_CONCLUDED_DATE),
+            CASE_CONCLUDED_DATE,
             MEDIATION_SESSIONS_COUNT,
             MEDIATION_TIME_MINUTES,
             OUTCOME,

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CivilClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CivilClaimDetailsViewField.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import lombok.Getter;
 import uk.gov.justice.laa.amend.claim.models.CivilClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.Amendability;
 import uk.gov.justice.laa.amend.claim.models.enums.FieldType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 
@@ -78,7 +79,13 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       FieldType.DATE,
       String.class,
       CivilClaimDetails::getCaseConcludedDate,
-      ClaimPatch.Builder::caseConcludedDate),
+      ClaimPatch.Builder::caseConcludedDate,
+      Amendability.UNTIL_ASSESSED),
+  UNIQUE_FILE_NUMBER(
+      FieldType.TEXT,
+      String.class,
+      CivilClaimDetails::getUniqueFileNumber,
+      ClaimPatch.Builder::uniqueFileNumber),
   CASE_STAGE(
       FieldType.ENUM,
       String.class,
@@ -298,6 +305,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
   private final CivilClaimViewFieldGetter<?> getter;
   private final FieldType fieldType;
   private final ClaimViewFieldPatcher<?> patcher;
+  private final Amendability amendability;
   private final List<FieldOption> options;
 
   <T> CivilClaimDetailsViewField(
@@ -305,7 +313,16 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Class<T> patchType,
       Function<CivilClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher) {
-    this(fieldType, patchType, getter, patcher, List.of());
+    this(fieldType, patchType, getter, patcher, List.of(), Amendability.ALWAYS);
+  }
+
+  <T> CivilClaimDetailsViewField(
+      FieldType fieldType,
+      Class<T> patchType,
+      Function<CivilClaimDetails, ?> getter,
+      BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
+      Amendability amendability) {
+    this(fieldType, patchType, getter, patcher, List.of(), amendability);
   }
 
   <T> CivilClaimDetailsViewField(
@@ -314,10 +331,21 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Function<CivilClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
       List<FieldOption> options) {
+    this(fieldType, patchType, getter, patcher, options, Amendability.ALWAYS);
+  }
+
+  <T> CivilClaimDetailsViewField(
+      FieldType fieldType,
+      Class<T> patchType,
+      Function<CivilClaimDetails, ?> getter,
+      BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
+      List<FieldOption> options,
+      Amendability amendability) {
     this.getter = new CivilClaimViewFieldGetter<>(getter);
     this.fieldType = fieldType;
     this.patcher = new ClaimViewFieldPatcher<>(patchType, patcher);
     this.options = List.copyOf(options);
+    this.amendability = amendability;
   }
 
   public record CivilClaimViewFieldGetter<T>(Function<CivilClaimDetails, T> getter)

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/ClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/ClaimDetailsViewField.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import lombok.Getter;
 import uk.gov.justice.laa.amend.claim.models.Claim;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.Amendability;
 import uk.gov.justice.laa.amend.claim.models.enums.FieldType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 
@@ -54,18 +55,21 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       Claim::getCaseReferenceNumber,
       ClaimPatch.Builder::caseReferenceNumber),
   CASE_START_DATE(
-      FieldType.DATE, String.class, Claim::getCaseStartDate, ClaimPatch.Builder::caseStartDate),
-  UNIQUE_FILE_NUMBER(
+      FieldType.DATE,
+      String.class,
+      Claim::getCaseStartDate,
+      ClaimPatch.Builder::caseStartDate,
+      Amendability.UNTIL_ASSESSED),
+  FEE_CODE(
       FieldType.TEXT,
       String.class,
-      Claim::getUniqueFileNumber,
-      ClaimPatch.Builder::uniqueFileNumber),
-  CASE_CONCLUDED_DATE(
-      FieldType.DATE, String.class, Claim::getCaseEndDate, ClaimPatch.Builder::caseConcludedDate),
-  FEE_CODE(FieldType.TEXT, String.class, ClaimDetails::getFeeCode, ClaimPatch.Builder::feeCode),
+      ClaimDetails::getFeeCode,
+      ClaimPatch.Builder::feeCode,
+      Amendability.UNTIL_ASSESSED),
 
   // Common cost fields
-  FIXED_FEE(FieldType.TEXT, Object.class, ClaimDetails::getFixedFee, (b, v) -> b, List.of(), false),
+  FIXED_FEE(
+      FieldType.TEXT, Object.class, ClaimDetails::getFixedFee, (b, v) -> b, Amendability.NEVER),
   PROFIT_COST(
       FieldType.BIG_DECIMAL,
       BigDecimal.class,
@@ -90,7 +94,7 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
   private final ClaimDetailsViewFieldGetter<?> getter;
   private final FieldType fieldType;
   private final ClaimViewFieldPatcher<?> patcher;
-  private final boolean editable;
+  private final Amendability amendability;
   private final List<FieldOption> options;
 
   <T> ClaimDetailsViewField(
@@ -98,7 +102,7 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       Class<T> patchType,
       Function<ClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher) {
-    this(fieldType, patchType, getter, patcher, List.of(), true);
+    this(fieldType, patchType, getter, patcher, List.of(), Amendability.ALWAYS);
   }
 
   <T> ClaimDetailsViewField(
@@ -107,7 +111,16 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       Function<ClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
       List<FieldOption> options) {
-    this(fieldType, patchType, getter, patcher, options, true);
+    this(fieldType, patchType, getter, patcher, options, Amendability.ALWAYS);
+  }
+
+  <T> ClaimDetailsViewField(
+      FieldType fieldType,
+      Class<T> patchType,
+      Function<ClaimDetails, ?> getter,
+      BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
+      Amendability amendability) {
+    this(fieldType, patchType, getter, patcher, List.of(), amendability);
   }
 
   <T> ClaimDetailsViewField(
@@ -116,12 +129,12 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       Function<ClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
       List<FieldOption> options,
-      boolean editable) {
+      Amendability amendability) {
     this.getter = new ClaimDetailsViewFieldGetter<>(getter);
     this.fieldType = fieldType;
     this.patcher = new ClaimViewFieldPatcher<>(patchType, patcher);
     this.options = List.copyOf(options);
-    this.editable = editable;
+    this.amendability = amendability;
   }
 
   public record ClaimDetailsViewFieldGetter<T>(Function<ClaimDetails, T> getter)

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/ClaimViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/ClaimViewField.java
@@ -42,10 +42,6 @@ public interface ClaimViewField<T extends Claim> {
     return Amendability.ALWAYS;
   }
 
-  default boolean isEditable() {
-    return isEditable(false);
-  }
-
   default boolean isEditable(boolean claimIsAssessed) {
     return switch (getAmendability()) {
       case ALWAYS -> true;

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/ClaimViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/ClaimViewField.java
@@ -11,6 +11,7 @@ import uk.gov.justice.laa.amend.claim.models.Claim;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.MediationClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.Amendability;
 import uk.gov.justice.laa.amend.claim.models.enums.FieldType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 
@@ -37,8 +38,20 @@ public interface ClaimViewField<T extends Claim> {
     return getPatcher().apply(patchBuilder, value);
   }
 
+  default Amendability getAmendability() {
+    return Amendability.ALWAYS;
+  }
+
   default boolean isEditable() {
-    return true;
+    return isEditable(false);
+  }
+
+  default boolean isEditable(boolean claimIsAssessed) {
+    return switch (getAmendability()) {
+      case ALWAYS -> true;
+      case UNTIL_ASSESSED -> !claimIsAssessed;
+      case NEVER -> false;
+    };
   }
 
   default List<FieldOption> getOptions() {

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CrimeClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/CrimeClaimDetailsViewField.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import lombok.Getter;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.CrimeClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.Amendability;
 import uk.gov.justice.laa.amend.claim.models.enums.FieldType;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 
@@ -26,11 +27,24 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
       ClaimDetails::getStageReached,
       ClaimPatch.Builder::stageReachedCode,
       FieldOptions.CRIME_STAGE_REACHED),
+  UNIQUE_FILE_NUMBER(
+      FieldType.TEXT,
+      String.class,
+      CrimeClaimDetails::getUniqueFileNumber,
+      ClaimPatch.Builder::uniqueFileNumber,
+      Amendability.UNTIL_ASSESSED),
   REPRESENTATION_ORDER_DATE(
       FieldType.DATE,
       String.class,
       CrimeClaimDetails::getRepresentationOrderDate,
-      ClaimPatch.Builder::representationOrderDate),
+      ClaimPatch.Builder::representationOrderDate,
+      Amendability.UNTIL_ASSESSED),
+  CASE_CONCLUDED_DATE(
+      FieldType.DATE,
+      String.class,
+      CrimeClaimDetails::getCaseEndDate,
+      ClaimPatch.Builder::caseConcludedDate,
+      Amendability.UNTIL_ASSESSED),
   STANDARD_FEE_CATEGORY(
       FieldType.ENUM,
       String.class,
@@ -57,9 +71,14 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
       FieldType.TEXT,
       String.class,
       CrimeClaimDetails::getPoliceStationCourtPrisonId,
-      ClaimPatch.Builder::policeStationCourtPrisonId),
+      ClaimPatch.Builder::policeStationCourtPrisonId,
+      Amendability.UNTIL_ASSESSED),
   SCHEME_ID(
-      FieldType.TEXT, String.class, CrimeClaimDetails::getSchemeId, ClaimPatch.Builder::schemeId),
+      FieldType.TEXT,
+      String.class,
+      CrimeClaimDetails::getSchemeId,
+      ClaimPatch.Builder::schemeId,
+      Amendability.UNTIL_ASSESSED),
   DSCC_NUMBER(
       FieldType.TEXT,
       String.class,
@@ -97,6 +116,7 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
   private final CrimeClaimViewFieldGetter<?> getter;
   private final FieldType fieldType;
   private final ClaimViewFieldPatcher<?> patcher;
+  private final Amendability amendability;
   private final List<FieldOption> options;
 
   <T> CrimeClaimDetailsViewField(
@@ -104,7 +124,16 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
       Class<T> patchType,
       Function<CrimeClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher) {
-    this(fieldType, patchType, getter, patcher, List.of());
+    this(fieldType, patchType, getter, patcher, List.of(), Amendability.ALWAYS);
+  }
+
+  <T> CrimeClaimDetailsViewField(
+      FieldType fieldType,
+      Class<T> patchType,
+      Function<CrimeClaimDetails, ?> getter,
+      BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
+      Amendability amendability) {
+    this(fieldType, patchType, getter, patcher, List.of(), amendability);
   }
 
   <T> CrimeClaimDetailsViewField(
@@ -113,10 +142,21 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
       Function<CrimeClaimDetails, ?> getter,
       BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
       List<FieldOption> options) {
+    this(fieldType, patchType, getter, patcher, options, Amendability.ALWAYS);
+  }
+
+  <T> CrimeClaimDetailsViewField(
+      FieldType fieldType,
+      Class<T> patchType,
+      Function<CrimeClaimDetails, ?> getter,
+      BiFunction<ClaimPatch.Builder, T, ClaimPatch.Builder> patcher,
+      List<FieldOption> options,
+      Amendability amendability) {
     this.getter = new CrimeClaimViewFieldGetter<>(getter);
     this.fieldType = fieldType;
     this.patcher = new ClaimViewFieldPatcher<>(patchType, patcher);
     this.options = List.copyOf(options);
+    this.amendability = amendability;
   }
 
   public record CrimeClaimViewFieldGetter<T>(Function<CrimeClaimDetails, T> getter)

--- a/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/MediationClaimDetailsViewField.java
+++ b/src/main/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/MediationClaimDetailsViewField.java
@@ -145,6 +145,11 @@ public enum MediationClaimDetailsViewField implements ClaimViewField<MediationCl
       String.class,
       MediationClaimDetails::getScheduleReference,
       ClaimPatch.Builder::scheduleReference),
+  CASE_CONCLUDED_DATE(
+      FieldType.DATE,
+      String.class,
+      MediationClaimDetails::getCaseEndDate,
+      ClaimPatch.Builder::caseConcludedDate),
   ;
 
   private final MediationClaimViewFieldGetter<?> getter;

--- a/src/main/resources/templates/amendments/amend-case-details.html
+++ b/src/main/resources/templates/amendments/amend-case-details.html
@@ -47,7 +47,9 @@
                 <dt class="govuk-summary-list__key" th:text="#{${'claimCase.rows.' + entry.key.name()}}"></dt>
                 <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.key, entry.value).resolve(#messages)}"></dd>
                 <dd class="govuk-summary-list__value">
-                  <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${entry.key}, ${'claimCase.rows.' + entry.key.name()}, ${formErrors})}"></th:block>
+                  <th:block th:if="${entry.key.isEditable(claimIsAssessed)}">
+                    <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${entry.key}, ${'claimCase.rows.' + entry.key.name()}, ${formErrors})}"></th:block>
+                  </th:block>
                 </dd>
               </div>
             </dl>

--- a/src/main/resources/templates/amendments/amend-costs.html
+++ b/src/main/resources/templates/amendments/amend-costs.html
@@ -43,7 +43,7 @@
                 <dt class="govuk-summary-list__key" th:text="#{${'claimCosts.rows.' + field.name()}}"></dt>
                 <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></dd>
                 <dd class="govuk-summary-list__value">
-                  <th:block th:if="${field.isEditable()}">
+                  <th:block th:if="${field.isEditable(claimIsAssessed)}">
                     <th:block th:replace="~{partials/amendments/amendment-input :: amendmentInput(${field}, ${'claimCosts.rows.' + field.name()}, ${null})}"></th:block>
                   </th:block>
                 </dd>

--- a/src/main/resources/templates/amendments/amend-stage-reached.html
+++ b/src/main/resources/templates/amendments/amend-stage-reached.html
@@ -9,6 +9,7 @@
     )}">
 <body>
 <main class="govuk-main-wrapper" id="main-content">
+  <th:block th:replace="~{partials/amendments-assessed-banner :: assessedBannerRow}"></th:block>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 

--- a/src/main/resources/templates/amendments/view-case.html
+++ b/src/main/resources/templates/amendments/view-case.html
@@ -30,7 +30,7 @@
             <li class="govuk-summary-card__action">
               <a class="govuk-link govuk-link--no-visited-state"
                  id="amend-case-type-link"
-                 th:href="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-fee-code(submissionId=${submissionId}, claimId=${claimId})}"
+                 th:href="@{${caseTypeAmendUrl}}"
                  th:text="#{amendments.change}"></a>
             </li>
           </ul>

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseDetailsControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseDetailsControllerTest.java
@@ -91,18 +91,13 @@ class AmendCaseDetailsControllerTest extends BaseControllerTest {
 
   @Test
   void postCaseDetailsAsExpected() throws Exception {
-    var caseDetailsRows = Map.of("FEE_CODE", FEE_CODE);
-    var caseDetailsForm = new AmendmentForm();
-    caseDetailsForm.setInputs(caseDetailsRows);
-
-    var updatedForms = MockAmendmentFormsFunctions.empty();
-    updatedForms.getCaseDetailsForm().setCurrent(caseDetailsForm);
+    var updatedForms = MockAmendmentFormsFunctions.justCaseDetailsFilled(claim);
 
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms);
 
     var request =
         post(buildAmendCaseDetailsPath())
-            .param(INPUTS.formatted("FEE_CODE"), "updated")
+            .param(INPUTS.formatted("MAAT_ID"), "updated")
             .session(session)
             .with(csrf());
 
@@ -113,24 +108,38 @@ class AmendCaseDetailsControllerTest extends BaseControllerTest {
         .andExpect(request().sessionAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms));
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
-    assertThat(updatedForm.getCaseDetailsForm().getCurrent().getInputs().get("FEE_CODE"))
+    assertThat(updatedForm.getCaseDetailsForm().getCurrent().getInputs().get("MAAT_ID"))
         .isEqualTo("updated");
   }
 
   @Test
-  void postCaseDetailsWithInvalidValueRedirectsBackAndPreservesInput() throws Exception {
-    var caseDetailsRows = Map.of("FEE_CODE", FEE_CODE);
-    var caseDetailsForm = new AmendmentForm();
-    caseDetailsForm.setInputs(caseDetailsRows);
+  void postCaseDetailsIgnoresInputsNotBelongingToTheForm() throws Exception {
+    var updatedForms = MockAmendmentFormsFunctions.justCaseDetailsFilled(claim);
 
-    var updatedForms = MockAmendmentFormsFunctions.empty();
-    updatedForms.getCaseDetailsForm().setCurrent(caseDetailsForm);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms);
+
+    var request =
+        post(buildAmendCaseDetailsPath())
+            .param(INPUTS.formatted("FEE_CODE"), "tampered")
+            .session(session)
+            .with(csrf());
+
+    mockMvc.perform(request).andExpect(status().is3xxRedirection());
+
+    var saved =
+        requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    assertThat(saved.getCaseDetailsForm().getCurrent().getInputs().get("FEE_CODE")).isNull();
+  }
+
+  @Test
+  void postCaseDetailsWithInvalidValueRedirectsBackAndPreservesInput() throws Exception {
+    var updatedForms = MockAmendmentFormsFunctions.justCaseDetailsFilled(claim);
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms);
 
     var tooLong = "a".repeat(51);
     var request =
         post(buildAmendCaseDetailsPath())
-            .param(INPUTS.formatted("FEE_CODE"), tooLong)
+            .param(INPUTS.formatted("UNIQUE_FILE_NUMBER"), tooLong)
             .session(session)
             .with(csrf());
 
@@ -141,7 +150,7 @@ class AmendCaseDetailsControllerTest extends BaseControllerTest {
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
-    assertThat(updatedForm.getCaseDetailsForm().getCurrent().getInputs().get("FEE_CODE"))
+    assertThat(updatedForm.getCaseDetailsForm().getCurrent().getInputs().get("UNIQUE_FILE_NUMBER"))
         .isEqualTo(tooLong);
   }
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseDetailsControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseDetailsControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers.amendments;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -12,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 import static uk.gov.justice.laa.amend.claim.utils.SessionUtils.AMENDMENTS_KEY;
 
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -22,14 +24,16 @@ import org.springframework.mock.web.MockHttpSession;
 import uk.gov.justice.laa.amend.claim.controllers.BaseControllerTest;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
+import uk.gov.justice.laa.amend.claim.forms.amendments.validators.DateAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.TextAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.enums.AreaOfLaw;
+import uk.gov.justice.laa.amend.claim.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.amend.claim.resources.MockAmendmentFormsFunctions;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 
 @WebMvcTest(AmendCaseDetailsController.class)
-@Import({TextAmendmentFieldValidator.class})
+@Import({TextAmendmentFieldValidator.class, DateAmendmentFieldValidator.class})
 class AmendCaseDetailsControllerTest extends BaseControllerTest {
 
   private static final String INPUTS = "inputs[%s]";
@@ -41,6 +45,11 @@ class AmendCaseDetailsControllerTest extends BaseControllerTest {
 
   private static final String FEE_CODE = "feecode";
   private static final String MATTER_TYPE_CODE = "mattertype";
+  private static final String UFN = "010424/820";
+  private static final String SCHEME_ID = "schemeid";
+  private static final String SCHEDULE_REFERENCE = "schedref";
+  private static final LocalDate CASE_START_DATE = LocalDate.of(2024, 3, 5);
+  private static final LocalDate CASE_CONCLUDED_DATE = LocalDate.of(2024, 4, 6);
 
   @BeforeEach
   void setup() {
@@ -175,6 +184,96 @@ class AmendCaseDetailsControllerTest extends BaseControllerTest {
         .andExpect(
             content()
                 .string(containsString("Unique file number (UFN) must be 50 characters or less")));
+  }
+
+  @Test
+  void postCaseDetailsKeepsLockedFieldValuesWhenClaimAssessed() throws Exception {
+    var crimeClaim = MockClaimsFunctions.createMockCrimeClaim();
+    crimeClaim.setSubmissionId(submissionId);
+    crimeClaim.setClaimId(claimId);
+    crimeClaim.setUniqueFileNumber(UFN);
+    crimeClaim.setSchemeId(SCHEME_ID);
+    crimeClaim.setCaseEndDate(CASE_CONCLUDED_DATE);
+    crimeClaim.setHasAssessment(true);
+    crimeClaim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
+    session.setAttribute(claimId.toString(), crimeClaim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId),
+        MockAmendmentFormsFunctions.justCaseDetailsFilled(crimeClaim));
+
+    mockMvc
+        .perform(
+            post(buildAmendCaseDetailsPath())
+                .param(INPUTS.formatted("MAAT_ID"), "updated")
+                .param(INPUTS.formatted("UNIQUE_FILE_NUMBER"), "tampered")
+                .param(INPUTS.formatted("SCHEME_ID"), "tampered")
+                .param(INPUTS.formatted("CASE_CONCLUDED_DATE-day"), "9")
+                .param(INPUTS.formatted("CASE_CONCLUDED_DATE-month"), "9")
+                .param(INPUTS.formatted("CASE_CONCLUDED_DATE-year"), "2030")
+                .session(session)
+                .with(csrf()))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(buildAmendCaseTabPath()));
+
+    var saved =
+        requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var current = saved.getCaseDetailsForm().getCurrent();
+
+    assertThat(current.getInputs().get("MAAT_ID")).isEqualTo("updated");
+    assertThat(current.getInputs().get("UNIQUE_FILE_NUMBER")).isEqualTo(UFN);
+    assertThat(current.getInputs().get("SCHEME_ID")).isEqualTo(SCHEME_ID);
+    assertThat(current.getInputs().get("CASE_CONCLUDED_DATE-day")).isEqualTo("6");
+    assertThat(current.getInputs().get("CASE_CONCLUDED_DATE-month")).isEqualTo("4");
+    assertThat(current.getInputs().get("CASE_CONCLUDED_DATE-year")).isEqualTo("2024");
+  }
+
+  @Test
+  void postCaseDetailsKeepsLockedDateValuesWhenLegalHelpClaimAssessed() throws Exception {
+    var civilClaim = MockClaimsFunctions.createMockCivilClaim();
+    civilClaim.setSubmissionId(submissionId);
+    civilClaim.setClaimId(claimId);
+    civilClaim.setScheduleReference(SCHEDULE_REFERENCE);
+    civilClaim.setUniqueFileNumber(UFN);
+    civilClaim.setCaseStartDate(CASE_START_DATE);
+    civilClaim.setCaseConcludedDate(CASE_CONCLUDED_DATE);
+    civilClaim.setHasAssessment(true);
+    civilClaim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
+    session.setAttribute(claimId.toString(), civilClaim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId),
+        MockAmendmentFormsFunctions.justCaseDetailsFilled(civilClaim));
+
+    mockMvc
+        .perform(
+            post(buildAmendCaseDetailsPath())
+                .param(INPUTS.formatted("SCHEDULE_REFERENCE_CIVIL"), "updated")
+                .param(INPUTS.formatted("UNIQUE_FILE_NUMBER"), "010424/999")
+                .param(INPUTS.formatted("CASE_START_DATE-day"), "9")
+                .param(INPUTS.formatted("CASE_START_DATE-month"), "9")
+                .param(INPUTS.formatted("CASE_START_DATE-year"), "2030")
+                .param(INPUTS.formatted("CASE_CONCLUDED_CLAIMED_DATE-day"), "9")
+                .param(INPUTS.formatted("CASE_CONCLUDED_CLAIMED_DATE-month"), "9")
+                .param(INPUTS.formatted("CASE_CONCLUDED_CLAIMED_DATE-year"), "2030")
+                .session(session)
+                .with(csrf()))
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(buildAmendCaseTabPath()));
+
+    var saved =
+        requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var inputs = saved.getCaseDetailsForm().getCurrent().getInputs();
+
+    assertThat(inputs.get("CASE_START_DATE-day")).isEqualTo("5");
+    assertThat(inputs.get("CASE_START_DATE-month")).isEqualTo("3");
+    assertThat(inputs.get("CASE_START_DATE-year")).isEqualTo("2024");
+    assertThat(inputs.get("CASE_CONCLUDED_CLAIMED_DATE-day")).isEqualTo("6");
+    assertThat(inputs.get("CASE_CONCLUDED_CLAIMED_DATE-month")).isEqualTo("4");
+    assertThat(inputs.get("CASE_CONCLUDED_CLAIMED_DATE-year")).isEqualTo("2024");
+
+    assertThat(inputs.get("SCHEDULE_REFERENCE_CIVIL")).isEqualTo("updated");
+    assertThat(inputs.get("UNIQUE_FILE_NUMBER")).isEqualTo("010424/999");
   }
 
   public String buildAmendCaseDetailsPath() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
@@ -1,5 +1,6 @@
 package uk.gov.justice.laa.amend.claim.controllers.amendments;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.Mockito.when;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 import static uk.gov.justice.laa.amend.claim.utils.SessionUtils.AMENDMENTS_KEY;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,8 +32,10 @@ import uk.gov.justice.laa.amend.claim.forms.amendments.validators.FeeCodeAmendme
 import uk.gov.justice.laa.amend.claim.forms.amendments.validators.TextAmendmentFieldValidator;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.enums.AreaOfLaw;
+import uk.gov.justice.laa.amend.claim.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AvailableFeeCodesService;
+import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
 
 @WebMvcTest(AmendCaseTypeController.class)
 @Import({
@@ -968,6 +972,135 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
         .andExpect(status().is3xxRedirection())
         .andExpect(redirectedUrl(buildAmendCasePath()))
         .andExpect(request().sessionAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms));
+  }
+
+  @Test
+  void getAmendFeeCodeReturnsNotFoundWhenClaimAssessed() throws Exception {
+    markAssessed(claim);
+    session.setAttribute(claimId.toString(), claim);
+
+    mockMvc.perform(get(buildAmendFeeCodePath()).session(session)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void postAmendFeeCodeReturnsNotFoundWithoutSavingWhenClaimAssessed() throws Exception {
+    markAssessed(claim);
+    session.setAttribute(claimId.toString(), claim);
+
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    mockMvc
+        .perform(
+            post(buildAmendFeeCodePath())
+                .param(INPUTS.formatted("FEE_CODE"), "NEWFEE")
+                .session(session)
+                .with(csrf()))
+        .andExpect(status().isNotFound());
+
+    var unchanged = requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    assertThat(unchanged.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE")).isNull();
+  }
+
+  @Test
+  void getAmendStageReachedStillServedForAnAssessedCrimeClaim() throws Exception {
+    markAssessed(claim);
+    session.setAttribute(claimId.toString(), claim);
+
+    var caseTypeForm = new AmendmentForm();
+    caseTypeForm.setInputs(new HashMap<>(Map.of("STAGE_REACHED", STAGE_REACHED)));
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId),
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(caseTypeForm)
+            .caseDetails(new AmendmentForm())
+            .build());
+
+    mockMvc
+        .perform(get(buildAmendStageReachedPath()).session(session))
+        .andExpect(status().isOk())
+        .andExpect(view().name("amendments/amend-stage-reached"));
+  }
+
+  @Test
+  void postAmendStageReachedKeepsTheLockedFeeCodeWhenClaimAssessed() throws Exception {
+    claim.setFeeCode(FEE_CODE);
+    claim.setStageReached(STAGE_REACHED);
+    markAssessed(claim);
+    session.setAttribute(claimId.toString(), claim);
+
+    var view = ClaimCaseViewFactory.create(claim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId),
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm(view.caseTypeRows()))
+            .caseDetails(new AmendmentForm())
+            .build());
+
+    mockMvc
+        .perform(
+            post(buildAmendStageReachedPath())
+                .param(INPUTS.formatted("STAGE_REACHED"), "INVB")
+                .param(INPUTS.formatted("FEE_CODE"), "tampered")
+                .session(session)
+                .with(csrf()))
+        .andExpect(status().is3xxRedirection());
+
+    var saved = requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var current = saved.getCaseTypeForm().getCurrent();
+
+    assertThat(current.getInputs().get("STAGE_REACHED")).isEqualTo("INVB");
+    assertThat(current.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
+  }
+
+  @Test
+  void postAmendMatterTypeKeepsTheLockedFeeCodeWhenClaimAssessed() throws Exception {
+    var civilClaim = MockClaimsFunctions.createMockCivilClaim();
+    civilClaim.setSubmissionId(submissionId);
+    civilClaim.setClaimId(claimId);
+    civilClaim.setFeeCode(FEE_CODE);
+    civilClaim.setMatterType1(MATTER_TYPE_CODE_1);
+    civilClaim.setMatterType2(MATTER_TYPE_CODE_2);
+    markAssessed(civilClaim);
+    session.setAttribute(claimId.toString(), civilClaim);
+
+    var view = ClaimCaseViewFactory.create(civilClaim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId),
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm(view.caseTypeRows()))
+            .caseDetails(new AmendmentForm())
+            .build());
+
+    mockMvc
+        .perform(
+            post(buildAmendMatterTypeCodePath())
+                .param(INPUTS.formatted("MATTER_TYPE_CODE_1"), "NEW1")
+                .param(INPUTS.formatted("MATTER_TYPE_CODE_2"), "NEW2")
+                .param(INPUTS.formatted("FEE_CODE"), "tampered")
+                .session(session)
+                .with(csrf()))
+        .andExpect(status().is3xxRedirection());
+
+    var saved = requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var current = saved.getCaseTypeForm().getCurrent();
+
+    assertThat(current.getInputs().get("MATTER_TYPE_CODE_1")).isEqualTo("NEW1");
+    assertThat(current.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
+  }
+
+  private static void markAssessed(ClaimDetails claim) {
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
   }
 
   private String buildAmendCasePath() {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/controllers/amendments/AmendCaseTypeControllerTest.java
@@ -36,6 +36,7 @@ import uk.gov.justice.laa.amend.claim.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.service.AvailableFeeCodesService;
 import uk.gov.justice.laa.amend.claim.viewmodels.claimcase.ClaimCaseViewFactory;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 
 @WebMvcTest(AmendCaseTypeController.class)
 @Import({
@@ -1003,7 +1004,8 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
                 .with(csrf()))
         .andExpect(status().isNotFound());
 
-    var unchanged = requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var unchanged =
+        requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
     assertThat(unchanged.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE")).isNull();
   }
 
@@ -1053,7 +1055,8 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
                 .with(csrf()))
         .andExpect(status().is3xxRedirection());
 
-    var saved = requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var saved =
+        requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
     var current = saved.getCaseTypeForm().getCurrent();
 
     assertThat(current.getInputs().get("STAGE_REACHED")).isEqualTo("INVB");
@@ -1090,11 +1093,29 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
                 .with(csrf()))
         .andExpect(status().is3xxRedirection());
 
-    var saved = requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
+    var saved =
+        requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
     var current = saved.getCaseTypeForm().getCurrent();
 
     assertThat(current.getInputs().get("MATTER_TYPE_CODE_1")).isEqualTo("NEW1");
     assertThat(current.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
+  }
+
+  @Test
+  void getAmendMatterTypeReturnsNotFoundWhenClaimNotValid() throws Exception {
+    claim.setStatus(ClaimStatus.VOID);
+    session.setAttribute(claimId.toString(), claim);
+    session.setAttribute(
+        AMENDMENTS_KEY.formatted(claimId),
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build());
+
+    mockMvc
+        .perform(get(buildAmendMatterTypeCodePath()).session(session))
+        .andExpect(status().isNotFound());
   }
 
   private static void markAssessed(ClaimDetails claim) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/DateAmendmentFieldValidatorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/DateAmendmentFieldValidatorTest.java
@@ -9,6 +9,8 @@ import org.springframework.validation.Errors;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
 
 class DateAmendmentFieldValidatorTest {
 
@@ -61,7 +63,7 @@ class DateAmendmentFieldValidatorTest {
   void rejectsImpossibleDateNamingDifferentField() {
     var errors =
         validate(
-            ClaimDetailsViewField.CASE_CONCLUDED_DATE,
+            CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE,
             Map.of(
                 "CASE_CONCLUDED_DATE-day", "31",
                 "CASE_CONCLUDED_DATE-month", "2",
@@ -73,7 +75,7 @@ class DateAmendmentFieldValidatorTest {
     assertThat(fieldError.getArguments()[0]).isEqualTo("Case concluded date");
   }
 
-  private Errors validate(ClaimDetailsViewField field, Map<String, String> inputs) {
+  private Errors validate(ClaimViewField<?> field, Map<String, String> inputs) {
     var form = new AmendmentForm();
     form.setInputs(inputs);
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/TextAmendmentFieldValidatorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/TextAmendmentFieldValidatorTest.java
@@ -9,6 +9,8 @@ import org.springframework.validation.Errors;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
 
 class TextAmendmentFieldValidatorTest {
 
@@ -19,7 +21,8 @@ class TextAmendmentFieldValidatorTest {
   void acceptsTextValueAtMaxLength() {
     var value = "a".repeat(TextAmendmentFieldValidator.MAX_TEXT_LENGTH);
     var errors =
-        validate(ClaimDetailsViewField.UNIQUE_FILE_NUMBER, Map.of("UNIQUE_FILE_NUMBER", value));
+        validate(
+            CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER, Map.of("UNIQUE_FILE_NUMBER", value));
 
     assertThat(errors.hasErrors()).isFalse();
   }
@@ -28,7 +31,8 @@ class TextAmendmentFieldValidatorTest {
   void rejectsTextValueOverMaxLengthNamingTheField() {
     var value = "a".repeat(TextAmendmentFieldValidator.MAX_TEXT_LENGTH + 1);
     var errors =
-        validate(ClaimDetailsViewField.UNIQUE_FILE_NUMBER, Map.of("UNIQUE_FILE_NUMBER", value));
+        validate(
+            CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER, Map.of("UNIQUE_FILE_NUMBER", value));
 
     assertThat(errors.hasErrors()).isTrue();
     var fieldError = errors.getFieldError("inputs[UNIQUE_FILE_NUMBER]");
@@ -50,7 +54,7 @@ class TextAmendmentFieldValidatorTest {
     assertThat(fieldError.getArguments()[1]).isEqualTo("50");
   }
 
-  private Errors validate(ClaimDetailsViewField field, Map<String, String> inputs) {
+  private Errors validate(ClaimViewField<?> field, Map<String, String> inputs) {
     var form = new AmendmentForm();
     form.setInputs(inputs);
 

--- a/src/test/java/uk/gov/justice/laa/amend/claim/forms/validators/AmendmentFormValidatorTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/forms/validators/AmendmentFormValidatorTest.java
@@ -24,7 +24,6 @@ import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
 import uk.gov.justice.laa.amend.claim.models.enums.FieldType;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
-import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
 import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
 
@@ -118,7 +117,9 @@ class AmendmentFormValidatorTest {
             new AmendmentFormValidator(
                 MockClaimsFunctions.createMockCrimeClaim(),
                 defaultFieldValidators(),
-                List.of(rejectingFieldSpecificValidator(ClaimDetailsViewField.UNIQUE_FILE_NUMBER))),
+                List.of(
+                    rejectingFieldSpecificValidator(
+                        CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER))),
             Map.of("UNIQUE_FILE_NUMBER", "a".repeat(51)));
 
     assertThat(errors.getFieldErrors("inputs[UNIQUE_FILE_NUMBER]")).hasSize(1);

--- a/src/test/java/uk/gov/justice/laa/amend/claim/service/CheckAmendmentsServiceTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/service/CheckAmendmentsServiceTest.java
@@ -22,6 +22,7 @@ import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.amend.claim.forms.amendments.OriginalAndCurrent;
 import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimPatch;
 
@@ -592,6 +593,47 @@ class CheckAmendmentsServiceTest {
             .build();
 
     assertThat(patch).usingRecursiveComparison().isEqualTo(expected);
+  }
+
+  @Test
+  void doesNotPatchFieldsLockedByAssessmentButStillPatchesTheRest() {
+    var submissionId = UUID.randomUUID();
+    var claimId = UUID.randomUUID();
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setVersion(1L);
+    claim.setHasAssessment(true);
+    claim.setLastAssessment(
+        MockClaimsFunctions.createAssessment(AssessmentTypeEnum.ESCAPE_CASE_ASSESSMENT));
+
+    var amendmentForms =
+        amendmentForms(
+            forms(Map.of(), Map.of()),
+            forms(Map.of("FEE_CODE", "OLD_FEE"), Map.of("FEE_CODE", "NEW_FEE")),
+            forms(
+                Map.ofEntries(
+                    entry("UNIQUE_FILE_NUMBER", "OLD_UFN"),
+                    entry("SCHEME_ID", "OLD_SCHEME"),
+                    entry("POLICE_STATION_COURT_PRISON_ID", "OLD_STATION"),
+                    entry("MAAT_ID", "OLD_MAAT"),
+                    entry("STAGE_REACHED", "OLD_STAGE")),
+                Map.ofEntries(
+                    entry("UNIQUE_FILE_NUMBER", "NEW_UFN"),
+                    entry("SCHEME_ID", "NEW_SCHEME"),
+                    entry("POLICE_STATION_COURT_PRISON_ID", "NEW_STATION"),
+                    entry("MAAT_ID", "NEW_MAAT"),
+                    entry("STAGE_REACHED", "NEW_STAGE"))),
+            null,
+            forms(Map.of(), Map.of()));
+
+    var patch = submitAndCapturePatch(submissionId, claimId, claim, amendmentForms);
+
+    assertThat(patch.getFeeCode()).isNull();
+    assertThat(patch.getUniqueFileNumber()).isNull();
+    assertThat(patch.getSchemeId()).isNull();
+    assertThat(patch.getPoliceStationCourtPrisonId()).isNull();
+
+    assertThat(patch.getMaatId()).isEqualTo("NEW_MAAT");
+    assertThat(patch.getStageReachedCode()).isEqualTo("NEW_STAGE");
   }
 
   private ClaimPatch submitAndCapturePatch(

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/AssessedFieldLockTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/AssessedFieldLockTest.java
@@ -76,16 +76,8 @@ class AssessedFieldLockTest {
   @Test
   void stillHonoursFieldsThatAreNeverEditable() {
     assertThat(ClaimDetailsViewField.FIXED_FEE.getAmendability()).isEqualTo(Amendability.NEVER);
-    assertThat(ClaimDetailsViewField.FIXED_FEE.isEditable()).isFalse();
     assertThat(ClaimDetailsViewField.FIXED_FEE.isEditable(false)).isFalse();
     assertThat(ClaimDetailsViewField.FIXED_FEE.isEditable(true)).isFalse();
-  }
-
-  @Test
-  void treatsNoArgIsEditableAsTheUnassessedCase() {
-    assertThat(ClaimDetailsViewField.FEE_CODE.isEditable()).isTrue();
-    assertThat(CrimeClaimDetailsViewField.SCHEME_ID.isEditable()).isTrue();
-    assertThat(CrimeClaimDetailsViewField.MAAT_ID.isEditable()).isTrue();
   }
 
   private static Stream<ClaimViewField<?>> lockedIn(ClaimViewField<?>[] fields) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/AssessedFieldLockTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/viewmodels/viewfield/AssessedFieldLockTest.java
@@ -1,0 +1,95 @@
+package uk.gov.justice.laa.amend.claim.viewmodels.viewfield;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import uk.gov.justice.laa.amend.claim.models.enums.Amendability;
+
+class AssessedFieldLockTest {
+
+  @Test
+  void locksOnlyTheFinancialFieldsSharedAcrossAreasOfLaw() {
+    assertThat(lockedIn(ClaimDetailsViewField.values()))
+        .containsExactlyInAnyOrder(
+            ClaimDetailsViewField.FEE_CODE, ClaimDetailsViewField.CASE_START_DATE);
+  }
+
+  @Test
+  void locksOnlyTheFinancialCrimeLowerFields() {
+    assertThat(lockedIn(CrimeClaimDetailsViewField.values()))
+        .containsExactlyInAnyOrder(
+            CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER,
+            CrimeClaimDetailsViewField.REPRESENTATION_ORDER_DATE,
+            CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE,
+            CrimeClaimDetailsViewField.POLICE_STATION_COURT_PRISON_ID,
+            CrimeClaimDetailsViewField.SCHEME_ID);
+  }
+
+  @Test
+  void locksOnlyTheFinancialLegalHelpFields() {
+    assertThat(lockedIn(CivilClaimDetailsViewField.values()))
+        .containsExactlyInAnyOrder(CivilClaimDetailsViewField.CASE_CONCLUDED_CLAIMED_DATE);
+  }
+
+  @Test
+  void locksNoMediationSpecificFields() {
+    assertThat(lockedIn(MediationClaimDetailsViewField.values())).isEmpty();
+  }
+
+  @Test
+  void locksCaseConcludedDateForCrimeLowerButNotMediation() {
+    assertThat(CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE.isEditable(true)).isFalse();
+    assertThat(MediationClaimDetailsViewField.CASE_CONCLUDED_DATE.isEditable(true)).isTrue();
+
+    assertThat(CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE.name())
+        .isEqualTo(MediationClaimDetailsViewField.CASE_CONCLUDED_DATE.name());
+  }
+
+  @Test
+  void locksTheUniqueFileNumberForCrimeLowerButNotLegalHelp() {
+    assertThat(CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER.isEditable(true)).isFalse();
+    assertThat(CivilClaimDetailsViewField.UNIQUE_FILE_NUMBER.isEditable(true)).isTrue();
+
+    assertThat(CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER.name())
+        .isEqualTo(CivilClaimDetailsViewField.UNIQUE_FILE_NUMBER.name());
+  }
+
+  @Test
+  void locksNothingWhileTheClaimHasNotBeenAssessed() {
+    assertThat(ClaimDetailsViewField.FEE_CODE.isEditable(false)).isTrue();
+    assertThat(CrimeClaimDetailsViewField.UNIQUE_FILE_NUMBER.isEditable(false)).isTrue();
+    assertThat(CrimeClaimDetailsViewField.SCHEME_ID.isEditable(false)).isTrue();
+  }
+
+  @Test
+  void leavesTheNonFinancialCaseFieldsEditableOnAnAssessedClaim() {
+    assertThat(CrimeClaimDetailsViewField.STAGE_REACHED.isEditable(true)).isTrue();
+    assertThat(CrimeClaimDetailsViewField.OUTCOME_FOR_CLIENT.isEditable(true)).isTrue();
+    assertThat(CrimeClaimDetailsViewField.STANDARD_FEE_CATEGORY.isEditable(true)).isTrue();
+    assertThat(MediationClaimDetailsViewField.CASE_CONCLUDED_DATE.isEditable(true)).isTrue();
+    assertThat(CivilClaimDetailsViewField.MATTER_TYPE_CODE_1.isEditable(true)).isTrue();
+    assertThat(CivilClaimDetailsViewField.STAGE_REACHED.isEditable(true)).isTrue();
+  }
+
+  @Test
+  void stillHonoursFieldsThatAreNeverEditable() {
+    assertThat(ClaimDetailsViewField.FIXED_FEE.getAmendability()).isEqualTo(Amendability.NEVER);
+    assertThat(ClaimDetailsViewField.FIXED_FEE.isEditable()).isFalse();
+    assertThat(ClaimDetailsViewField.FIXED_FEE.isEditable(false)).isFalse();
+    assertThat(ClaimDetailsViewField.FIXED_FEE.isEditable(true)).isFalse();
+  }
+
+  @Test
+  void treatsNoArgIsEditableAsTheUnassessedCase() {
+    assertThat(ClaimDetailsViewField.FEE_CODE.isEditable()).isTrue();
+    assertThat(CrimeClaimDetailsViewField.SCHEME_ID.isEditable()).isTrue();
+    assertThat(CrimeClaimDetailsViewField.MAAT_ID.isEditable()).isTrue();
+  }
+
+  private static Stream<ClaimViewField<?>> lockedIn(ClaimViewField<?>[] fields) {
+    return Arrays.stream(fields)
+        .filter(field -> field.getAmendability() == Amendability.UNTIL_ASSESSED);
+  }
+}

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseDetailsViewTest.java
@@ -447,6 +447,95 @@ class AmendCaseDetailsViewTest extends AmendmentsBaseTest {
     assertShowsAssessedBanner(renderDocument());
   }
 
+  @Test
+  void assessedLegalHelpClaimLocksTheFinancialRowsOnly() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    claim.setScheduleReference(SCHEDULE_REFERENCE);
+    claim.setCaseStartDate(CASE_START_DATE);
+    claim.setCaseConcludedDate(CASE_CONCLUDED_DATE);
+    claim.setUniqueFileNumber(UFN);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    var caseDetails = getSummaryListInCard(renderDocument(), "Case details");
+
+    assertRowIsLocked(caseDetails.get(4), "Case start date", CASE_START_DATE.format(testFormatter));
+    assertRowIsLocked(
+        caseDetails.get(5),
+        "Case concluded date or case claimed date",
+        CASE_CONCLUDED_DATE.format(testFormatter));
+
+    assertRowIsEditable(caseDetails.get(1), "Schedule reference");
+    assertRowIsEditable(caseDetails.get(6), "Unique file number (UFN)");
+  }
+
+  @Test
+  void assessedCrimeClaimLocksTheFinancialRowsOnly() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    claim.setMatterTypeCode(MATTER_TYPE_CODE);
+    claim.setUniqueFileNumber(UFN);
+    claim.setRepresentationOrderDate(REPRESENTATION_ORDER_DATE);
+    claim.setCaseEndDate(CASE_CONCLUDED_DATE);
+    claim.setPoliceStationCourtPrisonId(POLICE_STATION_COURT_PRISON_ID);
+    claim.setSchemeId(SCHEME_ID);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    var caseDetails = getSummaryListInCard(renderDocument(), "Case details");
+
+    assertRowIsLocked(caseDetails.get(2), "Unique file number (UFN)", UFN);
+    assertRowIsLocked(
+        caseDetails.get(3),
+        "Representation order date",
+        REPRESENTATION_ORDER_DATE.format(testFormatter));
+    assertRowIsLocked(
+        caseDetails.get(9), "Police station/Court ID/Prison ID", POLICE_STATION_COURT_PRISON_ID);
+    assertRowIsLocked(caseDetails.get(10), "Scheme ID", SCHEME_ID);
+
+    assertRowIsLocked(
+        caseDetails.get(4), "Case concluded date", CASE_CONCLUDED_DATE.format(testFormatter));
+
+    assertRowIsEditable(caseDetails.get(1), "Matter type");
+    assertRowIsEditable(caseDetails.get(5), "Standard fee category");
+  }
+
+  @Test
+  void unassessedClaimLeavesEveryRowEditable() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    claim.setUniqueFileNumber(UFN);
+    claim.setSchemeId(SCHEME_ID);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    var caseDetails = getSummaryListInCard(renderDocument(), "Case details");
+
+    assertRowIsEditable(caseDetails.get(2), "Unique file number (UFN)");
+    assertRowIsEditable(caseDetails.get(10), "Scheme ID");
+  }
+
+  private void assertRowIsLocked(List<Element> row, String label, String currentValue) {
+    assertCellContainsText(row.getFirst(), label);
+    assertCellContainsText(row.get(1), currentValue);
+    Assertions.assertTrue(
+        row.get(2).select("input, select, textarea").isEmpty(),
+        "Expected no amend input for locked row '%s'".formatted(label));
+  }
+
+  private void assertRowIsEditable(List<Element> row, String label) {
+    assertCellContainsText(row.getFirst(), label);
+    Assertions.assertFalse(
+        row.get(2).select("input, select, textarea").isEmpty(),
+        "Expected an amend input for editable row '%s'".formatted(label));
+  }
+
   private static @NonNull AmendmentForms createCaseForms(ClaimDetails claimDetails) {
     var view = ClaimCaseViewFactory.create(claimDetails);
     return AmendmentForms.builder()

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseTabViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendCaseTabViewTest.java
@@ -666,6 +666,44 @@ class AmendCaseTabViewTest extends AmendmentsBaseTest {
     assertShowsAssessedBanner(renderDocument());
   }
 
+  @Test
+  void caseTypeChangeLinkSkipsFeeCodeForAnAssessedLegalHelpClaim() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    var doc = renderDocument();
+
+    assertPageHasLink(doc, "amend-case-type-link", "Change", amendMatterTypeCodeUrl);
+    assertPageHasLink(doc, "amend-case-details-link", "Change", amendCaseDetailsUrl);
+  }
+
+  @Test
+  void caseTypeChangeLinkSkipsFeeCodeForAnAssessedCrimeClaim() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    assertPageHasLink(renderDocument(), "amend-case-type-link", "Change", amendStageReachedUrl);
+  }
+
+  @Test
+  void caseTypeChangeLinkStartsAtFeeCodeWhenTheClaimIsNotAssessed() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseForms(claim));
+
+    assertPageHasLink(renderDocument(), "amend-case-type-link", "Change", amendFeeCodeUrl);
+  }
+
   private static @NonNull AmendmentForms createCaseForms(ClaimDetails claimDetails) {
     var view = ClaimCaseViewFactory.create(claimDetails);
     return AmendmentForms.builder()

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendFeeCodeViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendFeeCodeViewTest.java
@@ -2,6 +2,8 @@ package uk.gov.justice.laa.amend.claim.views.amendments;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.justice.laa.amend.claim.utils.SessionUtils.AMENDMENTS_KEY;
 
 import java.util.Map;
@@ -50,7 +52,7 @@ class AmendFeeCodeViewTest extends AmendmentsBaseTest {
   }
 
   @Test
-  void showsAssessedBanner() {
+  void isNotReachableWhenTheClaimHasBeenAssessed() throws Exception {
     var claim = MockClaimsFunctions.createMockCrimeClaim();
     this.claim = claim;
     claim.setSubmissionId(submissionId);
@@ -58,9 +60,10 @@ class AmendFeeCodeViewTest extends AmendmentsBaseTest {
     claim.setFeeCode(FEE_CODE);
     markAssessed(claim);
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseTypeForm(claim));
-    when(availableFeeCodesService.getAvailableFeeCodes(any())).thenReturn(Map.of(FEE_CODE, "ABC"));
 
-    assertShowsAssessedBanner(renderDocument());
+    session.setAttribute(claimId.toString(), claim);
+
+    mockMvc.perform(get(amendFeeCodeUrl).session(session)).andExpect(status().isNotFound());
   }
 
   private AmendmentForms createCaseTypeForm(ClaimDetails claim) {

--- a/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendStageReachedViewTest.java
+++ b/src/test/java/uk/gov/justice/laa/amend/claim/views/amendments/AmendStageReachedViewTest.java
@@ -54,6 +54,18 @@ class AmendStageReachedViewTest extends AmendmentsBaseTest {
     assertPageHasLabel(doc, "stage-reached-input", "Amended stage reached");
   }
 
+  @Test
+  void showsAssessedBanner() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    markAssessed(claim);
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), createCaseTypeForm(claim));
+
+    assertShowsAssessedBanner(renderDocument());
+  }
+
   private AmendmentForms createCaseTypeForm(ClaimDetails claim) {
     var view = ClaimCaseViewFactory.create(claim);
     return AmendmentForms.builder()


### PR DESCRIPTION
[BC-745](https://dsdmoj.atlassian.net/browse/BC-745)

Describe what you did and why.

- Once a claim has been assessed, some fields must no longer be amendable. Until now every `ClaimViewField` was editable, so those fields were offered on the amend screens and would be sent in the `ClaimPatch`.

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.



[BC-745]: https://dsdmoj.atlassian.net/browse/BC-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ