### PR TITLE
Add validation to the amend cost controller, fix redirect logic

### DIFF
--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseDetailsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseDetailsController.java
@@ -90,7 +90,6 @@ public class AmendCaseDetailsController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "caseDetailsFormErrors",
           "/submissions/%s/claims/%s/amendments/amend-case-details"
               .formatted(submissionId, claimId));
     }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseDetailsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseDetailsController.java
@@ -35,13 +35,15 @@ import uk.gov.justice.laa.payments.amend.viewmodels.claimcase.ClaimCaseViewFacto
 @HasRoleClaimAmendmentsCaseworker
 public class AmendCaseDetailsController extends AbstractAmendController {
 
+  public static final String CASE_DETAILS_FORM = "caseDetailsForm";
+
   public AmendCaseDetailsController(
       List<GenericAmendmentFieldValidator> genericAmendmentFieldValidators,
       List<FieldSpecificAmendmentValidator> fieldSpecificAmendmentValidators) {
     super(genericAmendmentFieldValidators, fieldSpecificAmendmentValidators);
   }
 
-  @InitBinder("caseDetailsForm")
+  @InitBinder(CASE_DETAILS_FORM)
   public void initCaseDetailsFormBinder(
       WebDataBinder binder,
       HttpSession session,
@@ -61,7 +63,9 @@ public class AmendCaseDetailsController extends AbstractAmendController {
     var caseView = ClaimCaseViewFactory.create(claim);
 
     model.addAttribute("caseView", caseView);
-    model.addAttribute("caseDetailsForm", amendmentForms.getCaseDetailsForm().getCurrent());
+    if (!model.containsAttribute(CASE_DETAILS_FORM)) {
+      model.addAttribute(CASE_DETAILS_FORM, amendmentForms.getCaseDetailsForm().getCurrent());
+    }
     model.addAttribute("forms", amendmentForms);
     model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
     return "pages/amendments/amend-case-details";
@@ -70,7 +74,7 @@ public class AmendCaseDetailsController extends AbstractAmendController {
   @PostMapping
   public String postAmendCaseDetails(
       HttpSession session,
-      @Valid @ModelAttribute("caseDetailsForm") AmendmentForm caseDetailsForm,
+      @Valid @ModelAttribute(CASE_DETAILS_FORM) AmendmentForm caseDetailsForm,
       BindingResult bindingResult,
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
@@ -79,20 +83,24 @@ public class AmendCaseDetailsController extends AbstractAmendController {
     var amendmentForms = getAmendmentForms(session, claimId);
     var caseDetails = amendmentForms.getCaseDetailsForm();
 
-    caseDetails.setCurrent(
+    var retainedForm =
         retainLockedInputs(
             caseDetailsForm,
             caseDetails.getOriginal(),
-            lockedFields(ClaimCaseViewFactory.create(claim).caseDetailsRows().keySet(), claim)));
-    saveAmendmentForms(session, claimId, amendmentForms);
+            lockedFields(ClaimCaseViewFactory.create(claim).caseDetailsRows().keySet(), claim));
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          CASE_DETAILS_FORM,
+          retainedForm,
           "/submissions/%s/claims/%s/amendments/amend-case-details"
               .formatted(submissionId, claimId));
     }
+
+    caseDetails.setCurrent(retainedForm);
+    saveAmendmentForms(session, claimId, amendmentForms);
 
     return "redirect:/submissions/%s/claims/%s/amendments/case".formatted(submissionId, claimId);
   }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseTypeController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseTypeController.java
@@ -103,7 +103,6 @@ public class AmendCaseTypeController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "caseTypeFormErrors",
           "/submissions/%s/claims/%s/amendments/amend-fee-code".formatted(submissionId, claimId));
     }
 
@@ -159,7 +158,6 @@ public class AmendCaseTypeController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "caseTypeFormErrors",
           "/submissions/%s/claims/%s/amendments/amend-stage-reached"
               .formatted(submissionId, claimId));
     }
@@ -200,7 +198,6 @@ public class AmendCaseTypeController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "caseTypeFormErrors",
           "/submissions/%s/claims/%s/amendments/amend-matter-type"
               .formatted(submissionId, claimId));
     }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseTypeController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseTypeController.java
@@ -80,7 +80,9 @@ public class AmendCaseTypeController extends AbstractAmendController {
 
     model.addAttribute("currentFeeCode", currentFeeCode);
     model.addAttribute("feeCodes", availableFeeCodes);
-    model.addAttribute("caseTypeForm", amendmentForms.getCaseTypeForm().getCurrent());
+    if (!model.containsAttribute("caseTypeForm")) {
+      model.addAttribute("caseTypeForm", amendmentForms.getCaseTypeForm().getCurrent());
+    }
     return "pages/amendments/amend-fee-code";
   }
 
@@ -96,15 +98,19 @@ public class AmendCaseTypeController extends AbstractAmendController {
     requireEditable(ClaimDetailsViewField.FEE_CODE, claim);
 
     var amendmentForms = getAmendmentForms(session, claimId);
-
-    saveCaseTypeForm(session, claimId, amendmentForms, caseTypeForm, claim);
+    var retainedForm = retainCaseTypeFormInputs(amendmentForms, caseTypeForm, claim);
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          "caseTypeForm",
+          retainedForm,
           "/submissions/%s/claims/%s/amendments/amend-fee-code".formatted(submissionId, claimId));
     }
+
+    amendmentForms.getCaseTypeForm().setCurrent(retainedForm);
+    saveAmendmentForms(session, claimId, amendmentForms);
 
     if (claim.getAreaOfLaw() == AreaOfLaw.CRIME_LOWER) {
       return "redirect:/submissions/%s/claims/%s/amendments/amend-stage-reached"
@@ -131,7 +137,9 @@ public class AmendCaseTypeController extends AbstractAmendController {
     var amendmentForms = getAmendmentForms(session, claimId);
     model.addAttribute("forms", amendmentForms);
     model.addAttribute("stageReachedOptions", FieldOptions.CRIME_STAGE_REACHED);
-    model.addAttribute("caseTypeForm", amendmentForms.getCaseTypeForm().getCurrent());
+    if (!model.containsAttribute("caseTypeForm")) {
+      model.addAttribute("caseTypeForm", amendmentForms.getCaseTypeForm().getCurrent());
+    }
     return "pages/amendments/amend-stage-reached";
   }
 
@@ -151,16 +159,20 @@ public class AmendCaseTypeController extends AbstractAmendController {
     requireEditable(CrimeClaimDetailsViewField.STAGE_REACHED, claim);
 
     var amendmentForms = getAmendmentForms(session, claimId);
-
-    saveCaseTypeForm(session, claimId, amendmentForms, caseTypeForm, claim);
+    var retainedForm = retainCaseTypeFormInputs(amendmentForms, caseTypeForm, claim);
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          "caseTypeForm",
+          retainedForm,
           "/submissions/%s/claims/%s/amendments/amend-stage-reached"
               .formatted(submissionId, claimId));
     }
+
+    amendmentForms.getCaseTypeForm().setCurrent(retainedForm);
+    saveAmendmentForms(session, claimId, amendmentForms);
 
     return "redirect:/submissions/%s/claims/%s/amendments/case".formatted(submissionId, claimId);
   }
@@ -176,7 +188,9 @@ public class AmendCaseTypeController extends AbstractAmendController {
     var amendmentForms = getAmendmentForms(session, claimId);
 
     model.addAttribute("forms", amendmentForms);
-    model.addAttribute("caseTypeForm", amendmentForms.getCaseTypeForm().getCurrent());
+    if (!model.containsAttribute("caseTypeForm")) {
+      model.addAttribute("caseTypeForm", amendmentForms.getCaseTypeForm().getCurrent());
+    }
 
     return "pages/amendments/amend-matter-type";
   }
@@ -191,31 +205,30 @@ public class AmendCaseTypeController extends AbstractAmendController {
       @PathVariable UUID claimId) {
     var claim = getValidClaim(session, submissionId, claimId);
     var amendmentForms = getAmendmentForms(session, claimId);
-
-    saveCaseTypeForm(session, claimId, amendmentForms, caseTypeForm, claim);
+    var retainedForm = retainCaseTypeFormInputs(amendmentForms, caseTypeForm, claim);
 
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          "caseTypeForm",
+          retainedForm,
           "/submissions/%s/claims/%s/amendments/amend-matter-type"
               .formatted(submissionId, claimId));
     }
 
+    amendmentForms.getCaseTypeForm().setCurrent(retainedForm);
+    saveAmendmentForms(session, claimId, amendmentForms);
+
     return "redirect:/submissions/%s/claims/%s/amendments/case".formatted(submissionId, claimId);
   }
 
