### PR TITLE
BC-785: Fix amended tag field mappings.

### DIFF
--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/mappers/ClaimMapper.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/mappers/ClaimMapper.java
@@ -5,7 +5,6 @@ import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
-import org.apache.commons.lang3.StringUtils;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -19,6 +18,7 @@ import uk.gov.justice.laa.payments.amend.models.CrimeClaimDetails;
 import uk.gov.justice.laa.payments.amend.models.MediationClaimDetails;
 import uk.gov.justice.laa.payments.amend.models.enums.AreaOfLaw;
 import uk.gov.justice.laa.payments.amend.models.enums.DerivedClaimStatus;
+import uk.gov.justice.laa.payments.amend.utils.MatterTypeUtils;
 
 @Mapper(
     componentModel = "spring",
@@ -262,11 +262,7 @@ public interface ClaimMapper {
    */
   @Named("matterType1")
   default String getMatterType1(String matterTypeCode) {
-    if (StringUtils.isNotBlank(matterTypeCode)) {
-      String[] matterType = matterTypeCode.split("[+:]");
-      return matterType.length > 0 ? matterType[0] : null;
-    }
-    return null;
+    return MatterTypeUtils.part(matterTypeCode, MatterTypeUtils.FIRST_PART);
   }
 
   /**
@@ -277,11 +273,7 @@ public interface ClaimMapper {
    */
   @Named("matterType2")
   default String getMatterType2(String matterTypeCode) {
-    if (StringUtils.isNotBlank(matterTypeCode)) {
-      String[] matterType = matterTypeCode.split("[+:]");
-      return matterType.length > 1 ? matterType[1] : null;
-    }
-    return null;
+    return MatterTypeUtils.part(matterTypeCode, MatterTypeUtils.SECOND_PART);
   }
 
   @ObjectFactory

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryAmendmentsService.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryAmendmentsService.java
@@ -7,6 +7,7 @@ import static uk.gov.justice.laa.payments.amend.models.enums.Amendability.NEVER;
 import static uk.gov.justice.laa.payments.amend.models.enums.AreaOfLaw.CRIME_LOWER;
 import static uk.gov.justice.laa.payments.amend.models.enums.AreaOfLaw.LEGAL_HELP;
 import static uk.gov.justice.laa.payments.amend.models.enums.AreaOfLaw.MEDIATION;
+import static uk.gov.justice.laa.payments.amend.utils.MatterTypeUtils.MATTER_TYPE_CODE;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -45,7 +46,6 @@ import uk.gov.justice.laa.payments.amend.viewmodels.viewfield.MediationClaimDeta
 public class ClaimHistoryAmendmentsService {
 
   private static final String FIELD_IDENTIFIER_FEE_CODE = "claim.feeCode";
-  private static final String FIELD_IDENTIFIER_MATTER_TYPE_CODE = "claim.matterTypeCode";
 
   private final UserRetrievalService userRetrievalService;
   private final SystemReferenceService systemReferenceService;
@@ -161,7 +161,7 @@ public class ClaimHistoryAmendmentsService {
   private List<ClaimHistoryAmendmentChange> resolveChanges(
       ClaimHistoryChangeEntry change, AreaOfLaw areaOfLaw, Map<String, String> availableFeeCodes) {
     var fieldIdentifier = change.getFieldIdentifier();
-    if (FIELD_IDENTIFIER_MATTER_TYPE_CODE.equals(fieldIdentifier)) {
+    if (MATTER_TYPE_CODE.equals(fieldIdentifier)) {
       return resolveMatterTypeChanges(change, areaOfLaw, availableFeeCodes);
     }
     return List.of(resolveChange(change, areaOfLaw, availableFeeCodes));
@@ -220,7 +220,7 @@ public class ClaimHistoryAmendmentsService {
     resolvedChanges.add(
         new ClaimHistoryAmendmentChange(
             field,
-            FIELD_IDENTIFIER_MATTER_TYPE_CODE,
+            MATTER_TYPE_CODE,
             resolveValue(beforePart, field, availableFeeCodes),
             resolveValue(afterPart, field, availableFeeCodes),
             areaOfLaw));

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryService.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryService.java
@@ -3,13 +3,13 @@ package uk.gov.justice.laa.payments.amend.service;
 import static java.lang.Boolean.TRUE;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toSet;
-import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryChangeEntry.ChangeSourceEnum.REQUESTED;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryEventType.AMENDMENT;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryEventType.ASSESSMENT;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryEventType.SUBMISSION;
 import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryEventType.VOID;
 
 import java.time.OffsetDateTime;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -34,6 +34,7 @@ import uk.gov.justice.laa.payments.amend.models.history.ClaimHistoryApiEvent;
 import uk.gov.justice.laa.payments.amend.models.history.ClaimHistoryAssessedEvent;
 import uk.gov.justice.laa.payments.amend.models.history.ClaimHistoryCreatedEvent;
 import uk.gov.justice.laa.payments.amend.models.history.ClaimHistoryVoidedEvent;
+import uk.gov.justice.laa.payments.amend.utils.MatterTypeUtils;
 import uk.gov.justice.laadata.providers.model.ProviderFirmOfficeDto;
 import uk.gov.justice.laadata.providers.model.ProviderFirmSummary;
 
@@ -79,14 +80,13 @@ public class ClaimHistoryService {
     builder.lastUpdatedUser(lastUpdated.user()).lastUpdatedDateTime(lastUpdated.dateTime());
 
     if (claim.isAmended()) {
-      builder.amendedFields(
-          historyEvents.stream()
-              .filter(event -> event.eventType() == AMENDMENT)
-              .map(ClaimHistoryService::getChanges)
-              .flatMap(List::stream)
-              .filter(ClaimHistoryService::isRequested)
-              .map(ClaimHistoryChangeEntry::getFieldIdentifier)
-              .collect(toSet()));
+      var amendedFields = new LinkedHashSet<String>();
+      historyEvents.stream()
+          .filter(event -> event.eventType() == AMENDMENT)
+          .map(ClaimHistoryService::getChanges)
+          .flatMap(List::stream)
+          .forEach(change -> addFieldIdentifiers(change, amendedFields));
+      builder.amendedFields(amendedFields);
     } else {
       builder.amendedFields(Set.of());
     }
@@ -288,8 +288,22 @@ public class ClaimHistoryService {
     return Optional.ofNullable(toAmendmentMetadata(historyEvent).getChanges()).orElse(List.of());
   }
 
-  private static boolean isRequested(ClaimHistoryChangeEntry change) {
-    return change.getChangeSource() == REQUESTED;
+  private static void addFieldIdentifiers(
+      ClaimHistoryChangeEntry change, Set<String> amendedFields) {
+    var fieldIdentifier = change.getFieldIdentifier();
+    if (fieldIdentifier == null) {
+      return;
+    }
+    amendedFields.add(fieldIdentifier);
+    if (MatterTypeUtils.MATTER_TYPE_CODE.equals(fieldIdentifier)) {
+      amendedFields.addAll(
+          MatterTypeUtils.changedPartIdentifiers(
+              toFallbackString(change.getBefore()), toFallbackString(change.getAfter())));
+    }
+  }
+
+  private static String toFallbackString(Object rawValue) {
+    return rawValue == null ? null : String.valueOf(rawValue);
   }
 
   private record LastUpdated(MicrosoftApiUser user, OffsetDateTime dateTime) {}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryService.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryService.java
@@ -294,11 +294,12 @@ public class ClaimHistoryService {
     if (fieldIdentifier == null) {
       return;
     }
-    amendedFields.add(fieldIdentifier);
     if (MatterTypeUtils.MATTER_TYPE_CODE.equals(fieldIdentifier)) {
       amendedFields.addAll(
           MatterTypeUtils.changedPartIdentifiers(
               toFallbackString(change.getBefore()), toFallbackString(change.getAfter())));
+    } else {
+      amendedFields.add(fieldIdentifier);
     }
   }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/MatterTypeUtils.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/MatterTypeUtils.java
@@ -1,0 +1,40 @@
+package uk.gov.justice.laa.payments.amend.utils;
+
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class MatterTypeUtils {
+
+  private static final String DELIMITER = "[+:]";
+  private static final String PART_SUFFIX = "#";
+
+  public static final String MATTER_TYPE_CODE = "claim.matterTypeCode";
+
+  public static final int FIRST_PART = 0;
+  public static final int SECOND_PART = 1;
+
+  public static String part(String matterTypeCode, int part) {
+    if (matterTypeCode == null || matterTypeCode.isBlank()) {
+      return null;
+    }
+    String[] split = matterTypeCode.split(DELIMITER);
+    return part < split.length ? split[part] : null;
+  }
+
+  public static String partIdentifier(int part) {
+    return MATTER_TYPE_CODE + PART_SUFFIX + part;
+  }
+
+  public static Set<String> changedPartIdentifiers(String before, String after) {
+    Set<String> identifiers = new LinkedHashSet<>();
+    for (int part : new int[] {FIRST_PART, SECOND_PART}) {
+      if (!Objects.equals(part(before, part), part(after, part))) {
+        identifiers.add(partIdentifier(part));
+      }
+    }
+    return identifiers;
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/MatterTypeUtils.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/MatterTypeUtils.java
@@ -16,6 +16,9 @@ public class MatterTypeUtils {
   public static final int FIRST_PART = 0;
   public static final int SECOND_PART = 1;
 
+  public static final String MATTER_TYPE_CODE_1 = MATTER_TYPE_CODE + PART_SUFFIX + FIRST_PART;
+  public static final String MATTER_TYPE_CODE_2 = MATTER_TYPE_CODE + PART_SUFFIX + SECOND_PART;
+
   public static String part(String matterTypeCode, int part) {
     if (matterTypeCode == null || matterTypeCode.isBlank()) {
       return null;
@@ -24,16 +27,13 @@ public class MatterTypeUtils {
     return part < split.length ? split[part] : null;
   }
 
-  public static String partIdentifier(int part) {
-    return MATTER_TYPE_CODE + PART_SUFFIX + part;
-  }
-
   public static Set<String> changedPartIdentifiers(String before, String after) {
     Set<String> identifiers = new LinkedHashSet<>();
-    for (int part : new int[] {FIRST_PART, SECOND_PART}) {
-      if (!Objects.equals(part(before, part), part(after, part))) {
-        identifiers.add(partIdentifier(part));
-      }
+    if (!Objects.equals(part(before, FIRST_PART), part(after, FIRST_PART))) {
+      identifiers.add(MATTER_TYPE_CODE_1);
+    }
+    if (!Objects.equals(part(before, SECOND_PART), part(after, SECOND_PART))) {
+      identifiers.add(MATTER_TYPE_CODE_2);
     }
     return identifiers;
   }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CivilClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CivilClaimDetailsViewField.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.payments.amend.viewmodels.viewfield;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
@@ -72,23 +71,13 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       String.class,
       CivilClaimDetails::getMatterType1,
       Builder::matterTypeCode,
-      "claim.matterTypeCode") {
-    @Override
-    public Set<String> getAmendedFieldIdentifiers() {
-      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.FIRST_PART));
-    }
-  },
+      MatterTypeUtils.MATTER_TYPE_CODE_1),
   MATTER_TYPE_CODE_2(
       FieldType.TEXT,
       String.class,
       CivilClaimDetails::getMatterType2,
       Builder::matterTypeCode,
-      "claim.matterTypeCode") {
-    @Override
-    public Set<String> getAmendedFieldIdentifiers() {
-      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.SECOND_PART));
-    }
-  },
+      MatterTypeUtils.MATTER_TYPE_CODE_2),
 
   // Case details fields
   STAGE_REACHED(

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CivilClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CivilClaimDetailsViewField.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.payments.amend.viewmodels.viewfield;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import uk.gov.justice.laa.payments.amend.models.CivilClaimDetails;
 import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
 import uk.gov.justice.laa.payments.amend.models.enums.Amendability;
 import uk.gov.justice.laa.payments.amend.models.enums.FieldType;
+import uk.gov.justice.laa.payments.amend.utils.MatterTypeUtils;
 
 @Getter
 public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetails> {
@@ -70,13 +72,23 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       String.class,
       CivilClaimDetails::getMatterType1,
       Builder::matterTypeCode,
-      "claim.matterTypeCode"),
+      "claim.matterTypeCode") {
+    @Override
+    public Set<String> getAmendedFieldIdentifiers() {
+      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.FIRST_PART));
+    }
+  },
   MATTER_TYPE_CODE_2(
       FieldType.TEXT,
       String.class,
       CivilClaimDetails::getMatterType2,
       Builder::matterTypeCode,
-      "claim.matterTypeCode"),
+      "claim.matterTypeCode") {
+    @Override
+    public Set<String> getAmendedFieldIdentifiers() {
+      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.SECOND_PART));
+    }
+  },
 
   // Case details fields
   STAGE_REACHED(

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimDetailsViewField.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.payments.amend.viewmodels.viewfield;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
@@ -15,7 +16,12 @@ import uk.gov.justice.laa.payments.amend.viewmodels.ThymeleafMessage;
 @Getter
 public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
   // Claim overview only fields
-  CLIENT_NAME(FieldType.TEXT, ClaimDetailsViewField::getClientName),
+  CLIENT_NAME(FieldType.TEXT, ClaimDetailsViewField::getClientName) {
+    @Override
+    public Set<String> getAmendedFieldIdentifiers() {
+      return Set.of("client.clientForename", "client.clientSurname");
+    }
+  },
   PROVIDER_NAME(FieldType.TEXT, ClaimDetailsViewField::getProviderName),
   OFFICE_CODE(FieldType.TEXT, ClaimDetails::getOfficeCode),
   SUBMITTED_DATE(FieldType.DATE, ClaimDetails::getSubmittedDate),
@@ -24,7 +30,7 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
   FEE_CODE_DESCRIPTION(FieldType.TEXT, ClaimDetails::getFeeCodeDescription),
   ESCAPED(FieldType.BOOLEAN, ClaimDetails::getEscaped),
   VAT_REQUESTED(FieldType.BOOLEAN, ClaimDetails::getVatApplicable),
-  TOTAL(FieldType.TEXT, ClaimDetails::getTotalAmount),
+  TOTAL(FieldType.TEXT, ClaimDetails::getTotalAmount, "fee.totalAmount"),
 
   // Common client fields
   SURNAME(
@@ -90,13 +96,7 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       "claim.feeCode"),
 
   // Common cost fields
-  FIXED_FEE(
-      FieldType.TEXT,
-      Object.class,
-      ClaimDetails::getFixedFee,
-      (b, v) -> b,
-      Amendability.NEVER,
-      "fee.fixedFeeAmount"),
+  FIXED_FEE(FieldType.TEXT, ClaimDetails::getFixedFee, "fee.fixedFeeAmount"),
   PROFIT_COST(
       FieldType.BIG_DECIMAL,
       BigDecimal.class,
@@ -134,8 +134,21 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
   private final Amendability amendability;
   private final List<FieldOption> options;
 
-  <T> ClaimDetailsViewField(FieldType fieldType, Function<ClaimDetails, ?> getter) {
-    this(fieldType, Object.class, getter, (b, v) -> b, List.of(), Amendability.NEVER, "", null);
+  ClaimDetailsViewField(FieldType fieldType, Function<ClaimDetails, ?> getter) {
+    this(fieldType, Object.class, getter, (b, _) -> b, List.of(), Amendability.NEVER, "", null);
+  }
+
+  ClaimDetailsViewField(
+      FieldType fieldType, Function<ClaimDetails, ?> getter, String feeApiFieldName) {
+    this(
+        fieldType,
+        Object.class,
+        getter,
+        (b, _) -> b,
+        List.of(),
+        Amendability.NEVER,
+        "",
+        feeApiFieldName);
   }
 
   <T> ClaimDetailsViewField(

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimViewField.java
@@ -3,6 +3,8 @@ package uk.gov.justice.laa.payments.amend.viewmodels.viewfield;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.springframework.context.MessageSource;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -29,6 +31,17 @@ public interface ClaimViewField<T extends Claim> {
 
   default String getFeeApiFieldName() {
     return null;
+  }
+
+  default Set<String> getAmendedFieldIdentifiers() {
+    return Stream.of(getClaimsApiFieldName(), getFeeApiFieldName())
+        .filter(name -> name != null && !name.isBlank())
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  default boolean isAmended(Set<String> amendedFields) {
+    return amendedFields != null
+        && getAmendedFieldIdentifiers().stream().anyMatch(amendedFields::contains);
   }
 
   ClaimViewFieldPatcher<?> getPatcher();

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimViewField.java
@@ -36,7 +36,7 @@ public interface ClaimViewField<T extends Claim> {
   default Set<String> getAmendedFieldIdentifiers() {
     return Stream.of(getClaimsApiFieldName(), getFeeApiFieldName())
         .filter(name -> name != null && !name.isBlank())
-        .collect(Collectors.toUnmodifiableSet());
+        .collect(Collectors.toSet());
   }
 
   default boolean isAmended(Set<String> amendedFields) {
@@ -52,9 +52,8 @@ public interface ClaimViewField<T extends Claim> {
     return messageSource.getMessage(new DefaultMessageSourceResolvable(codes), Locale.UK);
   }
 
-  default ClaimAmendmentPatch.Builder applyPatch(
-      ClaimAmendmentPatch.Builder patchBuilder, Object value) {
-    return getPatcher().apply(patchBuilder, value);
+  default void applyPatch(ClaimAmendmentPatch.Builder patchBuilder, Object value) {
+    getPatcher().apply(patchBuilder, value);
   }
 
   default Amendability getAmendability() {

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/MediationClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/MediationClaimDetailsViewField.java
@@ -1,12 +1,14 @@
 package uk.gov.justice.laa.payments.amend.viewmodels.viewfield;
 
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimAmendmentPatch.Builder;
 import uk.gov.justice.laa.payments.amend.models.MediationClaimDetails;
 import uk.gov.justice.laa.payments.amend.models.enums.FieldType;
+import uk.gov.justice.laa.payments.amend.utils.MatterTypeUtils;
 
 @Getter
 public enum MediationClaimDetailsViewField implements ClaimViewField<MediationClaimDetails> {
@@ -120,13 +122,23 @@ public enum MediationClaimDetailsViewField implements ClaimViewField<MediationCl
       String.class,
       MediationClaimDetails::getMatterType1,
       Builder::matterTypeCode,
-      "claim.matterTypeCode"),
+      "claim.matterTypeCode") {
+    @Override
+    public Set<String> getAmendedFieldIdentifiers() {
+      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.FIRST_PART));
+    }
+  },
   MATTER_TYPE_CODE_2(
       FieldType.TEXT,
       String.class,
       MediationClaimDetails::getMatterType2,
       Builder::matterTypeCode,
-      "claim.matterTypeCode"),
+      "claim.matterTypeCode") {
+    @Override
+    public Set<String> getAmendedFieldIdentifiers() {
+      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.SECOND_PART));
+    }
+  },
 
   // Case Details fields
   CLAIM_ID(

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/MediationClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/MediationClaimDetailsViewField.java
@@ -1,7 +1,6 @@
 package uk.gov.justice.laa.payments.amend.viewmodels.viewfield;
 
 import java.util.List;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
@@ -122,23 +121,13 @@ public enum MediationClaimDetailsViewField implements ClaimViewField<MediationCl
       String.class,
       MediationClaimDetails::getMatterType1,
       Builder::matterTypeCode,
-      "claim.matterTypeCode") {
-    @Override
-    public Set<String> getAmendedFieldIdentifiers() {
-      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.FIRST_PART));
-    }
-  },
+      MatterTypeUtils.MATTER_TYPE_CODE_1),
   MATTER_TYPE_CODE_2(
       FieldType.TEXT,
       String.class,
       MediationClaimDetails::getMatterType2,
       Builder::matterTypeCode,
-      "claim.matterTypeCode") {
-    @Override
-    public Set<String> getAmendedFieldIdentifiers() {
-      return Set.of(MatterTypeUtils.partIdentifier(MatterTypeUtils.SECOND_PART));
-    }
-  },
+      MatterTypeUtils.MATTER_TYPE_CODE_2),
 
   // Case Details fields
   CLAIM_ID(

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/confirmation.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/confirmation.html
@@ -48,7 +48,7 @@
                   th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></dd>
               <dd class="govuk-summary-list__value" th:if="${claim.hasAssessment}" th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}"></dd>
               <dd class="govuk-summary-list__actions"
-                  th:if="${confirmation.amendedFields.contains(field.claimsApiFieldName) || confirmation.amendedFields.contains(field.feeApiFieldName)}">
+                  th:if="${field.isAmended(confirmation.amendedFields)}">
                 <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
               </dd>
             </div>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-case.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-case.html
@@ -26,7 +26,7 @@
                         <div class="govuk-summary-list__row" th:each="entry : ${claim.caseTypeRows}">
                             <dt class="govuk-summary-list__key" th:text="#{${'claimField.' + entry.key}}"></dt>
                             <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.key, entry.value).resolve(#messages)}"></dd>
-                            <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(entry.key.claimsApiFieldName)}">
+                            <dd class="govuk-summary-list__actions" th:if="${entry.key.isAmended(amendedFields)}">
                                 <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                             </dd>
                         </div>
@@ -45,7 +45,7 @@
                         <div class="govuk-summary-list__row" th:each="entry : ${claim.caseDetailsRows}">
                             <dt class="govuk-summary-list__key" th:text="#{${'claimField.' + entry.key}}"></dt>
                             <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.key, entry.value).resolve(#messages)}"></dd>
-                            <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(entry.key.claimsApiFieldName)}">
+                            <dd class="govuk-summary-list__actions" th:if="${entry.key.isAmended(amendedFields)}">
                                 <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                             </dd>
                         </div>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-client.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-client.html
@@ -30,7 +30,7 @@
                         <div class="govuk-summary-list__row" th:each="entry : ${claim.client1Rows}">
                             <dt class="govuk-summary-list__key" th:text="#{${'claimField.' + entry.key}}"></dt>
                             <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.key, entry.value).resolve(#messages)}"></dd>
-                            <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(entry.key.claimsApiFieldName)}">
+                            <dd class="govuk-summary-list__actions" th:if="${entry.key.isAmended(amendedFields)}">
                                 <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                             </dd>
                         </div>
