### PR TITLE
fix: Change Thymeleaf template path reference to prevent OWASP ZAP false positives

### DIFF
--- a/laa-amend-a-claim-ui/src/main/resources/application.yml
+++ b/laa-amend-a-claim-ui/src/main/resources/application.yml
@@ -131,10 +131,10 @@ spring:
       
   thymeleaf:
     cache: false
-    prefix: file:laa-amend-a-claim-ui/src/main/resources/templates/
+    prefix: file:src/main/resources/templates/
   web:
     resources:
-      static-locations: file:laa-amend-a-claim-ui/build/resources/main/static/
+      static-locations: file:build/resources/main/static/
       cache:
         period: 0
 ---


### PR DESCRIPTION
## What is this PR?

fix: Change Thymeleaf template path reference to prevent OWASP ZAP false positives)

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

