### PR TITLE
BC-651: Show claim amendment errors on a page instead of a 500

### DIFF
--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/ExceptionControllerAdvice.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/ExceptionControllerAdvice.java
@@ -1,7 +1,11 @@
 package uk.gov.justice.laa.payments.amend.controllers;
 
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveAmendmentErrors;
+
+import jakarta.servlet.http.HttpSession;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import uk.gov.justice.laa.payments.amend.exceptions.AmendmentSubmissionFailedException;
 import uk.gov.justice.laa.payments.amend.exceptions.NoClaimInSessionException;
 
 @ControllerAdvice
@@ -10,5 +14,13 @@ public class ExceptionControllerAdvice {
   public String handle(NoClaimInSessionException ex) {
     return String.format(
         "redirect:/submissions/%s/claims/%s", ex.getSubmissionId(), ex.getClaimId());
+  }
+
+  @ExceptionHandler(AmendmentSubmissionFailedException.class)
+  public String handle(AmendmentSubmissionFailedException ex, HttpSession session) {
+    saveAmendmentErrors(session, ex.getClaimId(), ex.getErrorMessages());
+    return String.format(
+        "redirect:/submissions/%s/claims/%s/amendments/cannot-submit",
+        ex.getSubmissionId(), ex.getClaimId());
   }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentsCannotBeSubmittedController.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentsCannotBeSubmittedController.java
@@ -1,0 +1,50 @@
+package uk.gov.justice.laa.payments.amend.controllers.amendments;
+
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getAmendmentErrors;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getValidClaim;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.removeAmendmentErrors;
+
+import jakarta.servlet.http.HttpSession;
+import java.util.UUID;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.justice.laa.payments.amend.annotations.HasRoleClaimAmendmentsCaseworker;
+import uk.gov.justice.laa.payments.amend.annotations.RequiresFeatureFlag;
+import uk.gov.justice.laa.payments.amend.config.features.Feature;
+import uk.gov.justice.laa.payments.amend.controllers.UserControllerAdvice;
+
+@RequestMapping("/submissions/{submissionId}/claims/{claimId}/amendments/cannot-submit")
+@RequiresFeatureFlag(Feature.CLAIM_AMENDMENT)
+@HasRoleClaimAmendmentsCaseworker
+@UserControllerAdvice.Enabled
+@Controller
+public class AmendmentsCannotBeSubmittedController {
+
+  @GetMapping
+  public String cannotBeSubmitted(
+      HttpSession session,
+      Model model,
+      @PathVariable UUID submissionId,
+      @PathVariable UUID claimId) {
+    getValidClaim(session, submissionId, claimId);
+
+    var errors = getAmendmentErrors(session, claimId);
+    if (errors.isEmpty()) {
+      throw new ResponseStatusException(
+          HttpStatus.NOT_FOUND,
+          "No amendment errors found for submission %s claim %s".formatted(submissionId, claimId));
+    }
+    removeAmendmentErrors(session, claimId);
+
+    model.addAttribute("submissionId", submissionId);
+    model.addAttribute("claimId", claimId);
+    model.addAttribute("errors", errors);
+
+    return "pages/amendments/cannot-be-submitted";
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/exceptions/AmendmentSubmissionFailedException.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/exceptions/AmendmentSubmissionFailedException.java
@@ -1,0 +1,21 @@
+package uk.gov.justice.laa.payments.amend.exceptions;
+
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class AmendmentSubmissionFailedException extends RuntimeException {
+
+  private final UUID submissionId;
+  private final UUID claimId;
+  private final List<String> errorMessages;
+
+  public AmendmentSubmissionFailedException(
+      UUID submissionId, UUID claimId, List<String> errorMessages) {
+    super("Amendment submission failed with %d error(s)".formatted(errorMessages.size()));
+    this.submissionId = submissionId;
+    this.claimId = claimId;
+    this.errorMessages = errorMessages;
+  }
+}

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsService.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsService.java
@@ -3,13 +3,18 @@ package uk.gov.justice.laa.payments.amend.service;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.CivilClaimDetailsViewField.MATTER_TYPE_CODE_1;
 import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.CivilClaimDetailsViewField.MATTER_TYPE_CODE_2;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimAmendmentPatch;
 import uk.gov.justice.laa.payments.amend.client.ClaimsApiClient;
+import uk.gov.justice.laa.payments.amend.exceptions.AmendmentSubmissionFailedException;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.payments.amend.forms.amendments.OriginalAndCurrent;
 import uk.gov.justice.laa.payments.amend.models.CivilClaimDetails;
@@ -21,6 +26,10 @@ import uk.gov.justice.laa.payments.amend.viewmodels.AmendmentsHeaderView;
 @Slf4j
 @RequiredArgsConstructor
 public class CheckAmendmentsService {
+
+  private static final String GENERIC_ERROR_MESSAGE =
+      "A technical error occurred, please try again after some time";
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
   private final ClaimsApiClient claimsApiClient;
 
@@ -51,18 +60,37 @@ public class CheckAmendmentsService {
     try {
       claimsApiClient.updateClaim(submissionId, claimId, patchBuilder.build()).block();
     } catch (WebClientResponseException ex) {
-      // TODO: This will be handled gracefully by BC-651
-      log.error(
-          "Failed to submit amendment for submission {} claim {} with status {}: {}",
+      log.warn(
+          "Amendment submission rejected for submission {} claim {} with status {}: {}",
           submissionId,
           claimId,
           ex.getStatusCode(),
-          ex.getResponseBodyAsString(),
-          ex);
-      throw ex;
+          ex.getResponseBodyAsString());
+      throw new AmendmentSubmissionFailedException(submissionId, claimId, extractErrorMessages(ex));
     } catch (Exception ex) {
       log.error("Failed to submit amendment for submission {} claim {}", submissionId, claimId, ex);
       throw ex;
+    }
+  }
+
+  private List<String> extractErrorMessages(WebClientResponseException ex) {
+    try {
+      JsonNode root = OBJECT_MAPPER.readTree(ex.getResponseBodyAsString());
+      JsonNode errors = root.path("errors");
+      if (errors.isArray() && !errors.isEmpty()) {
+        List<String> messages = new ArrayList<>();
+        errors.forEach(
+            error -> messages.add(error.path("message").asString(GENERIC_ERROR_MESSAGE)));
+        return messages;
+      }
+      String detail = root.path("detail").asString(null);
+      return detail != null ? List.of(detail) : List.of(GENERIC_ERROR_MESSAGE);
+    } catch (Exception parseException) {
+      log.warn(
+          "Failed to parse amendment error response body: {}",
+          ex.getResponseBodyAsString(),
+          parseException);
+      return List.of(GENERIC_ERROR_MESSAGE);
     }
   }
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsService.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsService.java
@@ -5,9 +5,11 @@ import static uk.gov.justice.laa.payments.amend.viewmodels.viewfield.CivilClaimD
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import tools.jackson.databind.JsonNode;
@@ -30,6 +32,9 @@ public class CheckAmendmentsService {
   private static final String GENERIC_ERROR_MESSAGE =
       "A technical error occurred, please try again after some time";
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private static final Set<HttpStatus> VALIDATION_REJECTION_STATUSES =
+      Set.of(HttpStatus.BAD_REQUEST, HttpStatus.CONFLICT, HttpStatus.SERVICE_UNAVAILABLE);
 
   private final ClaimsApiClient claimsApiClient;
 
@@ -60,6 +65,16 @@ public class CheckAmendmentsService {
     try {
       claimsApiClient.updateClaim(submissionId, claimId, patchBuilder.build()).block();
     } catch (WebClientResponseException ex) {
+      if (!VALIDATION_REJECTION_STATUSES.contains(HttpStatus.resolve(ex.getStatusCode().value()))) {
+        log.error(
+            "Amendment submission to claims-api failed unexpectedly for submission {} claim {}"
+                + " with status {}",
+            submissionId,
+            claimId,
+            ex.getStatusCode(),
+            ex);
+        throw ex;
+      }
       log.warn(
           "Amendment submission rejected for submission {} claim {} with status {}: {}",
           submissionId,

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/SessionUtils.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/SessionUtils.java
@@ -1,6 +1,7 @@
 package uk.gov.justice.laa.payments.amend.utils;
 
 import jakarta.servlet.http.HttpSession;
+import java.util.List;
 import java.util.UUID;
 import lombok.experimental.UtilityClass;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,7 @@ public class SessionUtils {
 
   public static final String CLAIM_KEY = "%s";
   public static final String AMENDMENTS_KEY = "amendments:%s";
+  public static final String AMENDMENT_ERRORS_KEY = "amendmentErrors:%s";
 
   public static void saveClaim(HttpSession session, UUID claimId, Claim claim) {
     var key = CLAIM_KEY.formatted(claimId.toString());
@@ -85,5 +87,22 @@ public class SessionUtils {
   public static void removeAllForClaim(HttpSession session, UUID claimId) {
     removeClaim(session, claimId);
     removeAmendmentForms(session, claimId);
+  }
+
+  public static void saveAmendmentErrors(HttpSession session, UUID claimId, List<String> errors) {
+    var key = AMENDMENT_ERRORS_KEY.formatted(claimId.toString());
+    session.setAttribute(key, errors);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static List<String> getAmendmentErrors(HttpSession session, UUID claimId) {
+    var key = AMENDMENT_ERRORS_KEY.formatted(claimId.toString());
+    var errors = session.getAttribute(key);
+    return errors == null ? List.of() : (List<String>) errors;
+  }
+
+  public static void removeAmendmentErrors(HttpSession session, UUID claimId) {
+    var key = AMENDMENT_ERRORS_KEY.formatted(claimId.toString());
+    session.removeAttribute(key);
   }
 }

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/SessionUtils.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/utils/SessionUtils.java
@@ -87,6 +87,7 @@ public class SessionUtils {
   public static void removeAllForClaim(HttpSession session, UUID claimId) {
     removeClaim(session, claimId);
     removeAmendmentForms(session, claimId);
+    removeAmendmentErrors(session, claimId);
   }
 
   public static void saveAmendmentErrors(HttpSession session, UUID claimId, List<String> errors) {

--- a/laa-amend-a-claim-ui/src/main/resources/messages.properties
+++ b/laa-amend-a-claim-ui/src/main/resources/messages.properties
@@ -735,6 +735,11 @@ amendments.confirmation.updatedClaimTotal=The updated claim total is {0}.
 amendments.confirmation.viewClaim=View amended claim
 amendments.confirmation.backToSearch=Back to search results
 
+amendments.cannotBeSubmitted.title=Your amendments cannot be submitted
+amendments.cannotBeSubmitted.subheading=The following issues must be resolved before your amendments can be submitted.
+amendments.cannotBeSubmitted.resolveIssues=Resolve issues
+amendments.cannotBeSubmitted.cancelAmendments=Cancel amendments
+
 amendments.requestedBy.title=Who requested the amendment?
 amendments.requestedBy.required=Select who requested the amendment
 amendments.requestedBy.invalid=Select who requested the amendment

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/cannot-be-submitted.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/cannot-be-submitted.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en"
+      xmlns:th="http://www.thymeleaf.org"
+      th:replace="~{layout :: layout(
+        title=#{amendments.cannotBeSubmitted.title},
+        mainContent=~{::#main-content},
+        pageCategory=${null},
+        showBackLink=${false}
+    )}">
+<body>
+<main class="govuk-main-wrapper" id="main-content">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-xl" th:text="#{amendments.cannotBeSubmitted.title}"></h1>
+
+      <p class="govuk-body" th:text="#{amendments.cannotBeSubmitted.subheading}"></p>
+
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row" th:each="error : ${errors}">
+          <dd class="govuk-summary-list__value" th:text="${error}"></dd>
+        </div>
+      </dl>
+
+      <div class="govuk-button-group">
+        <a th:href="@{/submissions/{submissionId}/claims/{claimId}/amendments/check(submissionId=${submissionId}, claimId=${claimId})}"
+           th:text="#{amendments.cannotBeSubmitted.resolveIssues}"
+           role="button"
+           class="govuk-button"
+           data-module="govuk-button"
+           id="resolve-issues"></a>
+        <a th:href="@{/submissions/{submissionId}/claims/{claimId}(submissionId=${submissionId}, claimId=${claimId})}"
+           th:text="#{amendments.cannotBeSubmitted.cancelAmendments}"
+           class="govuk-link govuk-link--no-visited-state"
+           id="cancel-amendments"></a>
+      </div>
+    </div>
+  </div>
+</main>
+</body>
+</html>

--- a/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/cannot-be-submitted.html
+++ b/laa-amend-a-claim-ui/src/main/resources/templates/pages/amendments/cannot-be-submitted.html
@@ -15,11 +15,9 @@
 
       <p class="govuk-body" th:text="#{amendments.cannotBeSubmitted.subheading}"></p>
 
-      <dl class="govuk-summary-list">
-        <div class="govuk-summary-list__row" th:each="error : ${errors}">
-          <dd class="govuk-summary-list__value" th:text="${error}"></dd>
-        </div>
-      </dl>
+      <ul class="govuk-list govuk-list--bullet">
+        <li th:each="error : ${errors}" th:text="${error}"></li>
+      </ul>
 
       <div class="govuk-button-group">
         <a th:href="@{/submissions/{submissionId}/claims/{claimId}/amendments/check(submissionId=${submissionId}, claimId=${claimId})}"

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentsCannotBeSubmittedControllerTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/controllers/amendments/AmendmentsCannotBeSubmittedControllerTest.java
@@ -1,0 +1,79 @@
+package uk.gov.justice.laa.payments.amend.controllers.amendments;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+import static uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimStatus.VOID;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.getAmendmentErrors;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveAmendmentErrors;
+import static uk.gov.justice.laa.payments.amend.utils.SessionUtils.saveClaim;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.mock.web.MockHttpSession;
+import uk.gov.justice.laa.payments.amend.controllers.BaseControllerTest;
+import uk.gov.justice.laa.payments.amend.models.ClaimDetails;
+import uk.gov.justice.laa.payments.amend.resources.MockClaimsFunctions;
+
+@WebMvcTest(AmendmentsCannotBeSubmittedController.class)
+class AmendmentsCannotBeSubmittedControllerTest extends BaseControllerTest {
+
+  private UUID submissionId;
+  private UUID claimId;
+  private MockHttpSession session;
+  private ClaimDetails claim;
+
+  @BeforeEach
+  void setup() {
+    submissionId = UUID.randomUUID();
+    claimId = UUID.randomUUID();
+    session = new MockHttpSession();
+
+    claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setSubmissionId(submissionId);
+    claim.setClaimId(claimId);
+    saveClaim(session, claimId, claim);
+  }
+
+  @Test
+  void getsCannotBeSubmittedPageWithErrorsAndClearsThemFromSession() throws Exception {
+    saveAmendmentErrors(session, claimId, List.of("This claim has been modified by another user."));
+
+    mockMvc
+        .perform(get(buildPath()).session(session))
+        .andExpect(status().isOk())
+        .andExpect(view().name("pages/amendments/cannot-be-submitted"))
+        .andExpect(model().attribute("submissionId", submissionId))
+        .andExpect(model().attribute("claimId", claimId))
+        .andExpect(
+            model().attribute("errors", List.of("This claim has been modified by another user.")));
+
+    assertThatAmendmentErrorsWereCleared();
+  }
+
+  @Test
+  void returnsNotFoundWhenNoAmendmentErrorsInSession() throws Exception {
+    mockMvc.perform(get(buildPath()).session(session)).andExpect(status().isNotFound());
+  }
+
+  @Test
+  void returnsNotFoundForNonValidClaim() throws Exception {
+    claim.setStatus(VOID);
+    saveAmendmentErrors(session, claimId, List.of("This claim has been modified by another user."));
+
+    mockMvc.perform(get(buildPath()).session(session)).andExpect(status().isNotFound());
+  }
+
+  private void assertThatAmendmentErrorsWereCleared() {
+    assertThat(getAmendmentErrors(session, claimId)).isEmpty();
+  }
+
+  private String buildPath() {
+    return "/submissions/%s/claims/%s/amendments/cannot-submit".formatted(submissionId, claimId);
+  }
+}

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsServiceTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsServiceTest.java
@@ -2,12 +2,14 @@ package uk.gov.justice.laa.payments.amend.service;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.UUID;
 import org.jspecify.annotations.NonNull;
@@ -18,9 +20,12 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Mono;
 import uk.gov.justice.laa.dstew.payments.claimsdata.model.ClaimAmendmentPatch;
 import uk.gov.justice.laa.payments.amend.client.ClaimsApiClient;
+import uk.gov.justice.laa.payments.amend.exceptions.AmendmentSubmissionFailedException;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForm;
 import uk.gov.justice.laa.payments.amend.forms.amendments.AmendmentForms;
 import uk.gov.justice.laa.payments.amend.forms.amendments.OriginalAndCurrent;
@@ -42,6 +47,51 @@ class CheckAmendmentsServiceTest {
   @BeforeEach
   void setUp() {
     checkAmendmentsService = new CheckAmendmentsService(claimsApiClient);
+  }
+
+  @Test
+  void submitThrowsAmendmentSubmissionFailedExceptionWithErrorMessagesFromResponseBody() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setVersion(1L);
+    var amendmentForms =
+        amendmentForms(
+            forms(Map.of(), Map.of()),
+            forms(Map.of("FEE_CODE", "OLD_FEE"), Map.of("FEE_CODE", "NEW_FEE")),
+            forms(Map.of(), Map.of()),
+            null,
+            forms(Map.of(), Map.of()));
+    amendmentForms.setRequestedByForm(createRequestedByForm());
+    amendmentForms.setRequestedReasonForm(createRequestReasonForm());
+
+    var submissionId = UUID.randomUUID();
+    var claimId = UUID.randomUUID();
+    var responseBody =
+        """
+        {"errors":[{"code":"CLAIM_VERSION_CONFLICT","message":"This claim has been modified by another user."}]}
+        """;
+    when(claimsApiClient.updateClaim(eq(submissionId), eq(claimId), any(ClaimAmendmentPatch.class)))
+        .thenReturn(
+            Mono.error(
+                WebClientResponseException.create(
+                    HttpStatus.CONFLICT.value(),
+                    "Conflict",
+                    null,
+                    responseBody.getBytes(StandardCharsets.UTF_8),
+                    null)));
+
+    assertThatThrownBy(
+            () ->
+                checkAmendmentsService.submitAmendments(
+                    submissionId, claimId, USER_ID, claim, amendmentForms))
+        .isInstanceOf(AmendmentSubmissionFailedException.class)
+        .satisfies(
+            ex -> {
+              var failure = (AmendmentSubmissionFailedException) ex;
+              assertThat(failure.getSubmissionId()).isEqualTo(submissionId);
+              assertThat(failure.getClaimId()).isEqualTo(claimId);
+              assertThat(failure.getErrorMessages())
+                  .containsExactly("This claim has been modified by another user.");
+            });
   }
 
   @Test

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsServiceTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/service/CheckAmendmentsServiceTest.java
@@ -95,6 +95,43 @@ class CheckAmendmentsServiceTest {
   }
 
   @Test
+  void submitRethrowsWebClientResponseExceptionForNonValidationStatus() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    claim.setVersion(1L);
+    var amendmentForms =
+        amendmentForms(
+            forms(Map.of(), Map.of()),
+            forms(Map.of("FEE_CODE", "OLD_FEE"), Map.of("FEE_CODE", "NEW_FEE")),
+            forms(Map.of(), Map.of()),
+            null,
+            forms(Map.of(), Map.of()));
+    amendmentForms.setRequestedByForm(createRequestedByForm());
+    amendmentForms.setRequestedReasonForm(createRequestReasonForm());
+
+    var submissionId = UUID.randomUUID();
+    var claimId = UUID.randomUUID();
+    var responseBody =
+        """
+        {"detail":"An unexpected application error has occurred."}
+        """;
+    var thrownException =
+        WebClientResponseException.create(
+            HttpStatus.INTERNAL_SERVER_ERROR.value(),
+            "Internal Server Error",
+            null,
+            responseBody.getBytes(StandardCharsets.UTF_8),
+            null);
+    when(claimsApiClient.updateClaim(eq(submissionId), eq(claimId), any(ClaimAmendmentPatch.class)))
+        .thenReturn(Mono.error(thrownException));
+
+    assertThatThrownBy(
+            () ->
+                checkAmendmentsService.submitAmendments(
+                    submissionId, claimId, USER_ID, claim, amendmentForms))
+        .isSameAs(thrownException);
+  }
+
+  @Test
   void submitPopulatesCrimePatchFromAllFormFields() {
     var claim = MockClaimsFunctions.createMockCrimeClaim();
     claim.setVersion(1L);

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/utils/SessionUtilsTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/utils/SessionUtilsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -125,5 +126,21 @@ public class SessionUtilsTest {
             () -> SessionUtils.getValidAssessableClaim(session, SUBMISSION_ID, CLAIM_ID));
 
     assertEquals(HttpStatus.NOT_FOUND, exception.getStatusCode());
+  }
+
+  @Test
+  void removeAllForClaimRemovesClaimFormsAndAmendmentErrors() {
+    var claim = MockClaimsFunctions.createMockCrimeClaim();
+    var session = new MockHttpSession();
+    SessionUtils.saveClaim(session, CLAIM_ID, claim);
+    SessionUtils.saveAmendmentErrors(session, CLAIM_ID, List.of("Some error"));
+
+    SessionUtils.removeAllForClaim(session, CLAIM_ID);
+
+    assertThrows(
+        NoClaimInSessionException.class,
+        () -> SessionUtils.getClaim(session, SUBMISSION_ID, CLAIM_ID));
+    assertThat(session.getAttribute(SessionUtils.AMENDMENT_ERRORS_KEY.formatted(CLAIM_ID)))
+        .isNull();
   }
 }


### PR DESCRIPTION
## What is this PR?

[BC-651](https://dsdmoj.atlassian.net/browse/BC-651)

Currently, if a claim amendment submission fails validation in claims-api, `CheckAmendmentsService` re-throws the raw `WebClientResponseException` unhandled, so the caseworker sees a generic 500 error page instead of any useful information.

This PR catches that exception, parses the claims-api Problem Detail response body and redirects to a new 
"Your amendments cannot be submitted" page that lists the returned error messages

<img width="907" height="576" alt="Screenshot 2026-09-07 at 15 16 04" src="https://github.com/user-attachments/assets/5e3f0526-47d7-4615-84d2-5f6d568ccda9" />


## Checklist

Before you ask people to review this PR:

- [x] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [x] Tests should be passing: `./gradlew test`
- [x] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.



[BC-651]: https://dsdmoj.atlassian.net/browse/BC-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