@@ -51,7 +51,7 @@
                         <div class="govuk-summary-list__row" th:each="entry : ${claim.client2Rows}">
                             <dt class="govuk-summary-list__key" th:text="#{${'claimField.' + entry.key}}"></dt>
                             <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.key, entry.value).resolve(#messages)}"></dd>
-                            <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(entry.key.claimsApiFieldName)}">
+                            <dd class="govuk-summary-list__actions" th:if="${entry.key.isAmended(amendedFields)}">
                                 <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                             </dd>
                         </div>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-costs.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-costs.html
@@ -36,7 +36,7 @@
                             <dd class="govuk-summary-list__value"
                                 th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></dd>
                             <dd class="govuk-summary-list__value" th:if="${claim.hasAssessment}" th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}"></dd>
-                            <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(field.claimsApiFieldName)}">
+                            <dd class="govuk-summary-list__actions" th:if="${field.isAmended(amendedFields)}">
                                 <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                             </dd>
                         </div>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-summary.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/claimdetails/claim-summary.html
@@ -25,7 +25,7 @@
                                     <div class="govuk-summary-list__row" th:each="entry : ${claim.summaryRows}">
                                         <dt class="govuk-summary-list__key" th:text="#{${'claimField.' + entry.key}}"></dt>
                                         <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(entry.value).resolve(#messages)}"></dd>
-                                        <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(entry.key.claimsApiFieldName)}">
+                                        <dd class="govuk-summary-list__actions" th:if="${entry.key.isAmended(amendedFields)}">
                                             <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                                         </dd>
                                     </div>