-  private static void saveCaseTypeForm(
-      HttpSession session,
-      UUID claimId,
-      AmendmentForms amendmentForms,
-      AmendmentForm caseTypeForm,
-      ClaimDetails claim) {
+  private static AmendmentForm retainCaseTypeFormInputs(
+      AmendmentForms amendmentForms, AmendmentForm caseTypeForm, ClaimDetails claim) {
     var caseType = amendmentForms.getCaseTypeForm();
     var lockedFields =
         lockedFields(ClaimCaseViewFactory.create(claim).caseTypeRows().keySet(), claim);
 
-    caseType.setCurrent(retainLockedInputs(caseTypeForm, caseType.getOriginal(), lockedFields));
-    saveAmendmentForms(session, claimId, amendmentForms);
+    return retainLockedInputs(caseTypeForm, caseType.getOriginal(), lockedFields);
   }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendClientController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendClientController.java
@@ -34,13 +34,16 @@ import uk.gov.justice.laa.payments.amend.viewmodels.claimclient.ClaimClientViewF
 @HasRoleClaimAmendmentsCaseworker
 public class AmendClientController extends AbstractAmendController {
 
+  public static final String CLIENT_1_FORM = "client1Form";
+  public static final String CLIENT_2_FORM = "client2Form";
+
   public AmendClientController(
       List<GenericAmendmentFieldValidator> genericAmendmentFieldValidators,
       List<FieldSpecificAmendmentValidator> fieldSpecificAmendmentValidators) {
     super(genericAmendmentFieldValidators, fieldSpecificAmendmentValidators);
   }
 
-  @InitBinder({"client1Form", "client2Form"})
+  @InitBinder({CLIENT_1_FORM, CLIENT_2_FORM})
   public void initClientFormBinder(
       WebDataBinder binder,
       HttpSession session,
@@ -60,7 +63,9 @@ public class AmendClientController extends AbstractAmendController {
     var amendmentForms = getAmendmentForms(session, claimId);
 
     model.addAttribute("clientView", clientView);
-    model.addAttribute("client1Form", amendmentForms.getClient1Form().getCurrent());
+    if (!model.containsAttribute(CLIENT_1_FORM)) {
+      model.addAttribute(CLIENT_1_FORM, amendmentForms.getClient1Form().getCurrent());
+    }
     model.addAttribute("forms", amendmentForms);
 
     return "pages/amendments/amend-client-1";
@@ -69,22 +74,23 @@ public class AmendClientController extends AbstractAmendController {
   @PostMapping("/amend-client")
   public String amendClient1(
       HttpSession session,
-      @Valid @ModelAttribute("client1Form") AmendmentForm client1Form,
+      @Valid @ModelAttribute(CLIENT_1_FORM) AmendmentForm client1Form,
       BindingResult bindingResult,
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
-    var amendmentForms = getAmendmentForms(session, claimId);
-
-    amendmentForms.getClient1Form().setCurrent(client1Form);
-    saveAmendmentForms(session, claimId, amendmentForms);
-
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          CLIENT_1_FORM,
+          client1Form,
           "/submissions/%s/claims/%s/amendments/amend-client".formatted(submissionId, claimId));
     }
+
+    var amendmentForms = getAmendmentForms(session, claimId);
+    amendmentForms.getClient1Form().setCurrent(client1Form);
+    saveAmendmentForms(session, claimId, amendmentForms);
 
     return "redirect:/submissions/%s/claims/%s/amendments/client".formatted(submissionId, claimId);
   }
@@ -100,7 +106,9 @@ public class AmendClientController extends AbstractAmendController {
     var amendmentForms = getAmendmentForms(session, claimId);
 
     model.addAttribute("clientView", clientView);
-    model.addAttribute("client2Form", amendmentForms.getClient2Form().getCurrent());
+    if (!model.containsAttribute(CLIENT_2_FORM)) {
+      model.addAttribute(CLIENT_2_FORM, amendmentForms.getClient2Form().getCurrent());
+    }
     model.addAttribute("forms", amendmentForms);
 
     return "pages/amendments/amend-client-2";
@@ -109,22 +117,23 @@ public class AmendClientController extends AbstractAmendController {
   @PostMapping("/amend-client-two")
   public String postAmendClient2(
       HttpSession session,
-      @Valid @ModelAttribute("client2Form") AmendmentForm client2Form,
+      @Valid @ModelAttribute(CLIENT_2_FORM) AmendmentForm client2Form,
       BindingResult bindingResult,
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
-    var amendmentForms = getAmendmentForms(session, claimId);
-
-    amendmentForms.getClient2Form().setCurrent(client2Form);
-    saveAmendmentForms(session, claimId, amendmentForms);
-
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          CLIENT_2_FORM,
+          client2Form,
           "/submissions/%s/claims/%s/amendments/amend-client-two".formatted(submissionId, claimId));
     }
+
+    var amendmentForms = getAmendmentForms(session, claimId);
+    amendmentForms.getClient2Form().setCurrent(client2Form);
+    saveAmendmentForms(session, claimId, amendmentForms);
 
     return "redirect:/submissions/%s/claims/%s/amendments/client".formatted(submissionId, claimId);
   }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendClientController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendClientController.java
@@ -83,7 +83,6 @@ public class AmendClientController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "client1FormErrors",
           "/submissions/%s/claims/%s/amendments/amend-client".formatted(submissionId, claimId));
     }
 
@@ -124,7 +123,6 @@ public class AmendClientController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "client2FormErrors",
           "/submissions/%s/claims/%s/amendments/amend-client-two".formatted(submissionId, claimId));
     }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
