### PR TITLE
Update NPM dependabot directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
         patterns:
           - "**"
   - package-ecosystem: "npm"
-    directory: "/laa-amend-a-claim-ui"
+    directory: "/laa-amend-a-claim-ui/"
     schedule:
       interval: "daily"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,9 @@ updates:
         patterns:
           - "**"
   - package-ecosystem: "npm"
-    directory: "/laa-amend-a-claim-ui/"
+    directories:
+      - "/laa-amend-a-claim-ui/"
+      - "/e2e/"
     schedule:
       interval: "daily"
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,7 +42,7 @@ updates:
         patterns:
           - "**"
   - package-ecosystem: "npm"
-    directory: "/"
+    directory: "/laa-amend-a-claim-ui"
     schedule:
       interval: "daily"
     cooldown:


### PR DESCRIPTION
## What is this PR?

The current directory for NPM dependabot is currently wrong and should point to where package.json actually sits.

## Checklist

Before you ask people to review this PR:

- [ ] Branch naming followed as per [LAA Ways Of Working](https://dsdmoj.atlassian.net/wiki/spaces/LP1/pages/5697536341/LAA+Ways+of+working#Core-Branches).
- [ ] Tests should be passing: `./gradlew test`
- [ ] Github should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

