### PR TITLE
feat(BC-712): Expand set of financial fields locked after assessment

### DIFF
--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CivilClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CivilClaimDetailsViewField.java
@@ -26,6 +26,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       String.class,
       CivilClaimDetails::getClientDateOfBirth,
       Builder::clientDateOfBirth,
+      Amendability.UNTIL_ASSESSED,
       "client.clientDateOfBirth"),
   POSTCODE(
       FieldType.TEXT,
@@ -109,11 +110,8 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       String.class,
       CivilClaimDetails::getCaseConcludedDate,
       Builder::caseConcludedDate,
-      NO_OPTIONS,
       Amendability.UNTIL_ASSESSED,
-      "claim.caseConcludedDate",
-      NO_FEE_API_FIELD_NAME,
-      FieldType.DATE),
+      "claim.caseConcludedDate"),
   UNIQUE_FILE_NUMBER(
       FieldType.TEXT,
       String.class,
@@ -322,30 +320,38 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
   // Cost fields
   COUNSELS_COST(
       FieldType.MONETARY,
+      FieldType.MONETARY,
       BigDecimal.class,
       CivilClaimDetails::getCounselsCost,
       Builder::netCounselCostsAmount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.netCounselCostsAmount",
       "fee.netCostOfCounselAmount"),
   TRAVEL_AND_WAITING_COSTS(
       FieldType.MONETARY,
+      FieldType.MONETARY,
       BigDecimal.class,
       CivilClaimDetails::getTravelAndWaitingCosts,
       Builder::travelWaitingCostsAmount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.travelWaitingCostsAmount",
       "fee.travelAndWaitingCostsAmount"),
   DETENTION_TRAVEL(
       FieldType.MONETARY,
+      FieldType.MONETARY,
       BigDecimal.class,
       CivilClaimDetails::getDetentionTravelWaitingCosts,
       Builder::detentionTravelWaitingCostsAmount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.detentionTravelWaitingCostsAmount",
       "fee.detentionTravelAndWaitingCostsAmount"),
   JR_FORM_FILLING(
       FieldType.MONETARY,
+      FieldType.MONETARY,
       BigDecimal.class,
       CivilClaimDetails::getJrFormFillingCost,
       Builder::jrFormFillingAmount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.jrFormFillingAmount",
       "fee.jrFormFillingAmount"),
   ADJOURNED_HEARING_FEE(
@@ -354,6 +360,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Integer.class,
       CivilClaimDetails::getAdjournedHearing,
       Builder::adjournedHearingFeeAmount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.adjournedHearingFeeAmount",
       "fee.boltOnAdjournedHearingFee"),
   CMRH_TELEPHONE(
@@ -362,6 +369,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Integer.class,
       CivilClaimDetails::getCmrhTelephone,
       Builder::cmrhTelephoneCount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.cmrhTelephoneCount",
       "fee.boltOnCmrhTelephoneFee"),
   CMRH_ORAL(
@@ -370,6 +378,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Integer.class,
       CivilClaimDetails::getCmrhOral,
       Builder::cmrhOralCount,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.cmrhOralCount",
       "fee.boltOnCmrhOralFee"),
   HOME_OFFICE(
@@ -378,6 +387,7 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Integer.class,
       CivilClaimDetails::getHoInterview,
       Builder::hoInterview,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.hoInterview",
       "fee.boltOnHomeOfficeInterviewFee"),
   SUBSTANTIVE_HEARING(
@@ -386,29 +396,31 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Boolean.class,
       CivilClaimDetails::getSubstantiveHearing,
       Builder::isSubstantiveHearing,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.isSubstantiveHearing",
       "fee.boltOnSubstantiveHearingFee"),
   BOLT_ON_TOTAL_FEE(
       FieldType.MONETARY,
+      FieldType.MONETARY,
       NO_PATCH_TYPE,
       NO_CIVIL_GETTER,
       NO_PATCHER,
-      NO_OPTIONS,
       Amendability.NEVER,
       NO_CLAIMS_API_FIELD_NAME,
-      "fee.boltOnTotalFeeAmount",
-      FieldType.MONETARY),
+      "fee.boltOnTotalFeeAmount"),
   IS_LONDON_RATE(
       FieldType.BOOLEAN,
       Boolean.class,
       CivilClaimDetails::getIsLondonRate,
-      Builder::isLondonRate,
+      (Builder builder, Boolean isLondonRate) -> builder.isLondonRate(isLondonRate),
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.isLondonRate"),
   PRIOR_AUTHORITY_REFERENCE(
       FieldType.TEXT,
       String.class,
       CivilClaimDetails::getPriorAuthorityReference,
       Builder::priorAuthorityReference,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.priorAuthorityReference");
 
   private final CivilClaimViewFieldGetter<?> getter;
@@ -428,14 +440,14 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       String claimsApiFieldName) {
     this(
         fieldType,
+        NO_FEE_API_TYPE,
         patchType,
         getter,
         patcher,
         List.of(),
         Amendability.ALWAYS,
         claimsApiFieldName,
-        NO_FEE_API_FIELD_NAME,
-        fieldType);
+        NO_FEE_API_FIELD_NAME);
   }
 
   <T> CivilClaimDetailsViewField(
@@ -447,14 +459,14 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       String claimsApiFieldName) {
     this(
         fieldType,
+        NO_FEE_API_TYPE,
         patchType,
         getter,
         patcher,
         options,
         Amendability.ALWAYS,
         claimsApiFieldName,
-        NO_FEE_API_FIELD_NAME,
-        fieldType);
+        NO_FEE_API_FIELD_NAME);
   }
 
   <T> CivilClaimDetailsViewField(
@@ -462,18 +474,18 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Class<T> patchType,
       Function<CivilClaimDetails, ?> getter,
       BiFunction<Builder, T, Builder> patcher,
-      String claimsApiFieldName,
-      String feeApiFieldName) {
+      Amendability amendability,
+      String claimsApiFieldName) {
     this(
         fieldType,
+        NO_FEE_API_TYPE,
         patchType,
         getter,
         patcher,
         List.of(),
-        Amendability.ALWAYS,
+        amendability,
         claimsApiFieldName,
-        feeApiFieldName,
-        fieldType);
+        NO_FEE_API_FIELD_NAME);
   }
 
   <T> CivilClaimDetailsViewField(
@@ -482,30 +494,31 @@ public enum CivilClaimDetailsViewField implements ClaimViewField<CivilClaimDetai
       Class<T> patchType,
       Function<CivilClaimDetails, ?> getter,
       BiFunction<Builder, T, Builder> patcher,
+      Amendability amendability,
       String claimsApiFieldName,
       String feeApiFieldName) {
     this(
         fieldType,
+        feeFieldType,
         patchType,
         getter,
         patcher,
         List.of(),
-        Amendability.ALWAYS,
+        amendability,
         claimsApiFieldName,
-        feeApiFieldName,
-        feeFieldType);
+        feeApiFieldName);
   }
 
   <T> CivilClaimDetailsViewField(
       FieldType fieldType,
+      FieldType feeFieldType,
       Class<T> patchType,
       Function<CivilClaimDetails, ?> getter,
       BiFunction<Builder, T, Builder> patcher,
       List<FieldOption> options,
       Amendability amendability,
       String claimsApiFieldName,
-      String feeApiFieldName,
-      FieldType feeFieldType) {
+      String feeApiFieldName) {
     this.getter = new CivilClaimViewFieldGetter<>(getter);
     this.claimsApiFieldName = claimsApiFieldName;
     this.feeApiFieldName = feeApiFieldName;

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimDetailsViewField.java
@@ -115,6 +115,8 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       BigDecimal.class,
       ClaimDetails::getNetProfitCost,
       Builder::netProfitCostsAmount,
+      NO_OPTIONS,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.netProfitCostsAmount",
       "fee.netProfitCostsAmount"),
   DISBURSEMENTS(
@@ -122,6 +124,8 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       BigDecimal.class,
       ClaimDetails::getNetDisbursementAmount,
       Builder::netDisbursementAmount,
+      NO_OPTIONS,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.netDisbursementAmount",
       "fee.disbursementAmount"),
   DISBURSEMENTS_VAT(
@@ -129,6 +133,8 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       BigDecimal.class,
       ClaimDetails::getDisbursementVatAmount,
       Builder::disbursementsVatAmount,
+      NO_OPTIONS,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.disbursementsVatAmount",
       "fee.disbursementVatAmount"),
   CALCULATED_VAT_AMOUNT(
@@ -139,6 +145,8 @@ public enum ClaimDetailsViewField implements ClaimViewField<ClaimDetails> {
       Boolean.class,
       ClaimDetails::getVatClaimed,
       Builder::isVatApplicable,
+      NO_OPTIONS,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.isVatApplicable",
       "fee.vatIndicator");
 

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/ClaimViewField.java
@@ -25,6 +25,7 @@ public interface ClaimViewField<T extends Claim> {
   Function<ClaimDetails, ?> NO_GETTER = _ -> null;
   Function<CivilClaimDetails, ?> NO_CIVIL_GETTER = _ -> null;
   Class<Object> NO_PATCH_TYPE = Object.class;
+  FieldType NO_FEE_API_TYPE = null;
   BiFunction<ClaimAmendmentPatch.Builder, Object, ClaimAmendmentPatch.Builder> NO_PATCHER =
       (builder, _) -> builder;
   List<FieldOption> NO_OPTIONS = List.of();

--- a/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CrimeClaimDetailsViewField.java
+++ b/laa-amend-a-claim-ui/src/main/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/CrimeClaimDetailsViewField.java
@@ -133,6 +133,8 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
       BigDecimal.class,
       CrimeClaimDetails::getTravelCosts,
       Builder::travelWaitingCostsAmount,
+      NO_OPTIONS,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.travelWaitingCostsAmount",
       "fee.netTravelCostsAmount"),
   WAITING_COSTS(
@@ -140,6 +142,8 @@ public enum CrimeClaimDetailsViewField implements ClaimViewField<CrimeClaimDetai
       BigDecimal.class,
       CrimeClaimDetails::getWaitingCosts,
       Builder::netWaitingCostsAmount,
+      NO_OPTIONS,
+      Amendability.UNTIL_ASSESSED,
       "claimSummaryFee.netWaitingCostsAmount",
       "fee.netWaitingCostsAmount");
 

--- a/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/AssessedFieldLockTest.java
+++ b/laa-amend-a-claim-ui/src/test/java/uk/gov/justice/laa/payments/amend/viewmodels/viewfield/AssessedFieldLockTest.java
@@ -13,7 +13,12 @@ class AssessedFieldLockTest {
   void locksOnlyTheFinancialFieldsSharedAcrossAreasOfLaw() {
     assertThat(lockedIn(ClaimDetailsViewField.values()))
         .containsExactlyInAnyOrder(
-            ClaimDetailsViewField.FEE_CODE, ClaimDetailsViewField.CASE_START_DATE);
+            ClaimDetailsViewField.FEE_CODE,
+            ClaimDetailsViewField.CASE_START_DATE,
+            ClaimDetailsViewField.PROFIT_COST,
+            ClaimDetailsViewField.DISBURSEMENTS,
+            ClaimDetailsViewField.DISBURSEMENTS_VAT,
+            ClaimDetailsViewField.VAT);
   }
 
   @Test
@@ -24,13 +29,28 @@ class AssessedFieldLockTest {
             CrimeClaimDetailsViewField.REPRESENTATION_ORDER_DATE,
             CrimeClaimDetailsViewField.CASE_CONCLUDED_DATE,
             CrimeClaimDetailsViewField.POLICE_STATION_COURT_PRISON_ID,
-            CrimeClaimDetailsViewField.SCHEME_ID);
+            CrimeClaimDetailsViewField.SCHEME_ID,
+            CrimeClaimDetailsViewField.TRAVEL_COSTS,
+            CrimeClaimDetailsViewField.WAITING_COSTS);
   }
 
   @Test
   void locksOnlyTheFinancialLegalHelpFields() {
     assertThat(lockedIn(CivilClaimDetailsViewField.values()))
-        .containsExactlyInAnyOrder(CivilClaimDetailsViewField.CASE_CONCLUDED_CLAIMED_DATE);
+        .containsExactlyInAnyOrder(
+            CivilClaimDetailsViewField.DATE_OF_BIRTH,
+            CivilClaimDetailsViewField.CASE_CONCLUDED_CLAIMED_DATE,
+            CivilClaimDetailsViewField.COUNSELS_COST,
+            CivilClaimDetailsViewField.TRAVEL_AND_WAITING_COSTS,
+            CivilClaimDetailsViewField.DETENTION_TRAVEL,
+            CivilClaimDetailsViewField.JR_FORM_FILLING,
+            CivilClaimDetailsViewField.ADJOURNED_HEARING_FEE,
+            CivilClaimDetailsViewField.CMRH_TELEPHONE,
+            CivilClaimDetailsViewField.CMRH_ORAL,
+            CivilClaimDetailsViewField.HOME_OFFICE,
+            CivilClaimDetailsViewField.SUBSTANTIVE_HEARING,
+            CivilClaimDetailsViewField.IS_LONDON_RATE,
+            CivilClaimDetailsViewField.PRIOR_AUTHORITY_REFERENCE);
   }
 
   @Test


### PR DESCRIPTION
## What is this PR?

Making the set of fields that are financial and therefore not amendable after assessment match this:
https://justiceuk.sharepoint.com/:x:/r/sites/LAADigitalDocumentLibrary/Shared%20Documents/2.%20Payment/Amend%20a%20Bulk%20Claim/Amend%20MVP%20-%20fields%20for%20amendment.xlsx?d=we17bc9a40bd240a29520030f12ef77f1&csf=1&web=1&e=yFiot3

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