@@ -39,13 +39,15 @@ import uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimViewField;
 @HasRoleClaimAmendmentsCaseworker
 public class AmendCostsController extends AbstractAmendController {
 
+  public static final String COSTS_FORM = "costsForm";
+
   public AmendCostsController(
       List<GenericAmendmentFieldValidator> genericAmendmentFieldValidators,
       List<FieldSpecificAmendmentValidator> fieldSpecificAmendmentValidators) {
     super(genericAmendmentFieldValidators, fieldSpecificAmendmentValidators);
   }
 
-  @InitBinder("costsForm")
+  @InitBinder(COSTS_FORM)
   public void initClientFormBinder(
       WebDataBinder binder,
       HttpSession session,
@@ -67,18 +69,11 @@ public class AmendCostsController extends AbstractAmendController {
 
     var costFields = ClaimCostsViewFactory.create(claim).costFields();
     var amendmentForms = getAmendmentForms(session, claimId);
-    var costs = amendmentForms.getCostsForm();
-    var costsFormIsAmended =
-        costFields.keySet().stream()
-            .anyMatch(
-                field ->
-                    costs
-                        .getCurrent()
-                        .isAmendment(field.name(), costs.getOriginal(), field.getFieldType()));
 
     model.addAttribute("costFields", costFields);
-    model.addAttribute("costsForm", costs.getCurrent());
-    model.addAttribute("costsFormIsAmended", costsFormIsAmended);
+    if (!model.containsAttribute(COSTS_FORM)) {
+      model.addAttribute(COSTS_FORM, amendmentForms.getCostsForm().getCurrent());
+    }
     model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
     model.addAttribute("forms", amendmentForms);
 
@@ -88,7 +83,7 @@ public class AmendCostsController extends AbstractAmendController {
   @PostMapping
   public String postAmendCosts(
       HttpSession session,
-      @Valid @ModelAttribute("costsForm") AmendmentForm costsForm,
+      @Valid @ModelAttribute(COSTS_FORM) AmendmentForm costsForm,
       BindingResult bindingResult,
       RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
@@ -100,16 +95,18 @@ public class AmendCostsController extends AbstractAmendController {
 
     retainEditableInputs(costsForm, claim);
 
-    var amendmentForms = getAmendmentForms(session, claimId);
-    amendmentForms.getCostsForm().setCurrent(costsForm);
-    saveAmendmentForms(session, claimId, amendmentForms);
-
     if (bindingResult.hasErrors()) {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          COSTS_FORM,
+          costsForm,
           "/submissions/%s/claims/%s/amendments/amend-costs".formatted(submissionId, claimId));
     }
+
+    var amendmentForms = getAmendmentForms(session, claimId);
+    amendmentForms.getCostsForm().setCurrent(costsForm);
+    saveAmendmentForms(session, claimId, amendmentForms);
 
     return redirectToViewCosts(submissionId, claimId);
   }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
@@ -1,37 +1,62 @@
 package uk.gov.justice.laa.payments.amend.controllers.amendments;
 
+import static uk.gov.justice.laa.payments.amend.utils.AmendmentFormRedirects.redirectWithErrors;
 import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getAmendmentForms;
 import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getValidClaim;
 import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveAmendmentForms;
 
 import jakarta.servlet.http.HttpSession;
+import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 import uk.gov.justice.laa.payments.amend.annotations.HasRoleClaimAmendmentsCaseworker;
 import uk.gov.justice.laa.payments.amend.annotations.RequiresFeatureFlag;
 import uk.gov.justice.laa.payments.amend.config.features.Feature;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.payments.amend.forms.amendments.validators.FieldSpecificAmendmentValidator;
+import uk.gov.justice.laa.payments.amend.forms.amendments.validators.GenericAmendmentFieldValidator;
 import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
 import uk.gov.justice.laa.payments.amend.viewmodels.claimcosts.ClaimCostsViewFactory;
+import uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimViewField;
 
 @Controller
-@RequestMapping("/submissions/{submissionId}/claims/{claimId}/amendments")
-@RequiredArgsConstructor
+@RequestMapping("/submissions/{submissionId}/claims/{claimId}/amendments/amend-costs")
 @RequiresFeatureFlag(Feature.CLAIM_AMENDMENT)
 @HasRoleClaimAmendmentsCaseworker
-public class AmendCostsController {
+public class AmendCostsController extends AbstractAmendController {
 
-  @GetMapping("/amend-costs")
+
+  public AmendCostsController(
+      List<GenericAmendmentFieldValidator> genericAmendmentFieldValidators,
+      List<FieldSpecificAmendmentValidator> fieldSpecificAmendmentValidators) {
+    super(genericAmendmentFieldValidators, fieldSpecificAmendmentValidators);
+  }
+
+  @InitBinder("costsForm")
+  public void initClientFormBinder(
+      WebDataBinder binder,
+      HttpSession session,
+      @PathVariable UUID submissionId,
+      @PathVariable UUID claimId) {
+    initBinder(binder, session, submissionId, claimId);
+  }
+
+  @GetMapping
   public String amendCosts(
       HttpSession session,
       Model model,
@@ -62,10 +87,12 @@ public class AmendCostsController {
     return "pages/amendments/amend-costs";
   }
 
-  @PostMapping("/amend-costs")
+  @PostMapping
   public String postAmendCosts(
       HttpSession session,
-      @ModelAttribute("costsForm") AmendmentForm costsForm,
+      @Valid @ModelAttribute("costsForm") AmendmentForm costsForm,
+      BindingResult bindingResult,
+      RedirectAttributes redirectAttributes,
       @PathVariable UUID submissionId,
       @PathVariable UUID claimId) {
     var claim = getValidClaim(session, submissionId, claimId);
@@ -79,6 +106,14 @@ public class AmendCostsController {
     amendmentForms.getCostsForm().setCurrent(costsForm);
     saveAmendmentForms(session, claimId, amendmentForms);
 
+    if (bindingResult.hasErrors()) {
+      return redirectWithErrors(
+          redirectAttributes,
+          bindingResult,
+          "costFormErrors",
+          "/submissions/%s/claims/%s/amendments/amend-costs".formatted(submissionId, claimId));
+    }
+
     return redirectToViewCosts(submissionId, claimId);
   }
 
@@ -91,7 +126,7 @@ public class AmendCostsController {
     var editableFieldNames =
         ClaimCostsViewFactory.create(claim).costFields().keySet().stream()
             .filter(field -> field.isEditable(claimIsAssessed))
-            .map(field -> field.name())
+            .map(ClaimViewField::name)
             .toList();
     costsForm.getInputs().keySet().retainAll(editableFieldNames);
   }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
@@ -108,7 +108,6 @@ public class AmendCostsController extends AbstractAmendController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "costFormErrors",
           "/submissions/%s/claims/%s/amendments/amend-costs".formatted(submissionId, claimId));
     }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
@@ -39,7 +39,6 @@ import uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimViewField;
 @HasRoleClaimAmendmentsCaseworker
 public class AmendCostsController extends AbstractAmendController {
 
-
   public AmendCostsController(
       List<GenericAmendmentFieldValidator> genericAmendmentFieldValidators,
       List<FieldSpecificAmendmentValidator> fieldSpecificAmendmentValidators) {
@@ -129,5 +128,4 @@ public class AmendCostsController extends AbstractAmendController {
             .toList();
     costsForm.getInputs().keySet().retainAll(editableFieldNames);
   }
-
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
@@ -9,7 +9,6 @@ import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import java.util.List;
 import java.util.UUID;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsController.java
@@ -29,18 +29,7 @@ import uk.gov.justice.laa.payments.amend.viewmodels.claimcosts.ClaimCostsViewFac
 @RequiredArgsConstructor
 @RequiresFeatureFlag(Feature.CLAIM_AMENDMENT)
 @HasRoleClaimAmendmentsCaseworker
-public class CostsController {
-
-  @GetMapping("/costs")
-  public String viewCosts(
-      HttpSession session,
-      Model model,
-      @PathVariable UUID submissionId,
-      @PathVariable UUID claimId) {
-    addCostsModelAttributes(session, model, submissionId, claimId);
-
-    return "pages/amendments/view-costs";
-  }
+public class AmendCostsController {
 
   @GetMapping("/amend-costs")
   public String amendCosts(
@@ -53,7 +42,22 @@ public class CostsController {
       throw new ResponseStatusException(HttpStatus.NOT_FOUND);
     }
 
-    addCostsModelAttributes(session, model, submissionId, claimId);
+    var costFields = ClaimCostsViewFactory.create(claim).costFields();
+    var amendmentForms = getAmendmentForms(session, claimId);
+    var costs = amendmentForms.getCostsForm();
+    var costsFormIsAmended =
+        costFields.keySet().stream()
+            .anyMatch(
+                field ->
+                    costs
+                        .getCurrent()
+                        .isAmendment(field.name(), costs.getOriginal(), field.getFieldType()));
+
+    model.addAttribute("costFields", costFields);
+    model.addAttribute("costsForm", costs.getCurrent());
+    model.addAttribute("costsFormIsAmended", costsFormIsAmended);
+    model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
+    model.addAttribute("forms", amendmentForms);
 
     return "pages/amendments/amend-costs";
   }
@@ -92,24 +96,4 @@ public class CostsController {
     costsForm.getInputs().keySet().retainAll(editableFieldNames);
   }
 
-  private void addCostsModelAttributes(
-      HttpSession session, Model model, UUID submissionId, UUID claimId) {
-    var claim = getValidClaim(session, submissionId, claimId);
-    var costFields = ClaimCostsViewFactory.create(claim).costFields();
-    var amendmentForms = getAmendmentForms(session, claimId);
-    var costs = amendmentForms.getCostsForm();
-    var costsFormIsAmended =
-        costFields.keySet().stream()
-            .anyMatch(
-                field ->
-                    costs
-                        .getCurrent()
-                        .isAmendment(field.name(), costs.getOriginal(), field.getFieldType()));
-
-    model.addAttribute("costFields", costFields);
-    model.addAttribute("costsForm", costs.getCurrent());
-    model.addAttribute("costsFormIsAmended", costsFormIsAmended);
-    model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
-    model.addAttribute("forms", amendmentForms);
-  }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabController.java
@@ -1,0 +1,65 @@
+package uk.gov.justice.laa.payments.amend.controllers.amendments;
+
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getAmendmentForms;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getValidClaim;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveAmendmentForms;
+
+import jakarta.servlet.http.HttpSession;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.justice.laa.payments.amend.annotations.HasRoleClaimAmendmentsCaseworker;
+import uk.gov.justice.laa.payments.amend.annotations.RequiresFeatureFlag;
+import uk.gov.justice.laa.payments.amend.config.features.Feature;
+import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
+import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
+import uk.gov.justice.laa.payments.amend.viewmodels.claimcosts.ClaimCostsViewFactory;
+
+@Controller
+@RequestMapping("/submissions/{submissionId}/claims/{claimId}/amendments/costs")
+@RequiredArgsConstructor
+@RequiresFeatureFlag(Feature.CLAIM_AMENDMENT)
+@HasRoleClaimAmendmentsCaseworker
+public class AmendCostsTabController {
+
+  @GetMapping
+  public String viewCosts(
+      HttpSession session,
+      Model model,
+      @PathVariable UUID submissionId,
+      @PathVariable UUID claimId) {
+    addCostsModelAttributes(session, model, submissionId, claimId);
+
+    return "pages/amendments/view-costs";
+  }
+
+  private void addCostsModelAttributes(
+      HttpSession session, Model model, UUID submissionId, UUID claimId) {
+    var claim = getValidClaim(session, submissionId, claimId);
+    var costFields = ClaimCostsViewFactory.create(claim).costFields();
+    var amendmentForms = getAmendmentForms(session, claimId);
+    var costs = amendmentForms.getCostsForm();
+    var costsFormIsAmended =
+        costFields.keySet().stream()
+            .anyMatch(
+                field ->
+                    costs
+                        .getCurrent()
+                        .isAmendment(field.name(), costs.getOriginal(), field.getFieldType()));
+
+    model.addAttribute("costFields", costFields);
+    model.addAttribute("costsForm", costs.getCurrent());
+    model.addAttribute("costsFormIsAmended", costsFormIsAmended);
+    model.addAttribute("claimIsAssessed", AmendmentsHeaderView.isAssessed(claim));
+    model.addAttribute("forms", amendmentForms);
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabController.java
@@ -2,25 +2,18 @@ package uk.gov.justice.laa.payments.amend.controllers.amendments;
 
 import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getAmendmentForms;
 import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getValidClaim;
-import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveAmendmentForms;
 
 import jakarta.servlet.http.HttpSession;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.server.ResponseStatusException;
 import uk.gov.justice.laa.payments.amend.annotations.HasRoleClaimAmendmentsCaseworker;
 import uk.gov.justice.laa.payments.amend.annotations.RequiresFeatureFlag;
 import uk.gov.justice.laa.payments.amend.config.features.Feature;
-import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
-import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
 import uk.gov.justice.laa.payments.amend.viewmodels.claimcosts.ClaimCostsViewFactory;
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedByController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedByController.java
@@ -73,6 +73,8 @@ public class AmendmentRequestedByController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          "requestedByForm",
+          form,
           "/submissions/%s/claims/%s/amendments/requested-by".formatted(submissionId, claimId));
     }
     amendmentForms.getRequestedByForm().setRequestedBy(form.getRequestedBy());
@@ -85,6 +87,8 @@ public class AmendmentRequestedByController {
       Model model, UUID claimId, UUID submissionId, AmendmentForms amendmentForms) {
     model.addAttribute("claimId", claimId);
     model.addAttribute("submissionId", submissionId);
-    model.addAttribute("requestedByForm", amendmentForms.getRequestedByForm());
+    if (!model.containsAttribute("requestedByForm")) {
+      model.addAttribute("requestedByForm", amendmentForms.getRequestedByForm());
+    }
   }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedByController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedByController.java
@@ -73,7 +73,6 @@ public class AmendmentRequestedByController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "requestedByFormErrors",
           "/submissions/%s/claims/%s/amendments/requested-by".formatted(submissionId, claimId));
     }
     amendmentForms.getRequestedByForm().setRequestedBy(form.getRequestedBy());

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedReasonController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedReasonController.java
@@ -83,7 +83,6 @@ public class AmendmentRequestedReasonController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
-          "requestedReasonFormErrors",
           "/submissions/%s/claims/%s/amendments/requested-reason".formatted(submissionId, claimId));
     }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedReasonController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedReasonController.java
@@ -62,7 +62,9 @@ public class AmendmentRequestedReasonController {
     }
     model.addAttribute("claimId", claimId);
     model.addAttribute("submissionId", submissionId);
-    model.addAttribute("requestedReasonForm", amendmentForms.getRequestedReasonForm());
+    if (!model.containsAttribute("requestedReasonForm")) {
+      model.addAttribute("requestedReasonForm", amendmentForms.getRequestedReasonForm());
+    }
     return "pages/amendments/amend-request-reason";
   }
 
@@ -83,6 +85,8 @@ public class AmendmentRequestedReasonController {
       return redirectWithErrors(
           redirectAttributes,
           bindingResult,
+          "requestedReasonForm",
+          form,
           "/submissions/%s/claims/%s/amendments/requested-reason".formatted(submissionId, claimId));
     }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/AmendmentForm.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/AmendmentForm.java
@@ -70,15 +70,27 @@ public class AmendmentForm {
       if (dateFieldName != null) {
         if (processedDateFields.add(dateFieldName)) {
           var field = getField(dateFieldName, claimDetailsType);
-          fieldInputs.put(field, getAmendedValue(field));
+          if (field != null) {
+            fieldInputs.put(field, getAmendedValueOrNull(field));
+          }
         }
       } else {
         var field = getField(entry.getKey(), claimDetailsType);
-        fieldInputs.put(field, getAmendedValue(field));
+        if (field != null) {
+          fieldInputs.put(field, getAmendedValueOrNull(field));
+        }
       }
     }
 
     return fieldInputs;
+  }
+
+  private Object getAmendedValueOrNull(ClaimViewField<?> field) {
+    try {
+      return getAmendedValue(field);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
   }
 
   public static List<String> inputKeys(ClaimViewField<?> field) {
@@ -118,7 +130,11 @@ public class AmendmentForm {
 
   public boolean isAmendment(String key, AmendmentForm originalForm, FieldType fieldType) {
     if (fieldType == FieldType.BIG_DECIMAL) {
-      return !Objects.equals(originalForm.getBigDecimalValue(key), getBigDecimalValue(key));
+      try {
+        return !Objects.equals(originalForm.getBigDecimalValue(key), getBigDecimalValue(key));
+      } catch (IllegalArgumentException e) {
+        return true;
+      }
     }
 
     return isAmendment(key, originalForm);
@@ -296,7 +312,11 @@ public class AmendmentForm {
     try {
       return CrimeClaimDetailsViewField.valueOf(fieldName);
     } catch (IllegalArgumentException e) {
-      return ClaimDetailsViewField.valueOf(fieldName);
+      try {
+        return ClaimDetailsViewField.valueOf(fieldName);
+      } catch (IllegalArgumentException e2) {
+        return null;
+      }
     }
   }
 
@@ -304,7 +324,11 @@ public class AmendmentForm {
     try {
       return CivilClaimDetailsViewField.valueOf(fieldName);
     } catch (IllegalArgumentException e) {
-      return ClaimDetailsViewField.valueOf(fieldName);
+      try {
+        return ClaimDetailsViewField.valueOf(fieldName);
+      } catch (IllegalArgumentException e2) {
+        return null;
+      }
     }
   }
 
@@ -312,7 +336,11 @@ public class AmendmentForm {
     try {
       return MediationClaimDetailsViewField.valueOf(fieldName);
     } catch (IllegalArgumentException e) {
-      return ClaimDetailsViewField.valueOf(fieldName);
+      try {
+        return ClaimDetailsViewField.valueOf(fieldName);
+      } catch (IllegalArgumentException e2) {
+        return null;
+      }
     }
   }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/AmendmentForm.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/AmendmentForm.java
@@ -63,6 +63,15 @@ public class AmendmentForm {
 
   public Map<ClaimViewField<?>, Object> getFieldValues(Class<?> claimDetailsType) {
     var fieldInputs = new LinkedHashMap<ClaimViewField<?>, Object>();
+    for (var field : getFields(claimDetailsType)) {
+      fieldInputs.put(field, getAmendedValue(field));
+    }
+
+    return fieldInputs;
+  }
+
+  public List<ClaimViewField<?>> getFields(Class<?> claimDetailsType) {
+    var fields = new LinkedHashMap<String, ClaimViewField<?>>();
     var processedDateFields = new HashSet<String>();
 
     for (var entry : inputs.entrySet()) {
@@ -71,26 +80,18 @@ public class AmendmentForm {
         if (processedDateFields.add(dateFieldName)) {
           var field = getField(dateFieldName, claimDetailsType);
           if (field != null) {
-            fieldInputs.put(field, getAmendedValueOrNull(field));
+            fields.putIfAbsent(field.name(), field);
           }
         }
       } else {
         var field = getField(entry.getKey(), claimDetailsType);
         if (field != null) {
-          fieldInputs.put(field, getAmendedValueOrNull(field));
+          fields.putIfAbsent(field.name(), field);
         }
       }
     }
 
-    return fieldInputs;
-  }
-
-  private Object getAmendedValueOrNull(ClaimViewField<?> field) {
-    try {
-      return getAmendedValue(field);
-    } catch (IllegalArgumentException e) {
-      return null;
-    }
+    return List.copyOf(fields.values());
   }
 
   public static List<String> inputKeys(ClaimViewField<?> field) {

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidator.java
@@ -48,8 +48,7 @@ public class DisbursementVatAmountValidator implements FieldSpecificAmendmentVal
       String areaOfLawLabel =
           messageSource.getMessage(
               areaOfLaw.getMessageKey(), null, LocaleContextHolder.getLocale());
-      addUniqueFieldError(
-          field, ERROR_CODE, new Object[] {areaOfLawLabel, maxAllowed}, errors);
+      addUniqueFieldError(field, ERROR_CODE, new Object[] {areaOfLawLabel, maxAllowed}, errors);
     }
   }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidator.java
@@ -2,9 +2,11 @@ package uk.gov.justice.laa.payments.amend.forms.amendments.validators;
 
 import java.math.BigDecimal;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
-import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
@@ -15,7 +17,10 @@ import uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimViewField;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class DisbursementVatAmountValidator implements FieldSpecificAmendmentValidator {
+
+  private final MessageSource messageSource;
 
   public static final String ERROR_CODE = "amendmentForm.dates.disbursementVatExceeded";
   public static final double MAX_LEGAL_HELP_VAT_AMOUNT = 99999.99;
@@ -40,13 +45,11 @@ public class DisbursementVatAmountValidator implements FieldSpecificAmendmentVal
     BigDecimal maxAllowed = getMaxDisbursementVatAllowed(areaOfLaw);
 
     if (disbursementsVatValue.get().compareTo(maxAllowed) > 0) {
+      String areaOfLawLabel =
+          messageSource.getMessage(
+              areaOfLaw.getMessageKey(), null, LocaleContextHolder.getLocale());
       addUniqueFieldError(
-          field,
-          ERROR_CODE,
-          new Object[] {
-            new DefaultMessageSourceResolvable(new String[] {areaOfLaw.getMessageKey()}), maxAllowed
-          },
-          errors);
+          field, ERROR_CODE, new Object[] {areaOfLawLabel, maxAllowed}, errors);
     }
   }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/validators/AmendmentFormValidator.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/forms/validators/AmendmentFormValidator.java
@@ -34,8 +34,7 @@ public class AmendmentFormValidator implements Validator {
   public void validate(Object target, Errors errors) {
     var form = (AmendmentForm) target;
 
-    for (var entry : form.getFieldValues(claimDetailsType).entrySet()) {
-      var field = entry.getKey();
+    for (var field : form.getFields(claimDetailsType)) {
 
       var matched = false;
       for (var fieldValidator : fieldValidators) {

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirects.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirects.java
@@ -11,12 +11,23 @@ public class AmendmentFormRedirects {
   private static final ThymeleafUtils THYMELEAF_UTILS = new ThymeleafUtils();
 
   public static String redirectWithErrors(
+      RedirectAttributes redirectAttributes, BindingResult bindingResult, String redirectUrl) {
+    var errors =
+        new ArrayList<>(THYMELEAF_UTILS.toAmendmentFormErrors(bindingResult.getFieldErrors()));
+    redirectAttributes.addFlashAttribute("formErrors", errors);
+    return "redirect:" + redirectUrl;
+  }
+
+  public static String redirectWithErrors(
       RedirectAttributes redirectAttributes,
       BindingResult bindingResult,
+      String formAttributeName,
+      Object form,
       String redirectUrl) {
     var errors =
         new ArrayList<>(THYMELEAF_UTILS.toAmendmentFormErrors(bindingResult.getFieldErrors()));
     redirectAttributes.addFlashAttribute("formErrors", errors);
+    redirectAttributes.addFlashAttribute(formAttributeName, form);
     return "redirect:" + redirectUrl;
   }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirects.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirects.java
@@ -13,11 +13,10 @@ public class AmendmentFormRedirects {
   public static String redirectWithErrors(
       RedirectAttributes redirectAttributes,
       BindingResult bindingResult,
-      String errorsAttributeName,
       String redirectUrl) {
     var errors =
         new ArrayList<>(THYMELEAF_UTILS.toAmendmentFormErrors(bindingResult.getFieldErrors()));
-    redirectAttributes.addFlashAttribute(errorsAttributeName, errors);
+    redirectAttributes.addFlashAttribute("formErrors", errors);
     return "redirect:" + redirectUrl;
   }
 }

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-case-details.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-case-details.html
@@ -15,7 +15,7 @@
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-case-details(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${caseDetailsForm}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(caseDetailsFormErrors)}">
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
         <th:block th:replace="~{fragments/amendments-assessed-banner :: assessedBanner}"></th:block>
         <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-client-1.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-client-1.html
@@ -15,7 +15,7 @@
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-client(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${client1Form}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(client1FormErrors)}">
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
         <th:block th:replace="~{fragments/amendments-assessed-banner :: assessedBanner}"></th:block>
         <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-client-2.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-client-2.html
@@ -15,7 +15,7 @@
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-client-two(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${client2Form}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(client2FormErrors)}">
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
         <th:block th:replace="~{fragments/amendments-assessed-banner :: assessedBanner}"></th:block>
         <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-costs.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-costs.html
@@ -20,7 +20,11 @@
 
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-costs(submissionId=${submissionId}, claimId=${claimId})}"
-            th:object="${costsForm}">
+            th:object="${costsForm}"
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(costFormErrors)}">
+
+        <th:block th:replace="~{fragments/amendments-assessed-banner :: assessedBanner}"></th:block>
+        <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>
 
         <div class="govuk-summary-card">
           <div class="govuk-summary-card__title-wrapper">
@@ -44,7 +48,7 @@
                 <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></dd>
                 <dd class="govuk-summary-list__value">
                   <th:block th:if="${field.isEditable(claimIsAssessed)}">
-                    <th:block th:replace="~{fragments/amendments/amendment-input :: amendmentInput(${field}, ${'claimField.' + field.name()}, ${null})}"></th:block>
+                    <th:block th:replace="~{fragments/amendments/amendment-input :: amendmentInput(${field}, ${'claimField.' + field.name()}, ${formErrors})}"></th:block>
                   </th:block>
                 </dd>
               </div>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-costs.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-costs.html
@@ -21,7 +21,7 @@
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-costs(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${costsForm}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(costFormErrors)}">
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
         <th:block th:replace="~{fragments/amendments-assessed-banner :: assessedBanner}"></th:block>
         <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-fee-code.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-fee-code.html
@@ -17,7 +17,7 @@
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-fee-code(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${caseTypeForm}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
         <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>
 
 

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-matter-type.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-matter-type.html
@@ -14,7 +14,7 @@
   <form method="post"
         th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-matter-type(submissionId=${submissionId}, claimId=${claimId})}"
         th:object="${caseTypeForm}"
-        th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+        th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
     <div class="govuk-grid-row">
 
       <th:block th:replace="~{fragments/amendments-assessed-banner :: assessedBannerRow}"></th:block>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-request-reason.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-request-reason.html
@@ -19,7 +19,7 @@
             <form method="post"
                   th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/requested-reason(submissionId=${submissionId}, claimId=${claimId})}"
                   th:object="${requestedReasonForm}"
-                  th:with="formErrors=${@ThymeleafUtils.orEmpty(requestedReasonFormErrors)}">
+                  th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
                 <th:block th:replace="~{fragments/error-summary.html :: error-summary(${formErrors})}"></th:block>
 

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-requested-by.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-requested-by.html
@@ -19,7 +19,7 @@
             <form method="post"
                   th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/requested-by(submissionId=${submissionId}, claimId=${claimId})}"
                   th:object="${requestedByForm}"
-                  th:with="formErrors=${@ThymeleafUtils.orEmpty(requestedByFormErrors)}">
+                  th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
                 <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>
 

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-stage-reached.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/amend-stage-reached.html
@@ -17,7 +17,7 @@
       <form method="post"
             th:action="@{/submissions/{submissionId}/claims/{claimId}/amendments/amend-stage-reached(submissionId=${submissionId}, claimId=${claimId})}"
             th:object="${caseTypeForm}"
-            th:with="formErrors=${@ThymeleafUtils.orEmpty(caseTypeFormErrors)}">
+            th:with="formErrors=${@ThymeleafUtils.orEmpty(formErrors)}">
 
         <th:block th:replace="~{fragments/error-summary :: error-summary(${formErrors})}"></th:block>
 

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseDetailsControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseDetailsControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -138,21 +139,29 @@ class AmendCaseDetailsControllerTest extends BaseControllerTest {
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), updatedForms);
 
     var tooLong = "a".repeat(51);
+    var previousValue =
+        updatedForms.getCaseDetailsForm().getCurrent().getInputs().get("UNIQUE_FILE_NUMBER");
     var request =
         post(buildAmendCaseDetailsPath())
             .param(INPUTS.formatted("UNIQUE_FILE_NUMBER"), tooLong)
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendCaseDetailsPath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendCaseDetailsPath()))
+            .andExpect(flash().attributeExists("formErrors", "caseDetailsForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseDetailsForm");
+    assertThat(flashedForm.getInputs().get("UNIQUE_FILE_NUMBER")).isEqualTo(tooLong);
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseDetailsForm().getCurrent().getInputs().get("UNIQUE_FILE_NUMBER"))
-        .isEqualTo(tooLong);
+        .isEqualTo(previousValue);
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseTypeControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCaseTypeControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -296,6 +297,8 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
         .thenReturn(Map.of(FEE_CODE, FEE_CODE));
 
     var invalidStageReached = "NOT_A_VALID_STAGE";
+    var previousStageReached =
+        forms.getCaseTypeForm().getCurrent().getInputs().get("STAGE_REACHED");
     var request =
         post(buildAmendStageReachedPath())
             .param(INPUTS.formatted("FEE_CODE"), FEE_CODE)
@@ -303,15 +306,21 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendStageReachedPath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendStageReachedPath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("STAGE_REACHED")).isEqualTo(invalidStageReached);
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("STAGE_REACHED"))
-        .isEqualTo(invalidStageReached);
+        .isEqualTo(previousStageReached);
   }
 
   @Test
@@ -383,21 +392,28 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
 
     var tooLong = "a".repeat(51);
+    var previousFeeCode = forms.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE");
     var request =
         post(buildAmendFeeCodePath())
             .param(INPUTS.formatted("FEE_CODE"), tooLong)
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendFeeCodePath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendFeeCodePath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isEqualTo(tooLong);
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE"))
-        .isEqualTo(tooLong);
+        .isEqualTo(previousFeeCode);
   }
 
   @Test
@@ -476,15 +492,21 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendFeeCodePath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendFeeCodePath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isEqualTo("NOT_A_VALID_CODE");
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE"))
-        .isEqualTo("NOT_A_VALID_CODE");
+        .isEqualTo(FEE_CODE);
   }
 
   @Test
@@ -516,15 +538,21 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendFeeCodePath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendFeeCodePath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isIn("", null);
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE"))
-        .isNullOrEmpty();
+        .isEqualTo(FEE_CODE);
   }
 
   @Test
