### PR TITLE
BC-765 | Added ClientDateOfBirthDateValidator

### DIFF
--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/AmendmentDateValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/AmendmentDateValidator.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.MessageSource;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+
+@RequiredArgsConstructor
+public abstract class AmendmentDateValidator implements FieldSpecificAmendmentValidator {
+
+  private final MessageSource messageSource;
+
+  public static final String DATE_CANT_BE_BEFORE_CODE = "amendmentForm.dates.cantBeBefore";
+  public static final String DATE_CANT_BE_IN_FUTURE_CODE = "amendmentForm.dates.cantBeInFuture";
+  public static final String DATE_CANT_BE_LATER_THAN_SUBMISSION_PERIOD_CODE =
+      "amendmentForm.dates.cantBeLaterThanSubmissionPeriod";
+
+  private static final String DATE_FORMAT_D_MMM_YYYY = "d MMMM yyyy";
+  private static final DateTimeFormatter DATE_FORMATTER_D_MMM_YYYY =
+      DateTimeFormatter.ofPattern(DATE_FORMAT_D_MMM_YYYY);
+
+  private static final String DATE_FORMAT_MMM_YYYY = "MMM-yyyy";
+  public static final DateTimeFormatter SUBMISSION_PERIOD_FORMATTER =
+      new DateTimeFormatterBuilder()
+          .parseCaseInsensitive()
+          .appendPattern(DATE_FORMAT_MMM_YYYY)
+          .toFormatter(Locale.ENGLISH);
+
+  protected void addDateTooEarlyMessage(
+      Errors errors, ClaimViewField<?> field, LocalDate earliestDate) {
+    addUniqueFieldError(
+        field,
+        DATE_CANT_BE_BEFORE_CODE,
+        new Object[] {field.label(messageSource), DATE_FORMATTER_D_MMM_YYYY.format(earliestDate)},
+        errors);
+  }
+
+  protected void addDateInTheFutureMessage(Errors errors, ClaimViewField<?> field) {
+    addUniqueFieldError(
+        field, DATE_CANT_BE_IN_FUTURE_CODE, new Object[] {field.label(messageSource)}, errors);
+  }
+
+  protected void addDateOutsideSubmissionPeriodMessage(Errors errors, ClaimViewField<?> field) {
+    addUniqueFieldError(
+        field,
+        DATE_CANT_BE_LATER_THAN_SUBMISSION_PERIOD_CODE,
+        new Object[] {field.label(messageSource)},
+        errors);
+  }
+
+  protected final LocalDate getTwentiethOfNextMonth(@NotNull YearMonth submissionPeriod) {
+    return submissionPeriod.plusMonths(1).atDay(20);
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseConcludedDateValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseConcludedDateValidator.java
@@ -1,0 +1,60 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import java.time.LocalDate;
+import java.time.Month;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.models.enums.AreaOfLaw;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField;
+
+@Component
+public class CaseConcludedDateValidator extends AmendmentDateValidator {
+
+  private static final LocalDate EARLIEST_CASE_CONCLUDED_DATE_ALLOWED =
+      LocalDate.of(2013, Month.APRIL, 1);
+  private static final LocalDate EARLIEST_CRIME_CASE_CONCLUDED_DATE_ALLOWED =
+      LocalDate.of(2016, Month.APRIL, 1);
+
+  private final DateWrapperUtil dateWrapperUtil;
+
+  public CaseConcludedDateValidator(MessageSource messageSource, DateWrapperUtil dateWrapperUtil) {
+    super(messageSource);
+    this.dateWrapperUtil = dateWrapperUtil;
+  }
+
+  @Override
+  public boolean appliesTo(ClaimViewField<?> field) {
+    return CivilClaimDetailsViewField.CASE_CONCLUDED_CLAIMED_DATE.equals(field)
+        || CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE.equals(field)
+        || MediationClaimDetailsViewField.CASE_CONCLUDED_DATE.equals(field);
+  }
+
+  @Override
+  public void validate(
+      ClaimDetails claim, ClaimViewField<?> field, AmendmentForm form, Errors errors) {
+    var caseConcludedDate = form.getDateValue(field.name());
+    var earliestDate =
+        AreaOfLaw.CRIME_LOWER.equals(claim.getAreaOfLaw())
+            ? EARLIEST_CRIME_CASE_CONCLUDED_DATE_ALLOWED
+            : EARLIEST_CASE_CONCLUDED_DATE_ALLOWED;
+    if (caseConcludedDate == null || claim.getSubmissionPeriod() == null) {
+      return;
+    }
+
+    var twentiethOfNextMonth = getTwentiethOfNextMonth(claim.getSubmissionPeriod());
+    if (dateWrapperUtil.isFutureDate(caseConcludedDate)) {
+      addDateInTheFutureMessage(errors, field);
+    } else if (caseConcludedDate.isBefore(earliestDate)) {
+      addDateTooEarlyMessage(errors, field, earliestDate);
+    } else if (caseConcludedDate.isAfter(twentiethOfNextMonth)) {
+      addDateOutsideSubmissionPeriodMessage(errors, field);
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseStartDateValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseStartDateValidator.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import java.time.LocalDate;
+import java.time.Month;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+
+@Component
+public class CaseStartDateValidator extends AmendmentDateValidator {
+
+  private static final LocalDate OLDEST_DATE_ALLOWED = LocalDate.of(1995, Month.JANUARY, 1);
+
+  private final DateWrapperUtil dateWrapperUtil;
+
+  public CaseStartDateValidator(MessageSource messageSource, DateWrapperUtil dateWrapperUtil) {
+    super(messageSource);
+    this.dateWrapperUtil = dateWrapperUtil;
+  }
+
+  @Override
+  public boolean appliesTo(ClaimViewField<?> field) {
+    return ClaimDetailsViewField.CASE_START_DATE.equals(field);
+  }
+
+  @Override
+  public void validate(
+      ClaimDetails claim, ClaimViewField<?> field, AmendmentForm form, Errors errors) {
+    var caseStartDate = form.getDateValue(field.name());
+
+    if (caseStartDate == null) {
+      return;
+    }
+
+    if (dateWrapperUtil.isFutureDate(caseStartDate)) {
+      addDateInTheFutureMessage(errors, field);
+    } else if (caseStartDate.isBefore(OLDEST_DATE_ALLOWED)) {
+      addDateTooEarlyMessage(errors, field, OLDEST_DATE_ALLOWED);
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CivilTransferDateValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CivilTransferDateValidator.java
@@ -1,0 +1,46 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import java.time.LocalDate;
+import java.time.Month;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+
+@Component
+public class CivilTransferDateValidator extends AmendmentDateValidator {
+
+  private static final LocalDate EARLIEST_TRANSFER_DATE = LocalDate.of(1995, Month.JANUARY, 1);
+
+  private final DateWrapperUtil dateWrapperUtil;
+
+  public CivilTransferDateValidator(MessageSource messageSource, DateWrapperUtil dateWrapperUtil) {
+    super(messageSource);
+    this.dateWrapperUtil = dateWrapperUtil;
+  }
+
+  @Override
+  public boolean appliesTo(ClaimViewField<?> field) {
+    return CivilClaimDetailsViewField.TRANSFER_DATE.equals(field);
+  }
+
+  @Override
+  public void validate(
+      ClaimDetails claim, ClaimViewField<?> field, AmendmentForm form, Errors errors) {
+    var transferDate = form.getDateValue(field.name());
+
+    if (transferDate == null) {
+      return;
+    }
+
+    if (dateWrapperUtil.isFutureDate(transferDate)) {
+      addDateInTheFutureMessage(errors, field);
+    } else if (transferDate.isBefore(EARLIEST_TRANSFER_DATE)) {
+      addDateTooEarlyMessage(errors, field, EARLIEST_TRANSFER_DATE);
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/ClientDateOfBirthDateValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/ClientDateOfBirthDateValidator.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import java.time.LocalDate;
+import java.time.Month;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField;
+
+@Component
+public class ClientDateOfBirthDateValidator extends AmendmentDateValidator {
+
+  private static final LocalDate OLDEST_DATE_ALLOWED = LocalDate.of(1900, Month.JANUARY, 1);
+
+  private final DateWrapperUtil dateWrapperUtil;
+
+  public ClientDateOfBirthDateValidator(
+      MessageSource messageSource, DateWrapperUtil dateWrapperUtil) {
+    super(messageSource);
+    this.dateWrapperUtil = dateWrapperUtil;
+  }
+
+  @Override
+  public boolean appliesTo(ClaimViewField<?> field) {
+    return CivilClaimDetailsViewField.DATE_OF_BIRTH.equals(field)
+        || MediationClaimDetailsViewField.DATE_OF_BIRTH.equals(field)
+        || MediationClaimDetailsViewField.CLIENT_2_DATE_OF_BIRTH.equals(field);
+  }
+
+  @Override
+  public void validate(
+      ClaimDetails claim, ClaimViewField<?> field, AmendmentForm form, Errors errors) {
+    var dateOfBirth = form.getDateValue(field.name());
+
+    if (dateOfBirth == null) {
+      return;
+    }
+
+    if (dateOfBirth.isBefore(OLDEST_DATE_ALLOWED)) {
+      addDateTooEarlyMessage(errors, field, OLDEST_DATE_ALLOWED);
+    } else if (dateWrapperUtil.isFutureDate(dateOfBirth)) {
+      addDateInTheFutureMessage(errors, field);
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CrimeRepresentationOrderDateValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CrimeRepresentationOrderDateValidator.java
@@ -1,0 +1,47 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import java.time.LocalDate;
+import java.time.Month;
+import org.springframework.context.MessageSource;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
+
+@Component
+public class CrimeRepresentationOrderDateValidator extends AmendmentDateValidator {
+
+  private static final LocalDate EARLIEST_MIN_REP_ORDER_DATE = LocalDate.of(2016, Month.APRIL, 1);
+
+  private final DateWrapperUtil dateWrapperUtil;
+
+  public CrimeRepresentationOrderDateValidator(
+      MessageSource messageSource, DateWrapperUtil dateWrapperUtil) {
+    super(messageSource);
+    this.dateWrapperUtil = dateWrapperUtil;
+  }
+
+  @Override
+  public boolean appliesTo(ClaimViewField<?> field) {
+    return CrimeClaimDetailsViewField.REPRESENTATION_ORDER_DATE.equals(field);
+  }
+
+  @Override
+  public void validate(
+      ClaimDetails claim, ClaimViewField<?> field, AmendmentForm form, Errors errors) {
+    var representationOrderDate = form.getDateValue(field.name());
+
+    if (representationOrderDate == null) {
+      return;
+    }
+
+    if (dateWrapperUtil.isFutureDate(representationOrderDate)) {
+      addDateInTheFutureMessage(errors, field);
+    } else if (representationOrderDate.isBefore(EARLIEST_MIN_REP_ORDER_DATE)) {
+      addDateTooEarlyMessage(errors, field, EARLIEST_MIN_REP_ORDER_DATE);
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseConcludedDateValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseConcludedDateValidatorTest.java
@@ -1,0 +1,395 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.time.YearMonth;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField;
+
+@ExtendWith(MockitoExtension.class)
+class CaseConcludedDateValidatorTest {
+
+  CaseConcludedDateValidator validator;
+
+  @Mock DateWrapperUtil dateWrapperUtil;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = new CaseConcludedDateValidator(TestMessageSources.real(), dateWrapperUtil);
+  }
+
+  @Nested
+  class Civil {
+
+    @Test
+    void testAppliesTo() {
+      assertTrue(validator.appliesTo(CivilClaimDetailsViewField.CASE_CONCLUDED_CLAIMED_DATE));
+    }
+
+    @ParameterizedTest
+    @MethodSource(
+        "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+            + ".InvalidDateArgumentsProvider#invalidDateProvider")
+    void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_CLAIMED_DATE-day", day,
+              "CASE_CONCLUDED_CLAIMED_DATE-month", month,
+              "CASE_CONCLUDED_CLAIMED_DATE-year", year);
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_CLAIMED_DATE-day", "20",
+              "CASE_CONCLUDED_CLAIMED_DATE-month", "5",
+              "CASE_CONCLUDED_CLAIMED_DATE-year", "2013");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForFirstValidDate() {
+      // Day before submission end of next month rule
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_CLAIMED_DATE-day", "20",
+              "CASE_CONCLUDED_CLAIMED_DATE-month", "5",
+              "CASE_CONCLUDED_CLAIMED_DATE-year", "2013");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldAddErrorsForOldDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_CLAIMED_DATE-day", "31",
+              "CASE_CONCLUDED_CLAIMED_DATE-month", "3",
+              "CASE_CONCLUDED_CLAIMED_DATE-year", "2013");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date or case claimed date");
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getArguments()[1])
+          .isEqualTo("1 April 2013");
+    }
+
+    @Test
+    void shouldAddErrorsForDateInFuture() {
+      when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_CLAIMED_DATE-day", "2",
+              "CASE_CONCLUDED_CLAIMED_DATE-month", "1",
+              "CASE_CONCLUDED_CLAIMED_DATE-year", "2020");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date or case claimed date");
+    }
+
+    @Test
+    void shouldAddErrorsForDateNotInCorrectPeriod() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_CLAIMED_DATE-day", "21",
+              "CASE_CONCLUDED_CLAIMED_DATE-month", "5",
+              "CASE_CONCLUDED_CLAIMED_DATE-year", "2013");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_LATER_THAN_SUBMISSION_PERIOD_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_CLAIMED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date or case claimed date");
+    }
+
+    private Errors validateCivil(Map<String, String> inputs) {
+      ClaimDetails claimDetails = MockClaimsFunctions.createMockCivilClaim();
+      claimDetails.setSubmissionPeriod(YearMonth.of(2013, 4));
+
+      var form = new AmendmentForm();
+      form.setInputs(inputs);
+
+      var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+      validator.validate(
+          claimDetails, CivilClaimDetailsViewField.CASE_CONCLUDED_CLAIMED_DATE, form, errors);
+      return errors;
+    }
+  }
+
+  @Nested
+  class Mediation {
+
+    @Test
+    void testAppliesTo() {
+      assertTrue(validator.appliesTo(MediationClaimDetailsViewField.CASE_CONCLUDED_DATE));
+    }
+
+    @ParameterizedTest
+    @MethodSource(
+        "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+            + ".InvalidDateArgumentsProvider#invalidDateProvider")
+    void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", day,
+              "CASE_CONCLUDED_DATE-month", month,
+              "CASE_CONCLUDED_DATE-year", year);
+
+      Errors result = validationMediation(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "20",
+              "CASE_CONCLUDED_DATE-month", "5",
+              "CASE_CONCLUDED_DATE-year", "2013");
+
+      Errors result = validationMediation(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForFirstValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "1",
+              "CASE_CONCLUDED_DATE-month", "4",
+              "CASE_CONCLUDED_DATE-year", "2013");
+
+      Errors result = validationMediation(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldAddErrorsForOldDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "31",
+              "CASE_CONCLUDED_DATE-month", "3",
+              "CASE_CONCLUDED_DATE-year", "2013");
+
+      Errors result = validationMediation(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date");
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[1])
+          .isEqualTo("1 April 2013");
+    }
+
+    @Test
+    void shouldAddErrorsForDateInFuture() {
+      when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "2",
+              "CASE_CONCLUDED_DATE-month", "1",
+              "CASE_CONCLUDED_DATE-year", "2020");
+
+      Errors result = validationMediation(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date");
+    }
+
+    @Test
+    void shouldAddErrorsForDateNotInCorrectPeriod() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "21",
+              "CASE_CONCLUDED_DATE-month", "5",
+              "CASE_CONCLUDED_DATE-year", "2013");
+
+      Errors result = validationMediation(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_LATER_THAN_SUBMISSION_PERIOD_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date");
+    }
+
+    private Errors validationMediation(Map<String, String> inputs) {
+      ClaimDetails claimDetails = MockClaimsFunctions.createMockMediationClaim();
+      claimDetails.setSubmissionPeriod(YearMonth.of(2013, 4));
+
+      var form = new AmendmentForm();
+      form.setInputs(inputs);
+
+      var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+      validator.validate(
+          claimDetails, MediationClaimDetailsViewField.CASE_CONCLUDED_DATE, form, errors);
+      return errors;
+    }
+  }
+
+  @Nested
+  class Crime {
+
+    @Test
+    void testAppliesTo() {
+      assertTrue(validator.appliesTo(CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE));
+    }
+
+    @ParameterizedTest
+    @MethodSource(
+        "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+            + ".InvalidDateArgumentsProvider#invalidDateProvider")
+    void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", day,
+              "CASE_CONCLUDED_DATE-month", month,
+              "CASE_CONCLUDED_DATE-year", year);
+
+      Errors result = validateCrime(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "20",
+              "CASE_CONCLUDED_DATE-month", "5",
+              "CASE_CONCLUDED_DATE-year", "2016");
+
+      Errors result = validateCrime(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForFirstValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "1",
+              "CASE_CONCLUDED_DATE-month", "4",
+              "CASE_CONCLUDED_DATE-year", "2016");
+
+      Errors result = validateCrime(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldAddErrorsForOldDate() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "31",
+              "CASE_CONCLUDED_DATE-month", "3",
+              "CASE_CONCLUDED_DATE-year", "2016");
+
+      Errors result = validateCrime(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date");
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[1])
+          .isEqualTo("1 April 2016");
+    }
+
+    @Test
+    void shouldAddErrorsForDateInFuture() {
+      when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "2",
+              "CASE_CONCLUDED_DATE-month", "5",
+              "CASE_CONCLUDED_DATE-year", "2016");
+
+      Errors result = validateCrime(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date");
+    }
+
+    @Test
+    void shouldAddErrorsForDateNotInCorrectPeriod() {
+      Map<String, String> input =
+          Map.of(
+              "CASE_CONCLUDED_DATE-day", "21",
+              "CASE_CONCLUDED_DATE-month", "5",
+              "CASE_CONCLUDED_DATE-year", "2016");
+
+      Errors result = validateCrime(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_LATER_THAN_SUBMISSION_PERIOD_CODE);
+      assertThat(result.getFieldError("inputs['CASE_CONCLUDED_DATE']").getArguments()[0])
+          .isEqualTo("Case concluded date");
+    }
+
+    private Errors validateCrime(Map<String, String> inputs) {
+      ClaimDetails claimDetails = MockClaimsFunctions.createMockCrimeClaim();
+      claimDetails.setSubmissionPeriod(YearMonth.of(2016, 4));
+
+      var form = new AmendmentForm();
+      form.setInputs(inputs);
+
+      var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+      validator.validate(
+          claimDetails, CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE, form, errors);
+      return errors;
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseStartDateValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CaseStartDateValidatorTest.java
@@ -1,0 +1,130 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.ClaimDetailsViewField;
+
+@ExtendWith(MockitoExtension.class)
+class CaseStartDateValidatorTest {
+
+  CaseStartDateValidator validator;
+
+  @Mock DateWrapperUtil dateWrapperUtil;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = new CaseStartDateValidator(TestMessageSources.real(), dateWrapperUtil);
+  }
+
+  @Test
+  void testAppliesTo() {
+    assertTrue(validator.appliesTo(ClaimDetailsViewField.CASE_START_DATE));
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "uk.gov.justice.laa.amend.claim.forms.amendments.validators.InvalidDateArgumentsProvider#invalidDateProvider")
+  void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+    Map<String, String> input =
+        Map.of(
+            "CASE_START_DATE-day", day,
+            "CASE_START_DATE-month", month,
+            "CASE_START_DATE-year", year);
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotAddErrorsForValidDate() {
+    Map<String, String> input =
+        Map.of(
+            "CASE_START_DATE-day", "15",
+            "CASE_START_DATE-month", "12",
+            "CASE_START_DATE-year", "2020");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotAddErrorsForFirstValidDate() {
+    Map<String, String> input =
+        Map.of(
+            "CASE_START_DATE-day", "1",
+            "CASE_START_DATE-month", "1",
+            "CASE_START_DATE-year", "1995");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldAddErrorsForOldDate() {
+    Map<String, String> input =
+        Map.of(
+            "CASE_START_DATE-day", "31",
+            "CASE_START_DATE-month", "12",
+            "CASE_START_DATE-year", "1994");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isTrue();
+    assertThat(result.getFieldError("inputs['CASE_START_DATE']").getCode())
+        .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+    assertThat(result.getFieldError("inputs['CASE_START_DATE']").getArguments()[0])
+        .isEqualTo("Case start date");
+    assertThat(result.getFieldError("inputs['CASE_START_DATE']").getArguments()[1])
+        .isEqualTo("1 January 1995");
+  }
+
+  @Test
+  void shouldAddErrorsForDateInFuture() {
+    when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+    Map<String, String> input =
+        Map.of(
+            "CASE_START_DATE-day", "2",
+            "CASE_START_DATE-month", "1",
+            "CASE_START_DATE-year", "2020");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isTrue();
+    assertThat(result.getFieldError("inputs['CASE_START_DATE']").getCode())
+        .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+    assertThat(result.getFieldError("inputs['CASE_START_DATE']").getArguments()[0])
+        .isEqualTo("Case start date");
+  }
+
+  private Errors validate(Map<String, String> inputs) {
+    ClaimDetails claimDetails = MockClaimsFunctions.createMockCivilClaim();
+
+    var form = new AmendmentForm();
+    form.setInputs(inputs);
+
+    var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+    validator.validate(claimDetails, ClaimDetailsViewField.CASE_START_DATE, form, errors);
+    return errors;
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CivilTransferDateValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CivilTransferDateValidatorTest.java
@@ -1,0 +1,131 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
+
+@ExtendWith(MockitoExtension.class)
+class CivilTransferDateValidatorTest {
+
+  CivilTransferDateValidator validator;
+
+  @Mock DateWrapperUtil dateWrapperUtil;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = new CivilTransferDateValidator(TestMessageSources.real(), dateWrapperUtil);
+  }
+
+  @Test
+  void testAppliesTo() {
+    assertTrue(validator.appliesTo(CivilClaimDetailsViewField.TRANSFER_DATE));
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+          + ".InvalidDateArgumentsProvider#invalidDateProvider")
+  void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+    Map<String, String> input =
+        Map.of(
+            "TRANSFER_DATE-day", day,
+            "TRANSFER_DATE-month", month,
+            "TRANSFER_DATE-year", year);
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotAddErrorsForValidDate() {
+    Map<String, String> input =
+        Map.of(
+            "TRANSFER_DATE-day", "15",
+            "TRANSFER_DATE-month", "12",
+            "TRANSFER_DATE-year", "2020");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotAddErrorsForFirstValidDate() {
+    Map<String, String> input =
+        Map.of(
+            "TRANSFER_DATE-day", "1",
+            "TRANSFER_DATE-month", "1",
+            "TRANSFER_DATE-year", "1995");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldAddErrorsForOldDate() {
+    Map<String, String> input =
+        Map.of(
+            "TRANSFER_DATE-day", "31",
+            "TRANSFER_DATE-month", "12",
+            "TRANSFER_DATE-year", "1994");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isTrue();
+    assertThat(result.getFieldError("inputs['TRANSFER_DATE']").getCode())
+        .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+    assertThat(result.getFieldError("inputs['TRANSFER_DATE']").getArguments()[0])
+        .isEqualTo("Transfer date");
+    assertThat(result.getFieldError("inputs['TRANSFER_DATE']").getArguments()[1])
+        .isEqualTo("1 January 1995");
+  }
+
+  @Test
+  void shouldAddErrorsForDateInFuture() {
+    when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+    Map<String, String> input =
+        Map.of(
+            "TRANSFER_DATE-day", "2",
+            "TRANSFER_DATE-month", "1",
+            "TRANSFER_DATE-year", "2020");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isTrue();
+    assertThat(result.getFieldError("inputs['TRANSFER_DATE']").getCode())
+        .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+    assertThat(result.getFieldError("inputs['TRANSFER_DATE']").getArguments()[0])
+        .isEqualTo("Transfer date");
+  }
+
+  private Errors validate(Map<String, String> inputs) {
+    ClaimDetails claimDetails = MockClaimsFunctions.createMockCivilClaim();
+
+    var form = new AmendmentForm();
+    form.setInputs(inputs);
+
+    var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+    validator.validate(claimDetails, CivilClaimDetailsViewField.TRANSFER_DATE, form, errors);
+    return errors;
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/ClientDateOfBirthDateValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/ClientDateOfBirthDateValidatorTest.java
@@ -1,0 +1,336 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CivilClaimDetailsViewField;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.MediationClaimDetailsViewField;
+
+@ExtendWith(MockitoExtension.class)
+class ClientDateOfBirthDateValidatorTest {
+
+  ClientDateOfBirthDateValidator validator;
+
+  @Mock DateWrapperUtil dateWrapperUtil;
+
+  @BeforeEach
+  void beforeEach() {
+    validator = new ClientDateOfBirthDateValidator(TestMessageSources.real(), dateWrapperUtil);
+  }
+
+  @Nested
+  class Civil {
+
+    @Test
+    void testAppliesTo() {
+      assertTrue(validator.appliesTo(CivilClaimDetailsViewField.DATE_OF_BIRTH));
+    }
+
+    @ParameterizedTest
+    @MethodSource(
+        "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+            + ".InvalidDateArgumentsProvider#invalidDateProvider")
+    void shouldIgnoreUnparseableDateInputs(String day, String month, String year) {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", day,
+              "DATE_OF_BIRTH-month", month,
+              "DATE_OF_BIRTH-year", year);
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "20",
+              "DATE_OF_BIRTH-month", "5",
+              "DATE_OF_BIRTH-year", "2013");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForFirstValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "1",
+              "DATE_OF_BIRTH-month", "1",
+              "DATE_OF_BIRTH-year", "1900");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldAddErrorsForOldDate() {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "31",
+              "DATE_OF_BIRTH-month", "12",
+              "DATE_OF_BIRTH-year", "1899");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getArguments()[0])
+          .isEqualTo("Date of birth");
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getArguments()[1])
+          .isEqualTo("1 January 1900");
+    }
+
+    @Test
+    void shouldAddErrorsForDateInFuture() {
+      when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "1",
+              "DATE_OF_BIRTH-month", "1",
+              "DATE_OF_BIRTH-year", "2020");
+
+      Errors result = validateCivil(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getArguments()[0])
+          .isEqualTo("Date of birth");
+    }
+
+    private Errors validateCivil(Map<String, String> inputs) {
+      ClaimDetails claimDetails = MockClaimsFunctions.createMockCivilClaim();
+
+      var form = new AmendmentForm();
+      form.setInputs(inputs);
+
+      var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+      validator.validate(claimDetails, CivilClaimDetailsViewField.DATE_OF_BIRTH, form, errors);
+      return errors;
+    }
+  }
+
+  @Nested
+  class Mediation {
+
+    @Test
+    void testAppliesTo() {
+      assertTrue(validator.appliesTo(MediationClaimDetailsViewField.DATE_OF_BIRTH));
+    }
+
+    @ParameterizedTest
+    @MethodSource(
+        "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+            + ".InvalidDateArgumentsProvider#invalidDateProvider")
+    void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", day,
+              "DATE_OF_BIRTH-month", month,
+              "DATE_OF_BIRTH-year", year);
+
+      Errors result = validateMediationClient2(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "20",
+              "DATE_OF_BIRTH-month", "5",
+              "DATE_OF_BIRTH-year", "2013");
+
+      Errors result = validateMediationClient2(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForFirstValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "1",
+              "DATE_OF_BIRTH-month", "1",
+              "DATE_OF_BIRTH-year", "1900");
+
+      Errors result = validateMediationClient2(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldAddErrorsForOldDate() {
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "31",
+              "DATE_OF_BIRTH-month", "12",
+              "DATE_OF_BIRTH-year", "1899");
+
+      Errors result = validateMediationClient2(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getArguments()[0])
+          .isEqualTo("Date of birth");
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getArguments()[1])
+          .isEqualTo("1 January 1900");
+    }
+
+    @Test
+    void shouldAddErrorsForDateInFuture() {
+      when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+      Map<String, String> input =
+          Map.of(
+              "DATE_OF_BIRTH-day", "1",
+              "DATE_OF_BIRTH-month", "1",
+              "DATE_OF_BIRTH-year", "2020");
+
+      Errors result = validateMediationClient2(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+      assertThat(result.getFieldError("inputs['DATE_OF_BIRTH']").getArguments()[0])
+          .isEqualTo("Date of birth");
+    }
+
+    private Errors validateMediationClient2(Map<String, String> inputs) {
+      ClaimDetails claimDetails = MockClaimsFunctions.createMockMediationClaim();
+
+      var form = new AmendmentForm();
+      form.setInputs(inputs);
+
+      var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+      validator.validate(claimDetails, MediationClaimDetailsViewField.DATE_OF_BIRTH, form, errors);
+      return errors;
+    }
+  }
+
+  @Nested
+  class MediationClient2 {
+
+    @Test
+    void testAppliesTo() {
+      assertTrue(validator.appliesTo(MediationClaimDetailsViewField.CLIENT_2_DATE_OF_BIRTH));
+    }
+
+    @ParameterizedTest
+    @MethodSource(
+        "uk.gov.justice.laa.amend.claim.forms.amendments.validators"
+            + ".InvalidDateArgumentsProvider#invalidDateProvider")
+    void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+      Map<String, String> input =
+          Map.of(
+              "CLIENT_2_DATE_OF_BIRTH-day", day,
+              "CLIENT_2_DATE_OF_BIRTH-month", month,
+              "CLIENT_2_DATE_OF_BIRTH-year", year);
+
+      Errors result = validateMediation(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CLIENT_2_DATE_OF_BIRTH-day", "20",
+              "CLIENT_2_DATE_OF_BIRTH-month", "5",
+              "CLIENT_2_DATE_OF_BIRTH-year", "2013");
+
+      Errors result = validateMediation(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldNotAddErrorsForFirstValidDate() {
+      Map<String, String> input =
+          Map.of(
+              "CLIENT_2_DATE_OF_BIRTH-day", "1",
+              "CLIENT_2_DATE_OF_BIRTH-month", "1",
+              "CLIENT_2_DATE_OF_BIRTH-year", "1900");
+
+      Errors result = validateMediation(input);
+
+      assertThat(result.hasFieldErrors()).isFalse();
+    }
+
+    @Test
+    void shouldAddErrorsForOldDate() {
+      Map<String, String> input =
+          Map.of(
+              "CLIENT_2_DATE_OF_BIRTH-day", "31",
+              "CLIENT_2_DATE_OF_BIRTH-month", "12",
+              "CLIENT_2_DATE_OF_BIRTH-year", "1899");
+
+      Errors result = validateMediation(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CLIENT_2_DATE_OF_BIRTH']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+      assertThat(result.getFieldError("inputs['CLIENT_2_DATE_OF_BIRTH']").getArguments()[0])
+          .isEqualTo("Date of birth");
+      assertThat(result.getFieldError("inputs['CLIENT_2_DATE_OF_BIRTH']").getArguments()[1])
+          .isEqualTo("1 January 1900");
+    }
+
+    @Test
+    void shouldAddErrorsForDateInFuture() {
+      when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+      Map<String, String> input =
+          Map.of(
+              "CLIENT_2_DATE_OF_BIRTH-day", "1",
+              "CLIENT_2_DATE_OF_BIRTH-month", "1",
+              "CLIENT_2_DATE_OF_BIRTH-year", "2020");
+
+      Errors result = validateMediation(input);
+
+      assertThat(result.hasFieldErrors()).isTrue();
+      assertThat(result.getFieldError("inputs['CLIENT_2_DATE_OF_BIRTH']").getCode())
+          .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+      assertThat(result.getFieldError("inputs['CLIENT_2_DATE_OF_BIRTH']").getArguments()[0])
+          .isEqualTo("Date of birth");
+    }
+
+    private Errors validateMediation(Map<String, String> inputs) {
+      ClaimDetails claimDetails = MockClaimsFunctions.createMockMediationClaim();
+
+      var form = new AmendmentForm();
+      form.setInputs(inputs);
+
+      var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+      validator.validate(
+          claimDetails, MediationClaimDetailsViewField.CLIENT_2_DATE_OF_BIRTH, form, errors);
+      return errors;
+    }
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CrimeRepresentationOrderDateValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/CrimeRepresentationOrderDateValidatorTest.java
@@ -1,0 +1,131 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import uk.gov.justice.laa.amend.claim.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.amend.claim.models.ClaimDetails;
+import uk.gov.justice.laa.amend.claim.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.amend.claim.support.TestMessageSources;
+import uk.gov.justice.laa.amend.claim.utils.DateWrapperUtil;
+import uk.gov.justice.laa.amend.claim.viewmodels.viewfield.CrimeClaimDetailsViewField;
+
+@ExtendWith(MockitoExtension.class)
+class CrimeRepresentationOrderDateValidatorTest {
+
+  CrimeRepresentationOrderDateValidator validator;
+
+  @Mock DateWrapperUtil dateWrapperUtil;
+
+  @BeforeEach
+  void beforeEach() {
+    validator =
+        new CrimeRepresentationOrderDateValidator(TestMessageSources.real(), dateWrapperUtil);
+  }
+
+  @Test
+  void testAppliesTo() {
+    assertTrue(validator.appliesTo(CrimeClaimDetailsViewField.REPRESENTATION_ORDER_DATE));
+  }
+
+  @ParameterizedTest
+  @MethodSource(
+      "uk.gov.justice.laa.amend.claim.forms.amendments.validators.InvalidDateArgumentsProvider#invalidDateProvider")
+  void shouldNotAddErrorsForInvalidDates(String day, String month, String year) {
+    Map<String, String> input =
+        Map.of(
+            "REPRESENTATION_ORDER_DATE-day", day,
+            "REPRESENTATION_ORDER_DATE-month", month,
+            "REPRESENTATION_ORDER_DATE-year", year);
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotAddErrorsForValidDate() {
+    Map<String, String> input =
+        Map.of(
+            "REPRESENTATION_ORDER_DATE-day", "15",
+            "REPRESENTATION_ORDER_DATE-month", "12",
+            "REPRESENTATION_ORDER_DATE-year", "2020");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldNotAddErrorsForFirstValidDate() {
+    Map<String, String> input =
+        Map.of(
+            "REPRESENTATION_ORDER_DATE-day", "1",
+            "REPRESENTATION_ORDER_DATE-month", "4",
+            "REPRESENTATION_ORDER_DATE-year", "2016");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isFalse();
+  }
+
+  @Test
+  void shouldAddErrorsForOldDate() {
+    Map<String, String> input =
+        Map.of(
+            "REPRESENTATION_ORDER_DATE-day", "31",
+            "REPRESENTATION_ORDER_DATE-month", "3",
+            "REPRESENTATION_ORDER_DATE-year", "2016");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isTrue();
+    assertThat(result.getFieldError("inputs['REPRESENTATION_ORDER_DATE']").getCode())
+        .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_BEFORE_CODE);
+    assertThat(result.getFieldError("inputs['REPRESENTATION_ORDER_DATE']").getArguments()[0])
+        .isEqualTo("Representation order date");
+    assertThat(result.getFieldError("inputs['REPRESENTATION_ORDER_DATE']").getArguments()[1])
+        .isEqualTo("1 April 2016");
+  }
+
+  @Test
+  void shouldAddErrorsForDateInFuture() {
+    when(dateWrapperUtil.isFutureDate(any())).thenReturn(true);
+    Map<String, String> input =
+        Map.of(
+            "REPRESENTATION_ORDER_DATE-day", "2",
+            "REPRESENTATION_ORDER_DATE-month", "1",
+            "REPRESENTATION_ORDER_DATE-year", "2020");
+
+    Errors result = validate(input);
+
+    assertThat(result.hasFieldErrors()).isTrue();
+    assertThat(result.getFieldError("inputs['REPRESENTATION_ORDER_DATE']").getCode())
+        .isEqualTo(AmendmentDateValidator.DATE_CANT_BE_IN_FUTURE_CODE);
+    assertThat(result.getFieldError("inputs['REPRESENTATION_ORDER_DATE']").getArguments()[0])
+        .isEqualTo("Representation order date");
+  }
+
+  private Errors validate(Map<String, String> inputs) {
+    ClaimDetails claimDetails = MockClaimsFunctions.createMockCrimeClaim();
+    var form = new AmendmentForm();
+    form.setInputs(inputs);
+
+    var errors = new BeanPropertyBindingResult(form, "amendmentForm");
+    validator.validate(
+        claimDetails, CrimeClaimDetailsViewField.REPRESENTATION_ORDER_DATE, form, errors);
+    return errors;
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/InvalidDateArgumentsProvider.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/amend/claim/forms/amendments/validators/InvalidDateArgumentsProvider.java
@@ -1,0 +1,34 @@
+package uk.gov.justice.laa.amend.claim.forms.amendments.validators;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.Arguments;
+
+final class InvalidDateArgumentsProvider {
+
+  private InvalidDateArgumentsProvider() {}
+
+  static Stream<Arguments> invalidDateProvider() {
+    return Stream.of(
+        // Empty strings
+        Arguments.of("", "", ""),
+        Arguments.of("", "12", "2020"),
+        Arguments.of("15", "", "2020"),
+        Arguments.of("15", "12", ""),
+        // Invalid day (40th date)
+        Arguments.of("40", "12", "2020"),
+        Arguments.of("32", "01", "2020"),
+        Arguments.of("00", "12", "2020"),
+        // Invalid month
+        Arguments.of("15", "13", "2020"),
+        Arguments.of("15", "00", "2020"),
+        // Characters instead of numbers
+        Arguments.of("abc", "12", "2020"),
+        Arguments.of("15", "xyz", "2020"),
+        Arguments.of("15", "12", "abcd"),
+        Arguments.of("!@#", "$%^", "&*()"),
+        // Mixed valid and invalid characters
+        Arguments.of("1a", "12", "2020"),
+        Arguments.of("15", "1b", "2020"),
+        Arguments.of("15", "12", "20c0"));
+  }
+}


### PR DESCRIPTION
## What is this PR?

[Link to story](https://dsdmoj.atlassian.net/browse/BC-765)

Adds date based validation:

- [x] Civil Client DOB
- [x] Mediation Client DOB
- [x] Mediation Client 2 DOB

Remaining validation after this:
- Disbursement Start Date
- Disbursement VAT value
- Duplicate claim validation
- Effective Category of Law validation
- Mandatory field validation
- Schedule reference validation
- UFN Date validation

## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.