@@ -52,7 +52,7 @@
                                         <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.submitted).resolve(#messages)}"></dd>
                                         <dd class="govuk-summary-list__value" th:text="${@ThymeleafUtils.getFormattedValue(row.calculated).resolve(#messages)}"></dd>
                                         <dd class="govuk-summary-list__value" th:if="${claim.hasAssessment}" th:text="${@ThymeleafUtils.getFormattedValue(row.assessed).resolve(#messages)}"></dd>
-                                        <dd class="govuk-summary-list__actions" th:if="${amendedFields.contains(field.claimsApiFieldName)}">
+                                        <dd class="govuk-summary-list__actions" th:if="${field.isAmended(amendedFields)}">
                                             <strong class="govuk-tag govuk-tag--yellow" th:text="#{service.amended}"></strong>
                                         </dd>
                                     </div>

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryServiceTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryServiceTest.java
@@ -195,7 +195,7 @@ public class ClaimHistoryServiceTest {
   }
 
   @Test
-  void getClaimHistorySummaryReturnsRequestedAmendmentFieldIdentifiers() {
+  void getClaimHistorySummaryReturnsAmendmentFieldIdentifiersFromEveryChangeSource() {
     var claim = MockClaimsFunctions.createMockCivilClaim();
     claim.setAmended(true);
     claim.setDerivedClaimStatus(AMENDED);
@@ -208,7 +208,7 @@ public class ClaimHistoryServiceTest {
         List.of(
             change("REQUESTED", "claim.feeCode"),
             change("REQUESTED", "claimSummaryFee.netProfitCostsAmount"),
-            change("CALCULATED", "claim.caseStartDate"),
+            change("FSP", "fee.totalAmount"),
             change("REQUESTED", "claim.feeCode"));
 
     var history =
@@ -233,7 +233,67 @@ public class ClaimHistoryServiceTest {
     assertThat(summary.lastUpdatedUser()).isEqualTo(amendedUser);
     assertThat(summary.lastUpdatedDateTime()).isEqualTo(amendedDateTime);
     assertThat(summary.amendedFields())
-        .containsExactlyInAnyOrder("claim.feeCode", "claimSummaryFee.netProfitCostsAmount");
+        .containsExactlyInAnyOrder(
+            "claim.feeCode", "claimSummaryFee.netProfitCostsAmount", "fee.totalAmount");
+  }
+
+  @Test
+  void getClaimHistorySummaryIdentifiesOnlyTheChangedHalfOfTheMatterTypeCode() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    claim.setAmended(true);
+    claim.setDerivedClaimStatus(AMENDED);
+
+    var history =
+        new ClaimHistoryResultSet()
+            .claimId(claim.getClaimId())
+            .events(
+                List.of(
+                    new uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryEvent()
+                        .eventType(AMENDMENT)
+                        .metadata(
+                            Map.of(
+                                "changes",
+                                List.of(
+                                    change(
+                                        "REQUESTED",
+                                        "claim.matterTypeCode",
+                                        "FAMA:FPET",
+                                        "FAMA:FPRO"))))));
+
+    when(claimsApiClient.getClaimHistory(claim.getClaimId())).thenReturn(Mono.just(history));
+
+    assertThat(claimHistoryService.getClaimHistorySummary(claim).amendedFields())
+        .containsExactlyInAnyOrder("claim.matterTypeCode", "claim.matterTypeCode#1");
+  }
+
+  @Test
+  void getClaimHistorySummaryIdentifiesBothHalvesOfTheMatterTypeCodeWhenBothChanged() {
+    var claim = MockClaimsFunctions.createMockCivilClaim();
+    claim.setAmended(true);
+    claim.setDerivedClaimStatus(AMENDED);
+
+    var history =
+        new ClaimHistoryResultSet()
+            .claimId(claim.getClaimId())
+            .events(
+                List.of(
+                    new uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimHistoryEvent()
+                        .eventType(AMENDMENT)
+                        .metadata(
+                            Map.of(
+                                "changes",
+                                List.of(
+                                    change(
+                                        "REQUESTED",
+                                        "claim.matterTypeCode",
+                                        "FAMA:FPET",
+                                        "FAMB:FPRO"))))));
+
+    when(claimsApiClient.getClaimHistory(claim.getClaimId())).thenReturn(Mono.just(history));
+
+    assertThat(claimHistoryService.getClaimHistorySummary(claim).amendedFields())
+        .containsExactlyInAnyOrder(
+            "claim.matterTypeCode", "claim.matterTypeCode#0", "claim.matterTypeCode#1");
   }
 
   @Test
@@ -400,6 +460,24 @@ public class ClaimHistoryServiceTest {
     var change = new LinkedHashMap<String, String>();
     change.put("change_source", source);
     change.put("field_identifier", fieldIdentifier);
+    return change;
+  }
+
+  private static LinkedHashMap<String, String> change(
+      String source, String fieldIdentifier, String before, String after) {
+    var change = change(source, fieldIdentifier);
+    change.put("before", before);
+    change.put("after", after);
+    return change;
+  }
+
+  private static LinkedHashMap<String, Object> change(
+      String source, String fieldIdentifier, Object before, Object after) {
+    var change = new LinkedHashMap<String, Object>();
+    change.put("change_source", source);
+    change.put("field_identifier", fieldIdentifier);
+    change.put("before", before);
+    change.put("after", after);
     return change;
   }
 

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryServiceTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/ClaimHistoryServiceTest.java
@@ -263,7 +263,7 @@ public class ClaimHistoryServiceTest {
     when(claimsApiClient.getClaimHistory(claim.getClaimId())).thenReturn(Mono.just(history));
 
     assertThat(claimHistoryService.getClaimHistorySummary(claim).amendedFields())
-        .containsExactlyInAnyOrder("claim.matterTypeCode", "claim.matterTypeCode#1");
+        .containsExactlyInAnyOrder("claim.matterTypeCode#1");
   }
 
   @Test
@@ -292,8 +292,7 @@ public class ClaimHistoryServiceTest {
     when(claimsApiClient.getClaimHistory(claim.getClaimId())).thenReturn(Mono.just(history));
 
     assertThat(claimHistoryService.getClaimHistorySummary(claim).amendedFields())
-        .containsExactlyInAnyOrder(
-            "claim.matterTypeCode", "claim.matterTypeCode#0", "claim.matterTypeCode#1");
+        .containsExactlyInAnyOrder("claim.matterTypeCode#0", "claim.matterTypeCode#1");
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/viewmodels/claimcosts/ClaimCostsViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/viewmodels/claimcosts/ClaimCostsViewTest.java
@@ -3,7 +3,9 @@ package uk.gov.justice.laa.payments.amend.viewmodels.claimcosts;
 import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.CivilClaimDetailsViewField.COUNSELS_COST;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.CivilClaimDetailsViewField.SUBSTANTIVE_HEARING;
+import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimDetailsViewField.FIXED_FEE;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimDetailsViewField.PROFIT_COST;
+import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimDetailsViewField.TOTAL;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.ClaimDetailsViewField.VAT;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.CrimeClaimDetailsViewField.TRAVEL_COSTS;
 
@@ -44,5 +46,9 @@ class ClaimCostsViewTest {
     assertThat(VAT.getFeeApiFieldName()).isEqualTo("fee.vatIndicator");
     assertThat(COUNSELS_COST.getFeeApiFieldName()).isEqualTo("fee.netCostOfCounselAmount");
     assertThat(TRAVEL_COSTS.getFeeApiFieldName()).isEqualTo("fee.netTravelCostsAmount");
+    assertThat(FIXED_FEE.getFeeApiFieldName()).isEqualTo("fee.fixedFeeAmount");
+    assertThat(TOTAL.getFeeApiFieldName()).isEqualTo("fee.totalAmount");
+    assertThat(FIXED_FEE.getClaimsApiFieldName()).isBlank();
+    assertThat(TOTAL.getClaimsApiFieldName()).isBlank();
   }
 }

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/ViewTestBase.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/ViewTestBase.java
@@ -427,6 +427,10 @@ public abstract class ViewTestBase {
     Assertions.assertEquals("Amended", tag.text());
   }
 
+  protected void assertSummaryListRowHasNoAmendedTag(Element row) {
+    Assertions.assertTrue(row.select(".govuk-summary-list__actions .govuk-tag").isEmpty());
+  }
+
   protected void assertPageHasNoAmendedTags(Document doc) {
     Assertions.assertTrue(doc.select(".govuk-summary-list__actions .govuk-tag").isEmpty());
   }

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/claimdetails/ClaimCaseViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/claimdetails/ClaimCaseViewTest.java
@@ -217,7 +217,8 @@ class ClaimCaseViewTest extends ClaimDetailsBaseTest {
     claim = createMediationClaim();
     mockClaimHistorySummary(
         "claim.feeCode",
-        "claim.matterTypeCode",
+        "claim.matterTypeCode#0",
+        "claim.matterTypeCode#1",
         "claimCase.caseId",
         "claimCase.uniqueCaseId",
         "claim.mediationSessionsCount",
@@ -246,6 +247,28 @@ class ClaimCaseViewTest extends ClaimDetailsBaseTest {
         "Outreach location",
         "Referral",
         "Schedule reference (outcome)");
+  }
+
+  @Test
+  void testTagsOnlySecondMatterTypeRowWhenSecondHalfOfCodeChanged() {
+    claim = createCivilClaim();
+    mockClaimHistorySummary("claim.matterTypeCode", "claim.matterTypeCode#1");
+
+    var doc = renderDocument();
+
+    assertSummaryListRowHasNoAmendedTag(getSummaryListRowInCard(doc, "Case type", "Matter type 1"));
+    assertSummaryListRowHasAmendedTag(getSummaryListRowInCard(doc, "Case type", "Matter type 2"));
+  }
+
+  @Test
+  void testTagsOnlyFirstMatterTypeRowWhenFirstHalfOfCodeChanged() {
+    claim = createCivilClaim();
+    mockClaimHistorySummary("claim.matterTypeCode", "claim.matterTypeCode#0");
+
+    var doc = renderDocument();
+
+    assertSummaryListRowHasAmendedTag(getSummaryListRowInCard(doc, "Case type", "Matter type 1"));
+    assertSummaryListRowHasNoAmendedTag(getSummaryListRowInCard(doc, "Case type", "Matter type 2"));
   }
 
   @Test
@@ -344,7 +367,8 @@ class ClaimCaseViewTest extends ClaimDetailsBaseTest {
     claim = createCivilClaim();
     mockClaimHistorySummary(
         "claim.feeCode",
-        "claim.matterTypeCode",
+        "claim.matterTypeCode#0",
+        "claim.matterTypeCode#1",
         "claim.scheduleReference",
         "claimCase.caseId",
         "claim.caseReferenceNumber",

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/claimdetails/ClaimSummaryViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/claimdetails/ClaimSummaryViewTest.java
@@ -77,6 +77,38 @@ class ClaimSummaryViewTest extends ClaimDetailsBaseTest {
   }
 
   @Test
+  void testTagsRowsRecalculatedByTheFeeScheme() {
+    CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+    createClaimSummary(claim);
+    claim.setClaimId(claimId);
+    claim.setSubmissionId(submissionId);
+    claim.setAreaOfLaw(LEGAL_HELP);
+
+    when(claimService.getClaimDetails(any(), any())).thenReturn(claim);
+    mockClaimHistorySummary("fee.totalAmount", "fee.fixedFeeAmount");
+
+    Document doc = renderDocument();
+
+    assertSummaryListRowHasAmendedTag(getSummaryListRowInCard(doc, "Values", "Total"));
+    assertSummaryListRowHasAmendedTag(getSummaryListRowInCard(doc, "Values", "Fixed fee"));
+  }
+
+  @Test
+  void testTagsCombinedClientNameRowWhenEitherNameChanged() {
+    CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+    createClaimSummary(claim);
+    claim.setClaimId(claimId);
+    claim.setSubmissionId(submissionId);
+    claim.setAreaOfLaw(LEGAL_HELP);
+
+    when(claimService.getClaimDetails(any(), any())).thenReturn(claim);
+    mockClaimHistorySummary("client.clientSurname");
+
+    assertSummaryListRowHasAmendedTag(
+        getSummaryListRowInCard(renderDocument(), "Summary", "Client name"));
+  }
+
+  @Test
   void testCivilClaimPage() {
     CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
     createClaimSummary(claim);
@@ -406,7 +438,8 @@ class ClaimSummaryViewTest extends ClaimDetailsBaseTest {
         "claim.uniqueFileNumber",
         "client.uniqueClientNumber",
         "claim.feeCode",
-        "claim.matterTypeCode",
+        "claim.matterTypeCode#0",
+        "claim.matterTypeCode#1",
         "claim.caseStartDate",
         "claim.caseConcludedDate",
         "claimSummaryFee.netProfitCostsAmount",
@@ -523,7 +556,8 @@ class ClaimSummaryViewTest extends ClaimDetailsBaseTest {
         "claim.uniqueFileNumber",
         "client.uniqueClientNumber",
         "claim.feeCode",
-        "claim.matterTypeCode",
+        "claim.matterTypeCode#0",
+        "claim.matterTypeCode#1",
         "claim.caseStartDate",
         "claim.caseConcludedDate",
         "claimSummaryFee.netProfitCostsAmount",

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/claimdetails/ClaimSummaryViewTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/views/claimdetails/ClaimSummaryViewTest.java
@@ -491,6 +491,48 @@ class ClaimSummaryViewTest extends ClaimDetailsBaseTest {
   }
 
   @Test
+  void testAmendedCivilClaimTagsMatterType1WithoutMatterType2() {
+    CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+    createClaimSummary(claim);
+    claim.setClaimId(claimId);
+    claim.setSubmissionId(submissionId);
+    claim.setDerivedClaimStatus(AMENDED);
+    claim.setAreaOfLaw(LEGAL_HELP);
+    claim.setCategoryOfLaw("TEST");
+    claim.setMatterType1("IMLB");
+    claim.setMatterType2("AHQS");
+
+    when(claimService.getClaimDetails(any(), any())).thenReturn(claim);
+    mockClaimHistorySummary("claim.matterTypeCode#0");
+
+    Document doc = renderDocument();
+
+    assertSummaryListRowHasAmendedTag(getSummaryListRowInCard(doc, "Summary", "Matter type 1"));
+    assertSummaryListRowHasNoAmendedTag(getSummaryListRowInCard(doc, "Summary", "Matter type 2"));
+  }
+
+  @Test
+  void testAmendedCivilClaimTagsMatterType2WithoutMatterType1() {
+    CivilClaimDetails claim = MockClaimsFunctions.createMockCivilClaim();
+    createClaimSummary(claim);
+    claim.setClaimId(claimId);
+    claim.setSubmissionId(submissionId);
+    claim.setDerivedClaimStatus(AMENDED);
+    claim.setAreaOfLaw(LEGAL_HELP);
+    claim.setCategoryOfLaw("TEST");
+    claim.setMatterType1("IMLB");
+    claim.setMatterType2("AHQS");
+
+    when(claimService.getClaimDetails(any(), any())).thenReturn(claim);
+    mockClaimHistorySummary("claim.matterTypeCode#1");
+
+    Document doc = renderDocument();
+
+    assertSummaryListRowHasNoAmendedTag(getSummaryListRowInCard(doc, "Summary", "Matter type 1"));
+    assertSummaryListRowHasAmendedTag(getSummaryListRowInCard(doc, "Summary", "Matter type 2"));
+  }
+
+  @Test
   void testAmendedCrimeLowerClaim() {
     CrimeClaimDetails claim = MockClaimsFunctions.createMockCrimeClaim();
     createClaimSummary(claim);


### PR DESCRIPTION
## What is this PR?

[BC-785](https://dsdmoj.atlassian.net/browse/BC-785)

Fixes amended tag mapping defects for claim detail and confirmation pages.
The amended field identifiers from the claims API were not being mapped correctly in a few cases, which meant some rows were either not tagged when amended or were tagged incorrectly.



## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.



[BC-785]: https://dsdmoj.atlassian.net/browse/BC-785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