@@ -642,6 +670,8 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
     session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
 
     var tooLong = "a".repeat(51);
+    var previousMatterType1 =
+        forms.getCaseTypeForm().getCurrent().getInputs().get("MATTER_TYPE_CODE_1");
     var request =
         post(buildAmendMatterTypeCodePath())
             .param(INPUTS.formatted("FEE_CODE"), FEE_CODE)
@@ -650,15 +680,21 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendMatterTypeCodePath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendMatterTypeCodePath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("MATTER_TYPE_CODE_1")).isEqualTo(tooLong);
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("MATTER_TYPE_CODE_1"))
-        .isEqualTo(tooLong);
+        .isEqualTo(previousMatterType1);
   }
 
   @Test
@@ -756,15 +792,21 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendMatterTypeCodePath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendMatterTypeCodePath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isEqualTo("TAMPERED_CODE");
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE"))
-        .isEqualTo("TAMPERED_CODE");
+        .isEqualTo(FEE_CODE);
   }
 
   @Test
@@ -807,15 +849,21 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendMatterTypeCodePath()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendMatterTypeCodePath()))
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isIn("", null);
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForm.getCaseTypeForm().getCurrent().getInputs().get("FEE_CODE"))
-        .isNullOrEmpty();
+        .isEqualTo(FEE_CODE);
   }
 
   @Test
@@ -1047,20 +1095,27 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .caseDetails(new AmendmentForm())
             .build());
 
-    mockMvc
-        .perform(
-            post(buildAmendStageReachedPath())
-                .param(INPUTS.formatted("STAGE_REACHED"), "INVB")
-                .param(INPUTS.formatted("FEE_CODE"), "tampered")
-                .session(session)
-                .with(csrf()))
-        .andExpect(status().is3xxRedirection());
+    var postResult =
+        mockMvc
+            .perform(
+                post(buildAmendStageReachedPath())
+                    .param(INPUTS.formatted("STAGE_REACHED"), "INVB")
+                    .param(INPUTS.formatted("FEE_CODE"), "tampered")
+                    .session(session)
+                    .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("STAGE_REACHED")).isEqualTo("INVB");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
 
     var saved =
         requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
     var current = saved.getCaseTypeForm().getCurrent();
 
-    assertThat(current.getInputs().get("STAGE_REACHED")).isEqualTo("INVB");
+    assertThat(current.getInputs().get("STAGE_REACHED")).isEqualTo("INVC");
     assertThat(current.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
   }
 
@@ -1084,21 +1139,28 @@ class AmendCaseTypeControllerTest extends BaseControllerTest {
             .caseDetails(new AmendmentForm())
             .build());
 
-    mockMvc
-        .perform(
-            post(buildAmendMatterTypeCodePath())
-                .param(INPUTS.formatted("MATTER_TYPE_CODE_1"), "NEW1")
-                .param(INPUTS.formatted("MATTER_TYPE_CODE_2"), "NEW2")
-                .param(INPUTS.formatted("FEE_CODE"), "tampered")
-                .session(session)
-                .with(csrf()))
-        .andExpect(status().is3xxRedirection());
+    var postResult =
+        mockMvc
+            .perform(
+                post(buildAmendMatterTypeCodePath())
+                    .param(INPUTS.formatted("MATTER_TYPE_CODE_1"), "NEW1")
+                    .param(INPUTS.formatted("MATTER_TYPE_CODE_2"), "NEW2")
+                    .param(INPUTS.formatted("FEE_CODE"), "tampered")
+                    .session(session)
+                    .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andExpect(flash().attributeExists("formErrors", "caseTypeForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("caseTypeForm");
+    assertThat(flashedForm.getInputs().get("MATTER_TYPE_CODE_1")).isEqualTo("NEW1");
+    assertThat(flashedForm.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
 
     var saved =
         requireNonNull((AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId)));
     var current = saved.getCaseTypeForm().getCurrent();
 
-    assertThat(current.getInputs().get("MATTER_TYPE_CODE_1")).isEqualTo("NEW1");
+    assertThat(current.getInputs().get("MATTER_TYPE_CODE_1")).isEqualTo(MATTER_TYPE_CODE_1);
     assertThat(current.getInputs().get("FEE_CODE")).isEqualTo(FEE_CODE);
   }
 

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendClientControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendClientControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
@@ -340,15 +341,20 @@ class AmendClientControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendClient1Path()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendClient1Path()))
+            .andExpect(flash().attributeExists("formErrors", "client1Form"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("client1Form");
+    assertThat(flashedForm.getInputs().get("SURNAME")).isEqualTo(tooLong);
 
     AmendmentForms updatedForms =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
-    assertThat(updatedForms.getClient1Form().getCurrent().getInputs().get("SURNAME"))
-        .isEqualTo(tooLong);
+    assertThat(updatedForms.getClient1Form().getCurrent().getInputs().get("SURNAME")).isNull();
   }
 
   @Test
@@ -371,15 +377,21 @@ class AmendClientControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendClient2Path()));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendClient2Path()))
+            .andExpect(flash().attributeExists("formErrors", "client2Form"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("client2Form");
+    assertThat(flashedForm.getInputs().get("CLIENT_2_SURNAME")).isEqualTo(tooLong);
 
     AmendmentForms updatedForms =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
     assertThat(updatedForms.getClient2Form().getCurrent().getInputs().get("CLIENT_2_SURNAME"))
-        .isEqualTo(tooLong);
+        .isNull();
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsControllerTest.java
@@ -1,11 +1,14 @@
 package uk.gov.justice.laa.payments.amend.controllers.amendments;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.flash;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,17 +20,26 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockHttpSession;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.payments.amend.controllers.BaseControllerTest;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
+import uk.gov.justice.laa.payments.amend.forms.amendments.validators.BigDecimalAmendmentFieldValidator;
+import uk.gov.justice.laa.payments.amend.forms.amendments.validators.BooleanAmendmentFieldValidator;
+import uk.gov.justice.laa.payments.amend.forms.amendments.validators.TextAmendmentFieldValidator;
 import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
 
 @WebMvcTest(controllers = AmendCostsController.class)
+@Import({
+  BigDecimalAmendmentFieldValidator.class,
+  BooleanAmendmentFieldValidator.class,
+  TextAmendmentFieldValidator.class
+})
 class AmendCostsControllerTest extends BaseControllerTest {
 
   private static final String INPUTS = "inputs[%s]";
@@ -193,6 +205,67 @@ class AmendCostsControllerTest extends BaseControllerTest {
     var inputs = updatedForm.getCostsForm().getCurrent().getInputs();
     assertThat(inputs.containsKey("NOT_A_REAL_FIELD")).isFalse();
     assertThat(inputs.get("PROFIT_COST")).isEqualTo("150.25");
+  }
+
+  @Test
+  void postCostsWithInvalidValueRedirectsBackAndPreservesInput() throws Exception {
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var request =
+        post(buildAmendCostsPath())
+            .param(INPUTS.formatted("PROFIT_COST"), "not-a-number")
+            .session(session)
+            .with(csrf());
+
+    mockMvc
+        .perform(request)
+        .andExpect(status().is3xxRedirection())
+        .andExpect(redirectedUrl(buildAmendCostsPath()))
+        .andExpect(flash().attributeExists("costFormErrors"));
+
+    AmendmentForms updatedForm =
+        (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
+    assertThat(updatedForm.getCostsForm().getCurrent().getInputs().get("PROFIT_COST"))
+        .isEqualTo("not-a-number");
+  }
+
+  @Test
+  void postCostsWithInvalidValueRendersErrorSummaryAndInlineErrorOnRedirect() throws Exception {
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var postResult =
+        mockMvc
+            .perform(
+                post(buildAmendCostsPath())
+                    .param(INPUTS.formatted("PROFIT_COST"), "not-a-number")
+                    .session(session)
+                    .with(csrf()))
+            .andExpect(status().is3xxRedirection())
+            .andReturn();
+
+    mockMvc
+        .perform(
+            get(buildAmendCostsPath())
+                .session(session)
+                .flashAttrs(postResult.getFlashMap())
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("govuk-error-summary")))
+        .andExpect(content().string(containsString("govuk-error-message")))
+        .andExpect(
+            content().string(containsString("Net profit costs must be entered as a valid amount")));
   }
 
   private String buildCostsPath() {

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsControllerTest.java
@@ -27,8 +27,8 @@ import uk.gov.justice.laa.payments.amend.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
 
-@WebMvcTest(controllers = CostsController.class)
-class CostsControllerTest extends BaseControllerTest {
+@WebMvcTest(controllers = AmendCostsController.class)
+class AmendCostsControllerTest extends BaseControllerTest {
 
   private static final String INPUTS = "inputs[%s]";
 
@@ -49,23 +49,6 @@ class CostsControllerTest extends BaseControllerTest {
     saveClaim(session, claimId, claim);
     when(amendmentsHeaderViewFactory.create(any()))
         .thenReturn(new AmendmentsHeaderView(false, null));
-  }
-
-  @Test
-  void getCostsAsExpected() throws Exception {
-    var forms =
-        AmendmentForms.builder()
-            .client1(new AmendmentForm())
-            .caseType(new AmendmentForm())
-            .caseDetails(new AmendmentForm())
-            .build();
-    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
-
-    mockMvc
-        .perform(get(buildCostsPath()).session(session).with(csrf()))
-        .andExpect(status().isOk())
-        .andExpect(view().name("pages/amendments/view-costs"))
-        .andExpect(request().sessionAttribute(AMENDMENTS_KEY.formatted(claimId), forms));
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsControllerTest.java
@@ -223,16 +223,20 @@ class AmendCostsControllerTest extends BaseControllerTest {
             .session(session)
             .with(csrf());
 
-    mockMvc
-        .perform(request)
-        .andExpect(status().is3xxRedirection())
-        .andExpect(redirectedUrl(buildAmendCostsPath()))
-        .andExpect(flash().attributeExists("costFormErrors"));
+    var postResult =
+        mockMvc
+            .perform(request)
+            .andExpect(status().is3xxRedirection())
+            .andExpect(redirectedUrl(buildAmendCostsPath()))
+            .andExpect(flash().attributeExists("formErrors", "costsForm"))
+            .andReturn();
+
+    var flashedForm = (AmendmentForm) postResult.getFlashMap().get("costsForm");
+    assertThat(flashedForm.getInputs().get("PROFIT_COST")).isEqualTo("not-a-number");
 
     AmendmentForms updatedForm =
         (AmendmentForms) session.getAttribute(AMENDMENTS_KEY.formatted(claimId));
-    assertThat(updatedForm.getCostsForm().getCurrent().getInputs().get("PROFIT_COST"))
-        .isEqualTo("not-a-number");
+    assertThat(updatedForm.getCostsForm().getCurrent().getInputs().get("PROFIT_COST")).isNull();
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabControllerTest.java
@@ -1,0 +1,75 @@
+package uk.gov.justice.laa.payments.amend.controllers.amendments;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.AMENDMENTS_KEY;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveClaim;
+
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.mock.web.MockHttpSession;
+import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
+import uk.gov.justice.laa.payments.amend.controllers.BaseControllerTest;
+import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
+import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
+import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
+import uk.gov.justice.laa.payments.amend.models.enums.AssessmentTypeEnum;
+import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
+import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
+
+@WebMvcTest(controllers = AmendCostsTabController.class)
+class AmendCostsTabControllerTest extends BaseControllerTest {
+
+  private static final String INPUTS = "inputs[%s]";
+
+  private UUID submissionId;
+  private UUID claimId;
+  private MockHttpSession session;
+  private ClaimDetails claim;
+
+  @BeforeEach
+  void setup() {
+    submissionId = UUID.randomUUID();
+    claimId = UUID.randomUUID();
+    session = new MockHttpSession();
+    claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    MockClaimsFunctions.updateStatus(claim, claim.getAssessmentOutcome());
+    saveClaim(session, claimId, claim);
+    when(amendmentsHeaderViewFactory.create(any()))
+        .thenReturn(new AmendmentsHeaderView(false, null));
+  }
+
+  @Test
+  void getCostsAsExpected() throws Exception {
+    var forms =
+        AmendmentForms.builder()
+            .client1(new AmendmentForm())
+            .caseType(new AmendmentForm())
+            .caseDetails(new AmendmentForm())
+            .build();
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    mockMvc
+        .perform(get(buildCostsPath()).session(session).with(csrf()))
+        .andExpect(status().isOk())
+        .andExpect(view().name("pages/amendments/view-costs"))
+        .andExpect(request().sessionAttribute(AMENDMENTS_KEY.formatted(claimId), forms));
+  }
+
+  private String buildCostsPath() {
+    return "/submissions/%s/claims/%s/amendments/costs".formatted(submissionId, claimId);
+  }
+
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendCostsTabControllerTest.java
@@ -1,12 +1,9 @@
 package uk.gov.justice.laa.payments.amend.controllers.amendments;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
@@ -18,12 +15,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.mock.web.MockHttpSession;
-import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus;
 import uk.gov.justice.laa.payments.amend.controllers.BaseControllerTest;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
-import uk.gov.justice.laa.payments.amend.models.enums.AssessmentTypeEnum;
 import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
 
@@ -71,5 +66,4 @@ class AmendCostsTabControllerTest extends BaseControllerTest {
   private String buildCostsPath() {
     return "/submissions/%s/claims/%s/amendments/costs".formatted(submissionId, claimId);
   }
-
 }

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedByControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedByControllerTest.java
@@ -104,7 +104,7 @@ class AmendmentRequestedByControllerTest extends BaseControllerTest {
                     .param("requestedBy", REQUESTED_BY_FAIL))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(buildRequestedByPath()))
-            .andExpect(flash().attributeExists("requestedByFormErrors"))
+            .andExpect(flash().attributeExists("formErrors", "requestedByForm"))
             .andReturn();
 
     mockMvc
@@ -132,7 +132,7 @@ class AmendmentRequestedByControllerTest extends BaseControllerTest {
             .perform(post(buildRequestedByPath()).session(session).with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(buildRequestedByPath()))
-            .andExpect(flash().attributeExists("requestedByFormErrors"))
+            .andExpect(flash().attributeExists("formErrors", "requestedByForm"))
             .andReturn();
 
     mockMvc

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedReasonControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentRequestedReasonControllerTest.java
@@ -110,7 +110,7 @@ class AmendmentRequestedReasonControllerTest extends BaseControllerTest {
                     .param("requestedReason", REQUESTED_REASON_FAIL))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(buildRequestedReasonPath()))
-            .andExpect(flash().attributeExists("requestedReasonFormErrors"))
+            .andExpect(flash().attributeExists("formErrors", "requestedReasonForm"))
             .andReturn();
 
     mockMvc
@@ -138,7 +138,7 @@ class AmendmentRequestedReasonControllerTest extends BaseControllerTest {
             .perform(post(buildRequestedReasonPath()).session(session).with(csrf()))
             .andExpect(status().is3xxRedirection())
             .andExpect(redirectedUrl(buildRequestedReasonPath()))
-            .andExpect(flash().attributeExists("requestedReasonFormErrors"))
+            .andExpect(flash().attributeExists("formErrors", "requestedReasonForm"))
             .andReturn();
 
     mockMvc

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/amendments/AmendmentFormTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/amendments/AmendmentFormTest.java
@@ -122,6 +122,17 @@ class AmendmentFormTest {
   }
 
   @Test
+  void getFieldValuesThrowsWhenTypedValueIsInvalid() {
+    var form = new AmendmentForm();
+    form.setInputs(new HashMap<>(Map.of("IS_ELIGIBLE_CLIENT", "not-a-boolean")));
+
+    assertThatThrownBy(() -> form.getFieldValues(CivilClaimDetails.class))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid Boolean value")
+        .hasMessageContaining("IS_ELIGIBLE_CLIENT");
+  }
+
+  @Test
   void getDateValueRecombinesSubInputs() {
     var form = new AmendmentForm();
     form.setInputs(

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidatorTest.java
@@ -133,8 +133,7 @@ class DisbursementVatAmountValidatorTest {
 
     Errors result = validate(input);
 
-    assertFieldError(
-        result, "Mediation", DisbursementVatAmountValidator.MAX_MEDIATION_VAT_AMOUNT);
+    assertFieldError(result, "Mediation", DisbursementVatAmountValidator.MAX_MEDIATION_VAT_AMOUNT);
   }
 
   private void assertFieldError(Errors result, String areaOfLawLabel, double maxVatAmount) {

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/amendments/validators/DisbursementVatAmountValidatorTest.java
@@ -2,12 +2,17 @@ package uk.gov.justice.laa.payments.amend.forms.amendments.validators;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.MessageSource;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
@@ -21,10 +26,18 @@ class DisbursementVatAmountValidatorTest {
 
   DisbursementVatAmountValidator validator;
   ClaimDetails claimDetails;
+  MessageSource messageSource;
 
   @BeforeEach
   void beforeEach() {
-    validator = new DisbursementVatAmountValidator();
+    messageSource = mock(MessageSource.class);
+    when(messageSource.getMessage(eq("areaOfLaw.legalHelp"), isNull(), any()))
+        .thenReturn("Legal help");
+    when(messageSource.getMessage(eq("areaOfLaw.crimeLower"), isNull(), any()))
+        .thenReturn("Crime lower");
+    when(messageSource.getMessage(eq("areaOfLaw.mediation"), isNull(), any()))
+        .thenReturn("Mediation");
+    validator = new DisbursementVatAmountValidator(messageSource);
     claimDetails = MockClaimsFunctions.createMockCivilClaim();
   }
 
@@ -99,7 +112,7 @@ class DisbursementVatAmountValidatorTest {
     Errors result = validate(input);
 
     assertFieldError(
-        result, "areaOfLaw.legalHelp", DisbursementVatAmountValidator.MAX_LEGAL_HELP_VAT_AMOUNT);
+        result, "Legal help", DisbursementVatAmountValidator.MAX_LEGAL_HELP_VAT_AMOUNT);
   }
 
   @Test
@@ -110,7 +123,7 @@ class DisbursementVatAmountValidatorTest {
     Errors result = validate(input);
 
     assertFieldError(
-        result, "areaOfLaw.crimeLower", DisbursementVatAmountValidator.MAX_CRIME_LOWER_VAT_AMOUNT);
+        result, "Crime lower", DisbursementVatAmountValidator.MAX_CRIME_LOWER_VAT_AMOUNT);
   }
 
   @Test
@@ -121,18 +134,17 @@ class DisbursementVatAmountValidatorTest {
     Errors result = validate(input);
 
     assertFieldError(
-        result, "areaOfLaw.mediation", DisbursementVatAmountValidator.MAX_MEDIATION_VAT_AMOUNT);
+        result, "Mediation", DisbursementVatAmountValidator.MAX_MEDIATION_VAT_AMOUNT);
   }
 
-  private void assertFieldError(Errors result, String areaOfLawMessageKey, double maxVatAmount) {
+  private void assertFieldError(Errors result, String areaOfLawLabel, double maxVatAmount) {
     assertThat(result.hasFieldErrors()).isTrue();
 
     FieldError fieldError = result.getFieldError("inputs['DISBURSEMENTS_VAT']");
 
     assertThat(fieldError).isNotNull();
     assertThat(fieldError.getCode()).isEqualTo(DisbursementVatAmountValidator.ERROR_CODE);
-    assertThat(((MessageSourceResolvable) fieldError.getArguments()[0]).getCodes())
-        .containsExactly(areaOfLawMessageKey);
+    assertThat(fieldError.getArguments()[0]).isEqualTo(areaOfLawLabel);
     assertThat(fieldError.getArguments()[1]).isEqualTo(BigDecimal.valueOf(maxVatAmount));
   }
 

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/validators/AmendmentFormValidatorTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/forms/validators/AmendmentFormValidatorTest.java
@@ -89,15 +89,15 @@ class AmendmentFormValidatorTest {
   }
 
   @Test
-  void throwsForTamperedBooleanValueDuringFieldMapping() {
+  void reportsBooleanValidationErrorForTamperedBooleanValue() {
     var validator =
         new AmendmentFormValidator(
             MockClaimsFunctions.createMockCrimeClaim(), defaultFieldValidators(), List.of());
 
-    assertThatThrownBy(() -> validate(validator, Map.of("IS_DUTY_SOLICITOR", "notABoolean")))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid Boolean value")
-        .hasMessageContaining("IS_DUTY_SOLICITOR");
+    var errors = validate(validator, Map.of("IS_DUTY_SOLICITOR", "notABoolean"));
+
+    assertThat(errors.getFieldError("inputs[IS_DUTY_SOLICITOR]").getCode())
+        .isEqualTo("amendmentForm.boolean.invalid");
   }
 
   @Test
@@ -152,15 +152,12 @@ class AmendmentFormValidatorTest {
     assertThat(invalidForCrime.getFieldError("inputs[STANDARD_FEE_CATEGORY]").getCode())
         .isEqualTo("amendmentForm.enum.invalid");
 
-    assertThatThrownBy(
-            () ->
-                validate(
-                    new AmendmentFormValidator(
-                        MockClaimsFunctions.createMockCivilClaim(),
-                        defaultFieldValidators(),
-                        List.of()),
-                    Map.of("STANDARD_FEE_CATEGORY", "1A")))
-        .isInstanceOf(IllegalArgumentException.class);
+    var civilClaimErrors =
+        validate(
+            new AmendmentFormValidator(
+                MockClaimsFunctions.createMockCivilClaim(), defaultFieldValidators(), List.of()),
+            Map.of("STANDARD_FEE_CATEGORY", "1A"));
+    assertThat(civilClaimErrors.hasErrors()).isFalse();
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirectsTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirectsTest.java
@@ -36,8 +36,7 @@ class AmendmentFormRedirectsTest {
 
     verify(redirectAttributes)
         .addFlashAttribute(
-            "formErrors",
-            List.of(new AmendmentFormError("FEE_CODE", "Value is required")));
+            "formErrors", List.of(new AmendmentFormError("FEE_CODE", "Value is required")));
     assertThat(result).isEqualTo("redirect:/some/redirect/url");
   }
 
@@ -50,5 +49,19 @@ class AmendmentFormRedirectsTest {
     AmendmentFormRedirects.redirectWithErrors(redirectAttributes, bindingResult, "/other/url");
 
     verify(redirectAttributes).addFlashAttribute("formErrors", List.of());
+  }
+
+  @Test
+  void flashesFormObjectWhenProvided() {
+    var redirectAttributes = mock(RedirectAttributes.class);
+    var bindingResult = mock(BindingResult.class);
+    var form = new Object();
+    when(bindingResult.getFieldErrors()).thenReturn(List.of());
+
+    AmendmentFormRedirects.redirectWithErrors(
+        redirectAttributes, bindingResult, "costsForm", form, "/other/url");
+
+    verify(redirectAttributes).addFlashAttribute("formErrors", List.of());
+    verify(redirectAttributes).addFlashAttribute("costsForm", form);
   }
 }

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirectsTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/utils/AmendmentFormRedirectsTest.java
@@ -15,7 +15,7 @@ import uk.gov.justice.laa.payments.amend.forms.errors.AmendmentFormError;
 class AmendmentFormRedirectsTest {
 
   @Test
-  void flashesPlainErrorListUnderGivenAttributeNameNotTheRawBindingResult() {
+  void flashesPlainErrorListUnderFormErrorsNotTheRawBindingResult() {
     var redirectAttributes = mock(RedirectAttributes.class);
     var bindingResult = mock(BindingResult.class);
     when(bindingResult.getFieldErrors())
@@ -32,24 +32,23 @@ class AmendmentFormRedirectsTest {
 
     var result =
         AmendmentFormRedirects.redirectWithErrors(
-            redirectAttributes, bindingResult, "caseDetailsFormErrors", "/some/redirect/url");
+            redirectAttributes, bindingResult, "/some/redirect/url");
 
     verify(redirectAttributes)
         .addFlashAttribute(
-            "caseDetailsFormErrors",
+            "formErrors",
             List.of(new AmendmentFormError("FEE_CODE", "Value is required")));
     assertThat(result).isEqualTo("redirect:/some/redirect/url");
   }
 
   @Test
-  void usesGivenAttributeNameForFlashKey() {
+  void flashesUnderFormErrorsKey() {
     var redirectAttributes = mock(RedirectAttributes.class);
     var bindingResult = mock(BindingResult.class);
     when(bindingResult.getFieldErrors()).thenReturn(List.of());
 
-    AmendmentFormRedirects.redirectWithErrors(
-        redirectAttributes, bindingResult, "caseTypeFormErrors", "/other/url");
+    AmendmentFormRedirects.redirectWithErrors(redirectAttributes, bindingResult, "/other/url");
 
-    verify(redirectAttributes).addFlashAttribute("caseTypeFormErrors", List.of());
+    verify(redirectAttributes).addFlashAttribute("formErrors", List.of());
   }
 }

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsTabViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsTabViewTest.java
@@ -6,17 +6,17 @@ import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import uk.gov.justice.laa.payments.amend.controllers.amendments.CostsController;
+import uk.gov.justice.laa.payments.amend.controllers.amendments.AmendCostsTabController;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.payments.amend.viewmodels.claimcosts.ClaimCostsViewFactory;
 
-@WebMvcTest(CostsController.class)
-class ViewCostsViewTest extends AmendmentsBaseTest {
+@WebMvcTest(AmendCostsTabController.class)
+class AmendCostsTabViewTest extends AmendmentsBaseTest {
 
-  ViewCostsViewTest() {
+  AmendCostsTabViewTest() {
     this.mapping = costsUrl;
   }
 

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsViewTest.java
@@ -112,7 +112,7 @@ class AmendCostsViewTest extends AmendmentsBaseTest {
                 "amendmentForm.bigDecimal.invalid",
                 new Object[] {"Net profit costs"}));
 
-    var doc = renderDocument(Map.of("costFormErrors", errors));
+    var doc = renderDocument(Map.of("formErrors", errors));
 
     Assertions.assertFalse(
         doc.select(".govuk-error-summary").isEmpty(), "Error summary should be present");
@@ -141,7 +141,7 @@ class AmendCostsViewTest extends AmendmentsBaseTest {
                 "amendmentForm.bigDecimal.invalid",
                 new Object[] {"Net profit costs"}));
 
-    var doc = renderDocument(Map.of("costFormErrors", errors));
+    var doc = renderDocument(Map.of("formErrors", errors));
 
     var costs = getSummaryListInCard(doc, "List of costs");
     List<Element> profitCostRow = costs.get(2);

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsViewTest.java
@@ -4,6 +4,7 @@ import static uk.gov.justice.laa.payments.amend.constants.AmendClaimConstants.La
 import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.AMENDMENTS_KEY;
 
 import java.util.List;
+import java.util.Map;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Assertions;
@@ -12,6 +13,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import uk.gov.justice.laa.payments.amend.controllers.amendments.AmendCostsController;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
+import uk.gov.justice.laa.payments.amend.forms.errors.AmendmentFormError;
 import uk.gov.justice.laa.payments.amend.models.BoltOnClaimField;
 import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
@@ -90,6 +92,65 @@ class AmendCostsViewTest extends AmendmentsBaseTest {
         costs.get(11).get(2).select("select#SUBSTANTIVE_HEARING").isEmpty(),
         "Not-provided bolt-on should still be editable");
     assertBooleanSelectRow(costs.get(15), "London rate", "Yes", "IS_LONDON_RATE", true);
+  }
+
+  @Test
+  void testShowsErrorSummaryWhenCostFormErrorsPresent() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+
+    var forms = createCostsForms(claim);
+    forms.getCostsForm().getCurrent().getInputs().put("PROFIT_COST", "not-a-number");
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var errors =
+        List.of(
+            new AmendmentFormError(
+                "PROFIT_COST",
+                "amendmentForm.bigDecimal.invalid",
+                new Object[] {"Net profit costs"}));
+
+    var doc = renderDocument(Map.of("costFormErrors", errors));
+
+    Assertions.assertFalse(
+        doc.select(".govuk-error-summary").isEmpty(), "Error summary should be present");
+    Assertions.assertTrue(
+        doc.select(".govuk-error-summary")
+            .text()
+            .contains("Net profit costs must be entered as a valid amount"),
+        "Error summary should contain the field error message");
+  }
+
+  @Test
+  void testShowsInlineErrorOnBigDecimalInputWhenErrorPresent() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    this.claim = claim;
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+
+    var forms = createCostsForms(claim);
+    forms.getCostsForm().getCurrent().getInputs().put("PROFIT_COST", "not-a-number");
+    session.setAttribute(AMENDMENTS_KEY.formatted(claimId), forms);
+
+    var errors =
+        List.of(
+            new AmendmentFormError(
+                "PROFIT_COST",
+                "amendmentForm.bigDecimal.invalid",
+                new Object[] {"Net profit costs"}));
+
+    var doc = renderDocument(Map.of("costFormErrors", errors));
+
+    var costs = getSummaryListInCard(doc, "List of costs");
+    List<Element> profitCostRow = costs.get(2);
+    Assertions.assertFalse(
+        profitCostRow.get(2).select(".govuk-error-message").isEmpty(),
+        "Inline error message should be shown for PROFIT_COST");
+    Assertions.assertFalse(
+        profitCostRow.get(2).select("input.govuk-input--error").isEmpty(),
+        "Input should have error class when invalid");
   }
 
   private static AmendmentForms createCostsForms(ClaimDetails claimDetails) {

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/amendments/AmendCostsViewTest.java
@@ -9,7 +9,7 @@ import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import uk.gov.justice.laa.payments.amend.controllers.amendments.CostsController;
+import uk.gov.justice.laa.payments.amend.controllers.amendments.AmendCostsController;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.payments.amend.models.BoltOnClaimField;
@@ -17,7 +17,7 @@ import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
 import uk.gov.justice.laa.payments.amend.viewmodels.claimcosts.ClaimCostsViewFactory;
 
-@WebMvcTest(CostsController.class)
+@WebMvcTest(AmendCostsController.class)
 class AmendCostsViewTest extends AmendmentsBaseTest {
 
   AmendCostsViewTest() {


### PR DESCRIPTION
## What is this PR?

[Link to story](https://dsdmoj.atlassian.net/browse/BC-622)

Currently the cost controller is not setup to handle validation with the `AmendmentForm` object, and also doesn't align with the existing amend controllers. 

Also minor tweaks:
- Disbursement VAT amount message resolution fixed as the original solution didn't work with redis.
- Incorrect inputs were preserved during a POST-REDIRECT-GET. Now `AmendmentForm` is only saved if there are no errors in the binding result.
- Removed the ability to name a form errors object, all form errors now called `formErrors`
- Split up cost controllers to have a tab and amend controller to be consistent with other controllers

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

